### PR TITLE
BugFix: secretsmanager permissions on dataall prefixed secerts

### DIFF
--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -593,7 +593,9 @@ Resources:
             Action:
               - "secretsmanager:DescribeSecret"
               - "secretsmanager:GetSecretValue"
-            Resource: !Sub 'arn:aws:secretsmanager:*:${AWS::AccountId}:secret:${EnvironmentResourcePrefix}*'
+            Resource:
+              - !Sub 'arn:aws:secretsmanager:*:${AWS::AccountId}:secret:${EnvironmentResourcePrefix}*'
+              - !Sub 'arn:aws:secretsmanager:*:${AWS::AccountId}:secret:dataall*'
           - Sid: SecretsmanagerList
             Effect: Allow
             Action:

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -191,6 +191,7 @@ class IdpStack(pyNestedClass):
                     f'arn:aws:ssm:*:{self.account}:parameter/*{resource_prefix}*',
                     f'arn:aws:ssm:*:{self.account}:parameter/*dataall*',
                     f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                    f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                     f'arn:aws:rum:{self.region}:{self.account}:appmonitor/*{resource_prefix}*',
                 ],
             ),

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -327,6 +327,7 @@ class ContainerStack(pyNestedClass):
                     ],
                     resources=[
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                        f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                         f'arn:aws:ecs:{self.region}:{self.account}:cluster/*{resource_prefix}*',
                         f'arn:aws:ecs:{self.region}:{self.account}:container-instance/*{resource_prefix}*/*',
                         f'arn:aws:ecs:{self.region}:{self.account}:task-definition/*{resource_prefix}*:*',

--- a/deploy/stacks/cw_canaries.py
+++ b/deploy/stacks/cw_canaries.py
@@ -144,7 +144,8 @@ class CloudWatchCanariesStack(pyNestedClass):
                         'secretsmanager:DescribeSecret',
                     ],
                     resources=[
-                        f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*'
+                        f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                        f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*'
                     ],
                 ),
                 iam.PolicyStatement(

--- a/deploy/stacks/dbmigration.py
+++ b/deploy/stacks/dbmigration.py
@@ -42,6 +42,7 @@ class DBMigrationStack(pyNestedClass):
                 ],
                 resources=[
                     f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                    f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                     f'arn:aws:kms:{self.region}:{self.account}:key/*',
                     f'arn:aws:ssm:*:{self.account}:parameter/*dataall*',
                     f'arn:aws:ssm:*:{self.account}:parameter/*{resource_prefix}*',

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -167,6 +167,7 @@ class LambdaApiStack(pyNestedClass):
                     ],
                     resources=[
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                        f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                         f'arn:aws:ecs:{self.region}:{self.account}:cluster/*{resource_prefix}*',
                         f'arn:aws:ecs:{self.region}:{self.account}:task-definition/*{resource_prefix}*:*',
                         f'arn:aws:kms:{self.region}:{self.account}:key/*',

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -130,6 +130,7 @@ class PipelineStack(Stack):
                     f'arn:aws:s3:::{self.resource_prefix}*/*',
                     f'arn:aws:codebuild:{self.region}:{self.account}:project/*{self.resource_prefix}*',
                     f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{resource_prefix}*',
+                    f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                     f'arn:aws:kms:{self.region}:{self.account}:key/*',
                     f'arn:aws:ssm:*:{self.account}:parameter/*dataall*',
                     f'arn:aws:ssm:*:{self.account}:parameter/*{resource_prefix}*',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- [Shanger Lin] reported bug: access denied for certain secrets of dataall when using custom resource prefixes. Added permissions on resources prefixed as dataall

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
