### PR TITLE
Modify data pipeline blueprint SAM docker image url to use Amazon ECR Public

### DIFF
--- a/backend/blueprints/ml_data_pipeline/engine/resource_task.py
+++ b/backend/blueprints/ml_data_pipeline/engine/resource_task.py
@@ -57,7 +57,7 @@ def code_from_path_and_cmd(path: str, cmd: str, compatible_runtime: lambda_.Runt
         path=f'{path}',
         bundling=core.BundlingOptions(
             image=core.BundlingDockerImage.from_registry(
-                f'amazon/aws-sam-cli-build-image-{compatible_runtime.name}'
+                f'public.ecr.aws/sam/build-{compatible_runtime.name}'
             ),
             command=['bash', '-c', cmd],
         ),


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Modify data pipeline blueprint SAM docker image url to use Amazon ECR Public

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
