### PR TITLE
Add missing permissions to the Pivot role, that block Dataset and MLStudio features under specific conditions.

### DIFF
--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -331,6 +331,7 @@ Resources:
              - 'sagemaker:ListNotebookInstances'
              - 'sagemaker:ListDomains'
              - 'sagemaker:ListApps'
+             - 'sagemaker:DeleteApp'
             Resource: '*'
           - Effect: Allow
             Action:
@@ -513,6 +514,7 @@ Resources:
               - 'lakeformation:GetTableObjects'
               - 'lakeformation:UpdateTableObjects'
               - 'lakeformation:DeleteObjectsOnCancel'
+              - 'lakeformation:DescribeResource'
             Resource: '*'
           - Sid: Compute
             Effect: Allow


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Detail
- Missing LakeFormation permission in the Data.all Pivot role. As a consequence, dataset import failed when importing from a database that is already registered as a data location inside Lake Formation. With this fix, the dataset stack will not fail.
- Missing Sagemaker permissions used to delete Apps

### Relates
- No ticket associated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
