### PR TITLE
bug fix - list all environments when creating a new dataset

### DIFF
--- a/frontend/src/views/Datasets/DatasetCreateForm.js
+++ b/frontend/src/views/Datasets/DatasetCreateForm.js
@@ -54,7 +54,7 @@ const DatasetCreateForm = (props) => {
   const fetchEnvironments = useCallback(async () => {
     setLoading(true);
     const response = await client.query(
-      listEnvironments(Defaults.SelectListFilter)
+      listEnvironments({ filter: Defaults.SelectListFilter })
     );
     if (!response.errors) {
       setEnvironmentOptions(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fixes a bug in the dataset creation form. This change makes sure that all data.all environments are listed. In the current version, a maximum of 5 environments are listed because of a typo in the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
