### PR TITLE
Add ram:AssociateResourceShare to pivot role template

### DIFF
--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -362,6 +362,14 @@ Resources:
                   - LakeFormation*
           - Effect: Allow
             Action:
+              - 'ram:AssociateResourceShare'
+            Resource: !Sub 'arn:aws:ram:*:${AWS::AccountId}:resource-share/*'
+            Condition:
+              'ForAllValues:StringLike':
+                'ram:ResourceShareName':
+                  - LakeFormation*
+          - Effect: Allow
+            Action:
               - 'ram:DeleteResourceShare'
             Resource: !Sub 'arn:aws:ram:*:${AWS::AccountId}:resource-share/*'
             Condition:
@@ -455,7 +463,7 @@ Resources:
               - 'cloudformation:DescribeStackResource'
             Resource:
               - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/${EnvironmentResourcePrefix}*/*'
-              - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/CDKToolkit/*'
+              - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/CDKToolkitDataAll/*'
       ManagedPolicyName: !Sub ${EnvironmentResourcePrefix}-pivotrole-policy-1
       Roles:
         - !Ref PivotRoleName


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
During the testing of sharing glue tables across multiple environments in different AWS accounts we ran into the following error: 

Could not grant principal xxxxxxxxx permissions ['DESCRIBE', 'SELECT'] to table dataall_demodataset_6_28ibmjc5.dataall_demodataset_6_28ibmjc5 due to: An error occurred (AccessDeniedException) when calling the GrantPermissions operation: User: arn:aws:sts::xxxxxxxxx:assumed-role/dataallPivotRole/dataallPivotRole is not authorized to perform: ram:AssociateResourceShare on resource: arn:aws:ram:eu-central-1:xxxxxxxxx:resource-share/0c58101d-ca4b-48ee-8cd8-5b9a8bd9a68d (Service: AWSRAM; Status Code: 403; Error Code: AccessDeniedException; Request ID: acb6b394-24ef-4c74-bfbe-8fbcd71dca21; Proxy: null)_

Upon investigation we identified that the issue occurs during the execution of the ECS task share_manager.approve_share(). The code is using the data.all pivot role to execute api calls against Lakeformation and RAM to share the glue table with the other environment.

Adding the IAM action to the data.all pivot role solved the error message and the table is shared successfully between the environments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
