### PR TITLE
Change the OAuth2 grant type to code to benefit from refresh token, r…

### DIFF
--- a/frontend/src/contexts/AmplifyContext.js
+++ b/frontend/src/contexts/AmplifyContext.js
@@ -19,7 +19,7 @@ Auth.configure({
     domain: process.env.REACT_APP_COGNITO_DOMAIN,
     redirectSignIn: process.env.REACT_APP_COGNITO_REDIRECT_SIGNIN,
     redirectSignOut: process.env.REACT_APP_COGNITO_REDIRECT_SIGNOUT,
-    responseType: 'token'
+    responseType: 'code'
   }
 });
 
@@ -129,6 +129,7 @@ export const AuthProvider = (props) => {
     <AuthContext.Provider
       value={{
         ...state,
+        dispatch,
         platform: 'Amplify',
         login,
         logout

--- a/frontend/src/contexts/LocalContext.js
+++ b/frontend/src/contexts/LocalContext.js
@@ -97,6 +97,7 @@ export const AuthProvider = (props) => {
     <LocalContext.Provider
       value={{
         ...state,
+        dispatch,
         platform: 'local',
         login,
         logout

--- a/frontend/src/hooks/useToken.js
+++ b/frontend/src/hooks/useToken.js
@@ -2,9 +2,11 @@ import { useEffect, useState } from 'react';
 import { Auth } from 'aws-amplify';
 import { SET_ERROR } from '../store/errorReducer';
 import { useDispatch } from '../store';
+import useAuth from "./useAuth";
 
 const useToken = () => {
   const dispatch = useDispatch();
+  const auth = useAuth();
   const [token, setToken] = useState(null);
   const fetchAuthToken = async () => {
     if (
@@ -13,9 +15,15 @@ const useToken = () => {
     ) {
       setToken('localToken');
     } else {
-      const session = await Auth.currentSession();
-      const t = await session.getIdToken().getJwtToken();
-      setToken(t);
+      try {
+        const session = await Auth.currentSession();
+        const t = await session.getIdToken().getJwtToken();
+        setToken(t);
+      } catch (error) {
+        auth.dispatch({
+          type: 'LOGOUT'
+        });
+      }
     }
   };
 


### PR DESCRIPTION
In order to provide our customers with the best user experience the expiration of the ID & Access tokens every hour shouldn't force the users to log in again. Additionally the user is even not redirected to the login page automatically but gets stuck with the following error displayed by the application:
![image](https://user-images.githubusercontent.com/30467028/189888015-f4cfe737-d448-4da1-9f9e-3c3d2986dde1.png)
As a result the user needs to refresh the page to be redirected to the login page.

To reproduce:
- log in to the data.all
- do something else in the meantime and get back  to the UI after more than one hour (once the token expires) and click on the Catalog menu on the left (as an example)
- the error will be displayed, refresh the page to be redirected to the login page

The fix I propose:
- changes the OAuth2 grant type to 'CODE', as a result the refresh token is also returned by the Cognito
- under the hood data.all uses Amplify.js which is luckily able to make use of the refresh token automatically, so once the id token & access token expire it will send a request to Cognito to get new ones
- make a small change in the front-end code to redirect to the login page automatically
