### PR TITLE
upgrade node to node v16.15.1 in CodeBuild Synth project

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -198,6 +198,7 @@ class PipelineStack(Stack):
                     build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_3,
                 ),
                 commands=[
+                    'n 16.15.1',
                     'yum -y install shadow-utils wget && yum -y install openssl-devel bzip2-devel libffi-devel postgresql-devel',
                     f'aws codeartifact login --tool npm --repository {self.codeartifact.npm_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',
                     'npm install -g aws-cdk',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- upgrade node version. Node v.12 is deprecated and results in failure of the CodePipeline pipeline

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
