### PR TITLE
upgrade node to node v16.15.1 in CodeBuild QualityGate project

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -400,6 +400,7 @@ class PipelineStack(Stack):
                             phases={
                                 'build': {
                                     'commands': [
+                                        'n 16.15.1',
                                         'set -eu',
                                         'yum -y install shadow-utils wget && yum -y install openssl-devel bzip2-devel libffi-devel postgresql-devel',
                                         f'aws codeartifact login --tool pip --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- upgrade node version. Node v.12 is deprecated and results in failure of the CodePipeline pipeline
### Relates


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
