### PR TITLE
124 search funtionality for pipeline dashboard resources in dataall not working when used from specific pages

### DIFF
--- a/frontend/src/views/Dashboards/DashboardList.js
+++ b/frontend/src/views/Dashboards/DashboardList.js
@@ -110,6 +110,7 @@ const DashboardList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/Datasets/DatasetList.js
+++ b/frontend/src/views/Datasets/DatasetList.js
@@ -110,6 +110,7 @@ const DatasetList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/Environments/EnvironmentList.js
+++ b/frontend/src/views/Environments/EnvironmentList.js
@@ -84,6 +84,7 @@ const EnvironmentList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/MLStudio/NotebookList.js
+++ b/frontend/src/views/MLStudio/NotebookList.js
@@ -101,6 +101,7 @@ const NotebookList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/Notebooks/NotebookList.js
+++ b/frontend/src/views/Notebooks/NotebookList.js
@@ -99,6 +99,7 @@ const NotebookList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/Organizations/OrganizationList.js
+++ b/frontend/src/views/Organizations/OrganizationList.js
@@ -51,7 +51,7 @@ const OrganizationList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
-      setFilter({term: event.target.value });
+      setFilter({page: 1, term: event.target.value});
       fetchItems();
     }
   };

--- a/frontend/src/views/Organizations/OrganizationList.js
+++ b/frontend/src/views/Organizations/OrganizationList.js
@@ -51,6 +51,7 @@ const OrganizationList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({term: event.target.value });
       fetchItems();
     }
   };

--- a/frontend/src/views/Pipelines/PipelineList.js
+++ b/frontend/src/views/Pipelines/PipelineList.js
@@ -99,6 +99,7 @@ const PipelineList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );

--- a/frontend/src/views/Worksheets/WorksheetList.js
+++ b/frontend/src/views/Worksheets/WorksheetList.js
@@ -108,6 +108,7 @@ const WorksheetList = () => {
 
   const handleInputKeyup = (event) => {
     if (event.code === 'Enter') {
+      setFilter({page: 1, term: event.target.value});
       fetchItems().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix: When filtering by term in the search tab in a page different than 1 no results appear because we are also filtering by page.

### Detail
-  When "enter" is pressed in the search tab we set the page filter back to 1 in all list views


### Relates
- https://github.com/awslabs/aws-dataall/issues/124 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
