### PR TITLE
feat/autoupdates: extend IAM permissions for container execution roles

### DIFF
--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -350,6 +350,12 @@ class ContainerStack(pyNestedClass):
                 ),
                 iam.PolicyStatement(
                     actions=[
+                        'ecs:ListTasks',
+                    ],
+                    resources=['*'],
+                ),
+                iam.PolicyStatement(
+                    actions=[
                         's3:GetObject',
                         's3:ListBucketVersions',
                         's3:ListBucket',


### PR DESCRIPTION
Links to this issue: [Stacks Updater is triggered properly, but the container task does not complete #105](https://github.com/awslabs/aws-dataall/issues/105)