### PR TITLE
Enable any member of the glossary admin group to edit the glossary

### DIFF
--- a/backend/dataall/api/Objects/Glossary/resolvers.py
+++ b/backend/dataall/api/Objects/Glossary/resolvers.py
@@ -8,6 +8,9 @@ from ....db import paginate, exceptions, models
 from ....searchproxy import upsert_dataset
 from ....searchproxy import upsert_table
 from ....searchproxy.indexers import upsert_folder, upsert_dashboard
+from ....api.constants import (
+    GlossaryRole
+)
 
 
 def resolve_glossary_node(obj: models.GlossaryNode, *_):
@@ -180,6 +183,14 @@ def get_node(context: Context, source, nodeUri: str = None):
         if not node:
             raise exceptions.ObjectNotFound('Node', nodeUri)
     return node
+
+
+def resolve_user_role(context: Context, source: models.GlossaryNode, **kwargs):
+    if not source:
+        return None
+    if source.admin in context.groups:
+        return GlossaryRole.Admin.value
+    return GlossaryRole.NoPermission.value
 
 
 def delete_node(context: Context, source, nodeUri: str = None) -> bool:

--- a/backend/dataall/api/Objects/Glossary/schema.py
+++ b/backend/dataall/api/Objects/Glossary/schema.py
@@ -1,6 +1,6 @@
 from ... import gql
 from .resolvers import *
-
+from ...constants import GlossaryRole
 
 GlossaryNode = gql.Union(
     name='GlossaryNode',
@@ -35,6 +35,11 @@ Glossary = gql.ObjectType(
         gql.Field(name='label', type=gql.NonNullableType(gql.String)),
         gql.Field(name='name', type=gql.NonNullableType(gql.String)),
         gql.Field(name='admin', type=gql.String),
+        gql.Field(
+            name='userRoleForGlossary',
+            type=GlossaryRole.toGraphQLEnum(),
+            resolver=resolve_user_role,
+        ),
         gql.Field(name='readme', type=gql.String),
         gql.Field(name='created', type=gql.NonNullableType(gql.String)),
         gql.Field(name='updated', type=gql.String),

--- a/backend/dataall/api/constants.py
+++ b/backend/dataall/api/constants.py
@@ -90,6 +90,12 @@ class DatasetRole(GraphQLEnumMapper):
     NoPermission = '000'
 
 
+class GlossaryRole(GraphQLEnumMapper):
+    # Permissions on a glossary
+    Admin = '900'
+    NoPermission = '000'
+
+
 class RedshiftClusterRole(GraphQLEnumMapper):
     Creator = '950'
     Admin = '900'

--- a/frontend/src/api/Glossary/getGlossary.js
+++ b/frontend/src/api/Glossary/getGlossary.js
@@ -15,6 +15,7 @@ const getGlossary = (nodeUri) => ({
         status
         path
         admin
+        userRoleForGlossary
         stats {
           categories
           terms

--- a/frontend/src/views/Glossaries/GlossaryView.js
+++ b/frontend/src/views/Glossaries/GlossaryView.js
@@ -123,8 +123,9 @@ const GlossaryView = () => {
     const response = await client.query(getGlossary(params.uri));
     if (!response.errors && response.data.getGlossary !== null) {
       setIsAdmin(
-        response.data.getGlossary.owner === user.email ||
-          response.data.getGlossary.admin === user.email
+        ['Admin'].indexOf(
+          response.data.getGlossary.userRoleForGlossary
+        ) !== -1
       );
       setGlossary(response.data.getGlossary);
     } else {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- in the current version, only the Glossary creator can edit the Glossary. With this PR, members of the admin group of the glossary can also edit it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.