### PR TITLE
Bugfix: add description param to env init

### DIFF
--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -43,6 +43,7 @@ class Environment:
             label=data.get('label', 'Unnamed'),
             tags=data.get('tags', []),
             owner=username,
+            description=data.get('description', ''),
             environmentType=data.get('type', EnvironmentType.Data.value),
             AwsAccountId=data.get('AwsAccountId'),
             region=data.get('region'),


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Detail
- [martonjuhaszyara] report bug: environment description not saved
   **[explanation]**  The value of description field is not passed when we create env record in environment table.
   **[Solution]** Get the user-defined value of description and pass to env init process.

### Relates
- #54 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
