### PR TITLE
fix for requesting data access for the team who does not have INVITE_…

### DIFF
--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -295,6 +295,7 @@ class Environment:
 
         g_permissions.append(permissions.RUN_ATHENA_QUERY)
         g_permissions.append(permissions.GET_ENVIRONMENT)
+        g_permissions.append(permissions.LIST_ENVIRONMENT_GROUPS)
         g_permissions.append(permissions.LIST_ENVIRONMENT_GROUP_PERMISSIONS)
         g_permissions.append(permissions.LIST_ENVIRONMENT_REDSHIFT_CLUSTERS)
         g_permissions.append(permissions.LIST_ENVIRONMENT_SHARED_WITH_OBJECTS)


### PR DESCRIPTION
Steps to reproduce the bug:
1. Invite a new team to the environment. The team should have a privilege for requesting a data access (
Request datasets access for this environment) but do not grant a privilege to invite the new team (Invite other teams to this environment)
2. Log in as a user who is a member of only this team.
3. Try to request  an access to data from the Catalog
4. It will throw an error since by default the team does not have the privilege for listing the groups in the environment but to me seems like this privilege should be granted by default.
![image](https://user-images.githubusercontent.com/30467028/187651970-cdbec466-5b22-473c-8b25-77c5b736c3cf.png)


