### PR TITLE
Bugfix: remove unrelated condition of sagemaker policy

### DIFF
--- a/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
+++ b/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
@@ -45,9 +45,6 @@ class Sagemaker(ServicePolicy):
             iam.PolicyStatement(
                 actions=['sagemaker:Create*'],
                 resources=['*'],
-                conditions={
-                    'StringEquals': {f'aws:RequestTag/{self.tag_key}': [self.tag_value]}
-                },
             ),
             iam.PolicyStatement(
                 actions=['sagemaker:Start*', 'sagemaker:Stop*'],

--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -320,6 +320,7 @@ Resources:
               - 'sagemaker:StartNotebookInstance'
               - 'sagemaker:AddTags'
               - 'sagemaker:DescribeDomain'
+              - 'sagemaker:CreatePresignedDomainUrl'
             Resource:
               - !Sub 'arn:aws:sagemaker:*:${AWS::AccountId}:notebook-instance/${EnvironmentResourcePrefix}*'
               - !Sub 'arn:aws:sagemaker:*:${AWS::AccountId}:domain/*'


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Detail
- [dosiennik] open notebook url failed due to not authorized to perform createApp action.
   **[explanation]** check my comment in #47 
   **[Solution]** remove the condition to make it work for now. Later when we add the creation of sagemaker domain we can orchestrate all these things, such as domain, user profile and app.

### Relates
- #47 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
