### PR TITLE
Add missing permissions for group role

### DIFF
--- a/backend/dataall/cdkproxy/stacks/policies/service_policy.py
+++ b/backend/dataall/cdkproxy/stacks/policies/service_policy.py
@@ -49,6 +49,12 @@ class ServicePolicy(object):
         from .cloudformation import Cloudformation
 
         policies: [aws_iam.ManagedPolicy] = [
+            
+            # This policy covers the minumum actions required independent 
+            # of the service permissions given to the group.
+            # The 'glue:GetTable', 'glue:GetPartitions' and 
+            # 'lakeformation:GetDataAccess' actions are additionally 
+            # required for the Worksheet/Athena feature.
             aws_iam.ManagedPolicy(
                 self.stack,
                 self.id,
@@ -59,6 +65,9 @@ class ServicePolicy(object):
                             'athena:ListEngineVersions',
                             'athena:ListDataCatalogs',
                             'athena:ListWorkGroups',
+                            'glue:GetTable',
+                            'glue:GetPartitions',
+                            'lakeformation:GetDataAccess',
                             'kms:Decrypt',
                             'kms:DescribeKey',
                             'kms:Encrypt',

--- a/backend/dataall/cdkproxy/stacks/policies/service_policy.py
+++ b/backend/dataall/cdkproxy/stacks/policies/service_policy.py
@@ -49,11 +49,10 @@ class ServicePolicy(object):
         from .cloudformation import Cloudformation
 
         policies: [aws_iam.ManagedPolicy] = [
-            
-            # This policy covers the minumum actions required independent 
+            # This policy covers the minumum actions required independent
             # of the service permissions given to the group.
-            # The 'glue:GetTable', 'glue:GetPartitions' and 
-            # 'lakeformation:GetDataAccess' actions are additionally 
+            # The 'glue:GetTable', 'glue:GetPartitions' and
+            # 'lakeformation:GetDataAccess' actions are additionally
             # required for the Worksheet/Athena feature.
             aws_iam.ManagedPolicy(
                 self.stack,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Environment group role is missing permissions for interaction with worksheet when no permission is given for creating datasets in the environment.

### Relates
Solves issue https://github.com/awslabs/aws-dataall/issues/115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
