### PR TITLE
fix: added node v. 16 to pipeline buildspec

### DIFF
--- a/backend/dataall/cdkproxy/stacks/pipeline.py
+++ b/backend/dataall/cdkproxy/stacks/pipeline.py
@@ -232,7 +232,8 @@ class PipelineStack(Stack):
                     ],
                 )
 
-                if stage != 'prod':
+                # Skip manual approval for one stage pipelines
+                if stage != 'prod' and len(pipeline.devStages) > 1:
                     self.codepipeline_pipeline.add_stage(
                         stage_name=f'ManualApproval-{stage}',
                         actions=[
@@ -361,14 +362,17 @@ class PipelineStack(Stack):
         yaml = """
             version: '0.2'
             phases:
+              install:
+                commands:
+                - 'n 16.15.1'
               pre_build:
                 commands:
                 - npm install -g aws-cdk
                 - pip install aws-ddk && pip install -r requirements.txt
               build:
                 commands:
-                    - aws sts get-caller-identity
-                    - ddk deploy
+                - aws sts get-caller-identity
+                - ddk deploy
         """
         with open(f'{path}/{output_file}', 'w') as text_file:
             print(yaml, file=text_file)


### PR DESCRIPTION
fix: 
- added node v. 16 to pipeline buildspec
- skipping manual approval for pipelines that have only one step

### Feature or Bugfix
- Bugfix

### Detail
- buildspec does not specify node version which default to node v. 12 which is already not supported by cdk. This ends with pipeline not building
- it a minor but when specifying pipeline stages user can choose to have only one stage. This one stage pipeline should not have a manual approval step in the end regardless the name of the stage.

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
