### PR TITLE
Feat/sagemakerdomain

### DIFF
--- a/backend/dataall/aws/handlers/sagemaker_studio.py
+++ b/backend/dataall/aws/handlers/sagemaker_studio.py
@@ -100,4 +100,3 @@ class SagemakerStudio:
             return _running_apps
         except ClientError as e:
             raise e
-

--- a/backend/dataall/aws/handlers/sagemaker_studio.py
+++ b/backend/dataall/aws/handlers/sagemaker_studio.py
@@ -99,5 +99,5 @@ class SagemakerStudio:
                         )
             return _running_apps
         except ClientError as e:
-            print(e)
-            return 'NotFound'
+            raise e
+

--- a/backend/dataall/cdkproxy/stacks/environment.py
+++ b/backend/dataall/cdkproxy/stacks/environment.py
@@ -209,14 +209,14 @@ class EnvironmentSetup(Stack):
                 ),
             )
 
-try:
-      default_vpc = ec2.Vpc.from_lookup(self, 'VPCStudio', is_default=True)
-except Exception as e:
-       logger.error(f"Default VPC not found, Exception: {e}")
-            vpc_id = default_vpc.vpc_id
-            subnet_ids = [private_subnet.subnet_id for private_subnet in default_vpc.private_subnets]
-            subnet_ids += [public_subnet.subnet_id for public_subnet in default_vpc.public_subnets]
-            subnet_ids += [isolated_subnet.subnet_id for isolated_subnet in default_vpc.isolated_subnets]
+            try:
+                default_vpc = ec2.Vpc.from_lookup(self, 'VPCStudio', is_default=True)
+                vpc_id = default_vpc.vpc_id
+                subnet_ids = [private_subnet.subnet_id for private_subnet in default_vpc.private_subnets]
+                subnet_ids += [public_subnet.subnet_id for public_subnet in default_vpc.public_subnets]
+                subnet_ids += [isolated_subnet.subnet_id for isolated_subnet in default_vpc.isolated_subnets]
+            except Exception as e:
+                logger.error(f"Default VPC not found, Exception: {e}. If you don't own a default VPC, modify the networking configuration, or disable ML Studio upon environment creation.")
 
             sagemaker_domain = sagemaker.CfnDomain(
                 self,

--- a/backend/dataall/cdkproxy/stacks/environment.py
+++ b/backend/dataall/cdkproxy/stacks/environment.py
@@ -213,6 +213,7 @@ class EnvironmentSetup(Stack):
             vpc_id = default_vpc.vpc_id
             subnet_ids = [private_subnet.subnet_id for private_subnet in default_vpc.private_subnets]
             subnet_ids += [public_subnet.subnet_id for public_subnet in default_vpc.public_subnets]
+            subnet_ids += [isolated_subnet.subnet_id for isolated_subnet in default_vpc.isolated_subnets]
 
             sagemaker_domain = sagemaker.CfnDomain(
                 self,

--- a/backend/dataall/cdkproxy/stacks/environment.py
+++ b/backend/dataall/cdkproxy/stacks/environment.py
@@ -172,26 +172,25 @@ class EnvironmentSetup(Stack):
         if self._environment.mlStudiosEnabled and not(self.sagemaker_domain_exists):
 
             sagemaker_domain_role = iam.Role(
-            self, 
-            'RoleForSagemakerStudioUsers',
-		    assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
-		    role_name="RoleSagemakerStudioUsers",
-		    managed_policies=
-                    [iam.ManagedPolicy.from_managed_policy_arn(
+                self,
+                'RoleForSagemakerStudioUsers',
+                assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
+                role_name="RoleSagemakerStudioUsers",
+                managed_policies=[iam.ManagedPolicy.from_managed_policy_arn(
                     self,
-			        id="SagemakerFullAccess",
-			        managed_policy_arn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"),
+                    id="SagemakerFullAccess",
+                    managed_policy_arn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"),
                     iam.ManagedPolicy.from_managed_policy_arn(
                     self,
-			        id="S3FullAccess",
-			        managed_policy_arn="arn:aws:iam::aws:policy/AmazonS3FullAccess")
-		            ]
+                        id="S3FullAccess",
+                        managed_policy_arn="arn:aws:iam::aws:policy/AmazonS3FullAccess")
+                ]
             )
 
             sagemaker_domain_key = kms.Key(
                 self,
                 'SagemakerDomainKmsKey',
-                alias=f"SagemakerStudioDomain",
+                alias="SagemakerStudioDomain",
                 enable_key_rotation=True,
                 policy=iam.PolicyDocument(
                     assign_sids=True,
@@ -216,33 +215,33 @@ class EnvironmentSetup(Stack):
             subnet_ids += [public_subnet.subnet_id for public_subnet in default_vpc.public_subnets]
 
             sagemaker_domain = sagemaker.CfnDomain(
-            self,
-            "SagemakerStudioDomain",
-            domain_name = f"SagemakerStudioDomain-{self._environment.region}-{self._environment.AwsAccountId}",
-            auth_mode = "IAM",
+                self,
+                "SagemakerStudioDomain",
+                domain_name=f"SagemakerStudioDomain-{self._environment.region}-{self._environment.AwsAccountId}",
+                auth_mode="IAM",
 
-            default_user_settings = sagemaker.CfnDomain.UserSettingsProperty(
-                execution_role = sagemaker_domain_role.role_arn,
+                default_user_settings=sagemaker.CfnDomain.UserSettingsProperty(
+                    execution_role=sagemaker_domain_role.role_arn,
 
-                security_groups=[],
+                    security_groups=[],
 
-                sharing_settings=sagemaker.CfnDomain.SharingSettingsProperty(
-                    notebook_output_option = "Allowed",
-                    s3_kms_key_id = sagemaker_domain_key.key_id,
-                    s3_output_path = f"s3://sagemaker-{self._environment.region}-{self._environment.AwsAccountId}",
-                )
-            ),
+                    sharing_settings=sagemaker.CfnDomain.SharingSettingsProperty(
+                        notebook_output_option="Allowed",
+                        s3_kms_key_id=sagemaker_domain_key.key_id,
+                        s3_output_path=f"s3://sagemaker-{self._environment.region}-{self._environment.AwsAccountId}",
+                    )
+                ),
 
-            vpc_id = vpc_id,
-            subnet_ids = subnet_ids,
-            app_network_access_type = "VpcOnly",
-            kms_key_id = sagemaker_domain_key.key_id,
+                vpc_id=vpc_id,
+                subnet_ids=subnet_ids,
+                app_network_access_type="VpcOnly",
+                kms_key_id=sagemaker_domain_key.key_id,
             )
 
             ssm.StringParameter(
                 self,
                 'SagemakerStudioDomainId',
-                string_value = sagemaker_domain.attr_domain_id,
+                string_value=sagemaker_domain.attr_domain_id,
                 parameter_name=f'/datahub/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
             )
 

--- a/backend/dataall/cdkproxy/stacks/environment.py
+++ b/backend/dataall/cdkproxy/stacks/environment.py
@@ -15,6 +15,8 @@ from aws_cdk import (
     aws_sqs as sqs,
     aws_sns_subscriptions as sns_subs,
     aws_kms as kms,
+    aws_ec2 as ec2,
+    aws_sagemaker as sagemaker,
     aws_athena,
     RemovalPolicy,
     Stack,
@@ -70,12 +72,7 @@ class EnvironmentSetup(Stack):
         )
         existing_domain_id = existing_domain.get('DomainId', False)
         if existing_domain_id:
-            ssm.StringParameter(
-                self,
-                'SagemakeStudioDomainId',
-                string_value=existing_domain_id,
-                parameter_name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
-            )
+            return existing_domain_id
 
     @staticmethod
     def get_environment_group_permissions(engine, environmentUri, group):
@@ -162,19 +159,92 @@ class EnvironmentSetup(Stack):
 
         self._environment = self.get_target(target_uri=target_uri)
 
-        self.environment_groups: [
-            models.EnvironmentGroup
-        ] = self.get_environment_groups(self.engine, environment=self._environment)
+        self.environment_groups: [models.EnvironmentGroup] = self.get_environment_groups(self.engine, environment=self._environment)
 
-        self.environment_admins_group: [
-            models.EnvironmentGroup
-        ] = self.get_environment_admins_group(self.engine, self._environment)
+        self.environment_admins_group: models.EnvironmentGroup = self.get_environment_admins_group(self.engine, self._environment)
 
         self.all_environment_datasets = self.get_all_environment_datasets(
             self.engine, self._environment
         )
 
-        self.check_sagemaker_studio(engine=self.engine, environment=self._environment)
+        self.sagemaker_domain_exists = self.check_sagemaker_studio(engine=self.engine, environment=self._environment)
+
+        if self._environment.mlStudiosEnabled and not(self.sagemaker_domain_exists):
+
+            sagemaker_domain_role = iam.Role(
+            self, 
+            'RoleForSagemakerStudioUsers',
+		    assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
+		    role_name="RoleSagemakerStudioUsers",
+		    managed_policies=
+                    [iam.ManagedPolicy.from_managed_policy_arn(
+                    self,
+			        id="SagemakerFullAccess",
+			        managed_policy_arn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"),
+                    iam.ManagedPolicy.from_managed_policy_arn(
+                    self,
+			        id="S3FullAccess",
+			        managed_policy_arn="arn:aws:iam::aws:policy/AmazonS3FullAccess")
+		            ]
+            )
+
+            sagemaker_domain_key = kms.Key(
+                self,
+                'SagemakerDomainKmsKey',
+                alias=f"SagemakerStudioDomain",
+                enable_key_rotation=True,
+                policy=iam.PolicyDocument(
+                    assign_sids=True,
+                    statements=[
+                        iam.PolicyStatement(
+                            resources=['*'],
+                            effect=iam.Effect.ALLOW,
+                            principals=[
+                                iam.AccountPrincipal(account_id=self._environment.AwsAccountId),
+                                iam.Role.from_role_arn(self, 'DomainRole', role_arn=sagemaker_domain_role.role_arn),
+                                iam.Role.from_role_arn(self, 'EnvironmentDefaultRole', role_arn=self.environment_admins_group.environmentIAMRoleArn),
+                            ] + [iam.Role.from_role_arn(self, f'{group.groupUri}Role', role_arn=group.environmentIAMRoleArn) for group in self.environment_groups],
+                            actions=['kms:*'],
+                        )
+                    ],
+                ),
+            )
+
+            default_vpc = ec2.Vpc.from_lookup(self, 'VPCStudio', is_default=True)
+            vpc_id = default_vpc.vpc_id
+            subnet_ids = [private_subnet.subnet_id for private_subnet in default_vpc.private_subnets]
+            subnet_ids += [public_subnet.subnet_id for public_subnet in default_vpc.public_subnets]
+
+            sagemaker_domain = sagemaker.CfnDomain(
+            self,
+            "SagemakerStudioDomain",
+            domain_name = f"SagemakerStudioDomain-{self._environment.region}-{self._environment.AwsAccountId}",
+            auth_mode = "IAM",
+
+            default_user_settings = sagemaker.CfnDomain.UserSettingsProperty(
+                execution_role = sagemaker_domain_role.role_arn,
+
+                security_groups=[],
+
+                sharing_settings=sagemaker.CfnDomain.SharingSettingsProperty(
+                    notebook_output_option = "Allowed",
+                    s3_kms_key_id = sagemaker_domain_key.key_id,
+                    s3_output_path = f"s3://sagemaker-{self._environment.region}-{self._environment.AwsAccountId}",
+                )
+            ),
+
+            vpc_id = vpc_id,
+            subnet_ids = subnet_ids,
+            app_network_access_type = "VpcOnly",
+            kms_key_id = sagemaker_domain_key.key_id,
+            )
+
+            ssm.StringParameter(
+                self,
+                'SagemakerStudioDomainId',
+                string_value = sagemaker_domain.attr_domain_id,
+                parameter_name=f'/datahub/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
+            )
 
         if self._environment.dashboardsEnabled:
             logger.warning('ensure_quicksight_default_group')

--- a/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
+++ b/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
@@ -126,7 +126,7 @@ class Sagemaker(ServicePolicy):
                     f'arn:aws:logs:{self.region}:{self.account}:log-group:/aws/sagemaker/*:log-stream:*',
                 ]
             ),
-             iam.PolicyStatement(
+            iam.PolicyStatement(
                 actions=[
                     'ecr:GetAuthorizationToken',
                     'ecr:BatchCheckLayerAvailability',

--- a/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
+++ b/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
@@ -9,11 +9,15 @@ class Sagemaker(ServicePolicy):
                 actions=[
                     'sagemaker:List*',
                     'sagemaker:Describe*',
+                    'sagemaker:BatchGet*',
+                    'sagemaker:BatchDescribe*',
                     'sagemaker:Search',
+                    'sagemaker:RenderUiTemplate',
                     'sagemaker:GetSearchSuggestions',
+                    'sagemaker:QueryLineage',
                     'sagemaker:CreateNotebookInstanceLifecycleConfig',
                     'sagemaker:DeleteNotebookInstanceLifecycleConfig',
-                    'sagemaker:CreatePresignedDomainUrl',
+                    'sagemaker:CreatePresignedDomainUrl'
                 ],
                 resources=['*'],
             ),
@@ -32,9 +36,19 @@ class Sagemaker(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:algorithm/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:model/*',
-                    f'arn:aws:sagemaker:{self.region}:{self.account}:training-job/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint-config/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment-trial/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment-group/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:model-bias-job-definition/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:model-package/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:model-package-group/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:model-quality-job-definition/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:monitoring-schedule/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:pipeline/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:project/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:app/*'
                 ],
                 conditions={
                     'StringEquals': {
@@ -54,9 +68,13 @@ class Sagemaker(ServicePolicy):
                 actions=['sagemaker:Start*', 'sagemaker:Stop*'],
                 resources=[
                     f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:monitoring-schedule/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:pipeline/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:training-job/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:processing-job/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:hyper-parameter-tuning-job/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:transform-job/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:automl-job/*'
                 ],
                 conditions={
                     'StringEquals': {
@@ -69,7 +87,17 @@ class Sagemaker(ServicePolicy):
                 resources=[
                     f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance-lifecycle-config/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:studio-lifecycle-config/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:pipeline/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:pipeline-execution/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:monitoring-schedule/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment-trial/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:experiment-trial-component/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:model-package/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:training-job/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:project/*'
                 ],
                 conditions={
                     'StringEquals': {
@@ -78,11 +106,9 @@ class Sagemaker(ServicePolicy):
                 },
             ),
             iam.PolicyStatement(
-                actions=['sagemaker:Update*'],
+                actions=['sagemaker:InvokeEndpoint', 'sagemaker:InvokeEndpointAsync'],
                 resources=[
-                    f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance/*',
-                    f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance-lifecycle-config/*',
-                    f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint/*',
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint/*'
                 ],
                 conditions={
                     'StringEquals': {
@@ -90,5 +116,25 @@ class Sagemaker(ServicePolicy):
                     }
                 },
             ),
+            iam.PolicyStatement(
+                actions=[
+                    'logs:CreateLogGroup',
+                    'logs:CreateLogStream',
+                    'logs:PutLogEvents'],
+                resources=[
+                    f'arn:aws:logs:{self.region}:{self.account}:log-group:/aws/sagemaker/*',
+                    f'arn:aws:logs:{self.region}:{self.account}:log-group:/aws/sagemaker/*:log-stream:*',
+                ]
+            ),
+             iam.PolicyStatement(
+                actions=[
+                    'ecr:GetAuthorizationToken',
+                    'ecr:BatchCheckLayerAvailability',
+                    'ecr:GetDownloadUrlForLayer',
+                    'ecr:BatchGetImage'],
+                resources=[
+                    '*'
+                ]
+            )
         ]
         return statements

--- a/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
+++ b/backend/dataall/cdkproxy/stacks/policies/sagemaker.py
@@ -43,6 +43,10 @@ class Sagemaker(ServicePolicy):
                 },
             ),
             iam.PolicyStatement(
+                actions=['sagemaker:CreateApp'],
+                resources=['*']
+            ),
+            iam.PolicyStatement(
                 actions=['sagemaker:Create*'],
                 resources=['*'],
             ),

--- a/backend/dataall/db/api/permission.py
+++ b/backend/dataall/db/api/permission.py
@@ -140,7 +140,7 @@ class Permission:
                 if p == permissions.CREATE_REDSHIFT_CLUSTER:
                     description = 'Create Redshift clusters on this environment'
                 if p == permissions.CREATE_SGMSTUDIO_NOTEBOOK:
-                    description = 'Create ML Studio notebooks on this environment'
+                    description = 'Manage ML Studio profiles on this environment'
                 if p == permissions.INVITE_ENVIRONMENT_GROUP:
                     description = 'Invite other teams to this environment'
                 if p == permissions.CREATE_SHARE_OBJECT:

--- a/documentation/userguide/docs/mlstudio.md
+++ b/documentation/userguide/docs/mlstudio.md
@@ -35,6 +35,6 @@ delete window that appears after clicking on delete.
 ![notebooks](pictures/mlstudio/ml_studio_3.png#zoom#shadow)
 
 ## :material-file-code-outline: **Open Amazon SageMaker Studio**
-Click on the **Open Notebook** button of the ML Studio notebook window to open Amazon SageMaker Studio.
+Click on the **Open ML Studio** button of the ML Studio notebook window to open Amazon SageMaker Studio.
 
 ![notebooks](pictures/mlstudio/ml_studio_2.png#zoom#shadow)

--- a/frontend/src/views/MLStudio/NotebookCreateForm.js
+++ b/frontend/src/views/MLStudio/NotebookCreateForm.js
@@ -106,7 +106,7 @@ const NotebookCreateForm = (props) => {
       if (!response.errors) {
         setStatus({ success: true });
         setSubmitting(false);
-        enqueueSnackbar('ML Studio creation stared', {
+        enqueueSnackbar('ML Studio user profile creation started', {
           anchorOrigin: {
             horizontal: 'right',
             vertical: 'top'
@@ -145,8 +145,11 @@ const NotebookCreateForm = (props) => {
         <Container maxWidth={settings.compact ? 'xl' : false}>
           <Grid container justifyContent="space-between" spacing={3}>
             <Grid item>
-              <Typography color="textPrimary" variant="h5">
-                Create a new notebook
+              <Typography
+                color="textPrimary"
+                variant="h5"
+              >
+                Create a new ML Studio profile
               </Typography>
               <Breadcrumbs
                 aria-label="breadcrumb"
@@ -203,7 +206,7 @@ const NotebookCreateForm = (props) => {
               validationSchema={Yup.object().shape({
                 label: Yup.string()
                   .max(255)
-                  .required('*Sagemaker Studio user profile is required'),
+                  .required('*ML Studio user profile is required'),
                 description: Yup.string().max(5000),
                 SamlAdminGroupName: Yup.string()
                   .max(255)
@@ -238,7 +241,7 @@ const NotebookCreateForm = (props) => {
                             error={Boolean(touched.label && errors.label)}
                             fullWidth
                             helperText={touched.label && errors.label}
-                            label="SageMaker Studio profile name"
+                            label="ML Studio profile name"
                             name="label"
                             onBlur={handleBlur}
                             onChange={handleChange}
@@ -404,7 +407,7 @@ const NotebookCreateForm = (props) => {
                           type="submit"
                           variant="contained"
                         >
-                          Create Notebook
+                          Create ML Studio profile
                         </LoadingButton>
                       </Box>
                     </Grid>

--- a/frontend/src/views/MLStudio/NotebookView.js
+++ b/frontend/src/views/MLStudio/NotebookView.js
@@ -113,7 +113,7 @@ const NotebookView = () => {
     );
     if (!response.errors) {
       handleDeleteObjectModalClose();
-      enqueueSnackbar('Notebook deleted', {
+      enqueueSnackbar('ML Studio Profile deleted', {
         anchorOrigin: {
           horizontal: 'right',
           vertical: 'top'
@@ -136,7 +136,7 @@ const NotebookView = () => {
   return (
     <>
       <Helmet>
-        <title>ML Studio: Notebook Details | data.all</title>
+        <title>ML Studio: Profile Details | DataStudio</title>
       </Helmet>
       <StackStatus
         stack={stack}
@@ -195,7 +195,7 @@ const NotebookView = () => {
                   type="button"
                   variant="outlined"
                 >
-                  Open Notebook
+                  Open JupyterLab
                 </LoadingButton>
                 <Button
                   color="primary"


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- In this PR, we provide the code to deploy a Sagemaker Domain with basic settings upon creation of a data.all workspace
- We also extend the Sagemaker permissions available to users, while ensuring they can only access their team's resources (using a resource tagging strategy)
- This takes as an input your default VPC, and assumes it has the appropriate networking configurations. To learn about the network requirements for Sagemaker Studio, read this documentation https://docs.aws.amazon.com/sagemaker/latest/dg/studio-notebooks-and-internet-access.html. For advanced networking customizations, stacks/environment.py should be modified according to your ecosystem's needs.

### Relates
- This was requested in issue 48 
- https://github.com/awslabs/aws-dataall/issues/48

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
