### PR TITLE
enhancement: change find_environment_group definition to keep DRY

### DIFF
--- a/backend/dataall/api/Objects/Dataset/resolvers.py
+++ b/backend/dataall/api/Objects/Dataset/resolvers.py
@@ -282,7 +282,7 @@ def get_dataset_assume_role_url(context: Context, source, datasetUri: str = None
                 session=session,
                 uri=share.environmentUri
             )
-            env_group = Environment.find_environment_group(
+            env_group = Environment.get_environment_group(
                 session=session,
                 group_uri=share.principalId,
                 environment_uri=share.environmentUri

--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -1038,19 +1038,11 @@ class Environment:
 
     @staticmethod
     def find_environment_group(session, group_uri, environment_uri):
-        env_group = (
-            session.query(models.EnvironmentGroup)
-            .filter(
-                (
-                    and_(
-                        models.EnvironmentGroup.groupUri == group_uri,
-                        models.EnvironmentGroup.environmentUri == environment_uri,
-                    )
-                )
-            )
-            .first()
-        )
-        return env_group
+        try:
+            env_group = Environment.get_environment_group(session, group_uri, environment_uri)
+            return env_group
+        except Exception:
+            return None
 
     @staticmethod
     def get_environment_group(session, group_uri, environment_uri):
@@ -1067,7 +1059,7 @@ class Environment:
             .first()
         )
         if not env_group:
-            exceptions.ObjectNotFound(
+            raise exceptions.ObjectNotFound(
                 'EnvironmentGroup', f'({group_uri},{environment_uri})'
             )
         return env_group


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Detail
- The definition of function 'find_environment_group' and 'get_environment_group' are duplicated. Change the definition of 'find_environment_group' to keep DRY.

### Relates
- No related issues or tickets. Found during development.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
