### PR TITLE
fix: changed type name in qpl GetFeed

### DIFF
--- a/frontend/src/api/Feed/listFeedMessages.js
+++ b/frontend/src/api/Feed/listFeedMessages.js
@@ -30,7 +30,7 @@ const listFeedMessages = ({ targetUri, targetType, filter }) => ({
           ... on Worksheet {
             label
           }
-          ... on SqlPipeline {
+          ... on DataPipeline {
             label
           }
         }


### PR DESCRIPTION
fix: changed type name in qpl GetFeed after migration from SqlPipeline to DataPipeline

### Feature or Bugfix
- Bugfix

### Detail
- when using chat feature on data set table detail there was an error. The reason was that GetFeed query was using the old type SqlPipeline which was migrated to DataPipeline

### Relates
- internal finding, no ticket

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
