### PR TITLE
set aurora postgres version to avoid deployment issue

### DIFF
--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -92,7 +92,9 @@ class AuroraServerlessStack(pyNestedClass):
         database = rds.ServerlessCluster(
             self,
             f'AuroraDatabase{envname}',
-            engine=rds.DatabaseClusterEngine.AURORA_POSTGRESQL,
+            engine=rds.DatabaseClusterEngine.aurora_postgres(
+                version=rds.AuroraPostgresEngineVersion.VER_10_18
+            ),
             deletion_protection=True,
             cluster_identifier=f'{resource_prefix}-{envname}-db',
             parameter_group=rds.ParameterGroup.from_parameter_group_name(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
The Aurora database deployment currenlty fails with the following error message in CloudFormation: **Cannot find version null for aurora-postgresql**
Setting the Postgres version in the CDK construct solves the error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
