### PR TITLE
Bug fix: M1 Mac docker error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       - $HOME/.aws/credentials:/root/.aws/credentials:ro
     restart:
       on-failure:60
+    platform:
+      linux/amd64
 
   graphql:
     build:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- M1 Macs does not properly build the `cdkproxy` container. To fix this, the container should be built on `linux/amd64` platform.

### Relates
- #45

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
