### PR TITLE
Fix issue when trying to edit table column description

### DIFF
--- a/frontend/src/views/Tables/TableColumns.js
+++ b/frontend/src/views/Tables/TableColumns.js
@@ -43,13 +43,13 @@ const TableColumns = (props) => {
     }
   };
 
-  const handleEditCellChangeCommitted = ({ id, field, props }) => {
-    /*eslint-disable-line*/
-    const data = props;
-    if (field === 'description') {
+  const handleEditCellChangeCommitted = (e:GridCellEditCommitParams) => {
+    const data = e.value;
+    if (e.field === 'description') {
       columns.map((c) => {
-        if (c.id === id) {
-          return updateDescription(c, data.value.toString()).catch((e) =>
+        if (c.id === e.id && data.toString() !== c.description) {
+          c.description = data.toString();
+          return updateDescription(c, data.toString()).catch((e) =>
             dispatch({ type: SET_ERROR, error: e.message })
           );
         }
@@ -171,7 +171,7 @@ const TableColumns = (props) => {
           <DataGrid
             rows={columns}
             columns={header}
-            onEditCellChangeCommitted={handleEditCellChangeCommitted}
+            onCellEditCommit={handleEditCellChangeCommitted}
           />
         )}
       </Card>


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Nothing happens when users try to edit the column description of data.all table. This code fixes the issue and propagate the changes to the Glue table.