### PR TITLE
Bugfix: import those handlers in where we invoke them

### DIFF
--- a/backend/dataall/api/Objects/DataPipeline/resolvers.py
+++ b/backend/dataall/api/Objects/DataPipeline/resolvers.py
@@ -7,6 +7,7 @@ from ...constants import DataPipelineRole
 from ...context import Context
 from ....aws.handlers.service_handlers import Worker
 from ....aws.handlers.sts import SessionHelper
+from ....aws.handlers.codecommit import CodeCommit
 from ....db import permissions, models, exceptions
 from ....db.api import Pipeline, Environment, ResourcePolicy, Stack, KeyValueTag
 

--- a/backend/dataall/api/Objects/Dataset/resolvers.py
+++ b/backend/dataall/api/Objects/Dataset/resolvers.py
@@ -13,6 +13,7 @@ from ....api.context import Context
 from ....aws.handlers.glue import Glue
 from ....aws.handlers.service_handlers import Worker
 from ....aws.handlers.sts import SessionHelper
+from ....aws.handlers.sns import Sns
 from ....db import paginate, exceptions, permissions, models
 from ....db.api import Dataset, Environment, ResourcePolicy
 from ....db.api.organization import Organization

--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -632,6 +632,15 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:states:*:${AWS::AccountId}:stateMachine:${EnvironmentResourcePrefix}*'
+          - Sid: CodeCommit
+            Action:
+              - 'codecommit:GetFile'
+              - 'codecommit:ListBranches'
+              - 'codecommit:GetFolder'
+              - 'codecommit:GetCommit'
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:codecommit:*:${AWS::AccountId}:${EnvironmentResourcePrefix}*'
       ManagedPolicyName: !Sub ${EnvironmentResourcePrefix}-pivotrole-policy-3
       Roles:
         - !Ref PivotRoleName


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Detail
- [eugeneteoh] reported bug: AWS handlers that are not reference are not registered. 

   [**_Solution_**]
    1. Add the reference in the file which will add related actions. (For example, we mainly invoke the codecommit actions in DataPipeline/resolvers.py. So I think it is proper to add the reference in this file. The action defined in sns.py is invoked in multiple places, such as Dataset and DataTable. Dataset is the main category, so I think it is good to add it in Dataset/resolvers.py.)
    2. Add the related permission to pivot role as well.
  
   [**_result_**]
   Check below pic.
<img width="1920" alt="Screen Shot 2022-06-20 at 17 55 32" src="https://user-images.githubusercontent.com/7521775/174606871-a046aad6-4a79-436a-93cf-d6b36d7b4385.png">


### Relates
- #18 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
