### PR TITLE
increase page size response for Glossary to show up to 500 glossary i…

### DIFF
--- a/frontend/src/views/Glossaries/GlossaryManagement.js
+++ b/frontend/src/views/Glossaries/GlossaryManagement.js
@@ -151,7 +151,7 @@ const GlossaryManagement = (props) => {
     setFetchingItems(true);
     setData(glossary);
     const response = await client.query(
-      listGlossaryTree({ nodeUri: glossary.nodeUri })
+      listGlossaryTree({ nodeUri: glossary.nodeUri, filter: {pageSize: 500} })
     );
     if (!response.errors && response.data.getGlossary !== null) {
       setItems({ ...response.data.getGlossary.tree });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
The GetGlossaryTree query returns a tree with only 10 items maximum. I increased the limit to 500.
This solves issue https://github.com/awslabs/aws-dataall/issues/79 . Unless there are more than 500 items in the glossary but this is unlikely in opinion.

### Relates
https://github.com/awslabs/aws-dataall/issues/79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
