### PR TITLE
Bugfix/query organization environments fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     -   repo: https://github.com/psf/black
-        rev: 21.6b0
+        rev: 22.8.0
         hooks:
             - id: black
               entry: black --skip-string-normalization backend/dataall

--- a/README.md
+++ b/README.md
@@ -1,25 +1,22 @@
 # **What's data.all**
-An open source development framework to help you build a data marketplace on AWS.
-**data.all** builds a modern data workspace that makes collaboration
-among diverse users (like business, analysts and engineers) easier, 
-increasing efficiency and agility in data projects ✨
+
+An open source development framework to help you build a data marketplace on AWS.**data.all** builds a modern data
+workspace that makes collaboration among diverse users (like business, analysts and engineers) easier, increasing
+efficiency and agility in data projects ✨
 
 ![data.all_catalog](documentation/userguide/docs/pictures/catalog/catalog.png)
 
 ## **Why we built data.all**
 
-Data teams can be diverse: analysts, scientists, engineers, business users. Diverse people, with 
-diverse tools and skillsets — diverse "DNAs". All leading to chaos and resulting in titanic 
-efforts spent in Collaboration Overhead.
+Data teams can be diverse: analysts, scientists, engineers, business users. Diverse people, with diverse tools and
+skillsets — diverse "DNAs". All leading to chaos and resulting in titanic efforts spent in Collaboration Overhead.
 
-Using data.all, any line of business within an organization can create their own isolated data lake, 
-produce, consume and share data within and across business units, worldwide. By simplifying data discovery, 
-data access management while letting more builders use AWS vast portfolio of data and analytics services, 
-data.all helps more data teams discover relevant data and let them use the power of the AWS cloud 
-to create data driven applications faster.
-
+Using data.all, any line of business within an organization can create their own isolated data lake, produce, consume
+and share data within and across business units, worldwide. By simplifying data discovery, data access management while
+letting more builders use AWS vast portfolio of data and analytics services, data.all helps more data teams discover
+relevant data and let them use the power of the AWS cloud to create data driven applications faster.
 
 ## **Want to know more?**
-Visit our [GitHub pages](https://awslabs.github.io/aws-dataall/) 
-to get started and learn more about the architecture and the code of **data.all**
 
+Visit our [GitHub pages](https://awslabs.github.io/aws-dataall/) to get started and learn more about the architecture
+and the code of **data.all**

--- a/backend/dataall/db/api/organization.py
+++ b/backend/dataall/db/api/organization.py
@@ -29,9 +29,7 @@ class Organization:
 
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
-    def create_organization(
-        session, username, groups, uri, data=None, check_perm=None
-    ) -> models.Organization:
+    def create_organization(session, username, groups, uri, data=None, check_perm=None) -> models.Organization:
         if not data:
             raise exceptions.RequiredParameter(data)
         if not data.get('SamlGroupName'):
@@ -107,8 +105,7 @@ class Organization:
             session.query(models.Organization)
             .outerjoin(
                 models.OrganizationGroup,
-                models.Organization.organizationUri
-                == models.OrganizationGroup.organizationUri,
+                models.Organization.organizationUri == models.OrganizationGroup.organizationUri,
             )
             .filter(
                 or_(
@@ -121,31 +118,23 @@ class Organization:
             query = query.filter(
                 or_(
                     models.Organization.label.ilike('%' + filter.get('term') + '%'),
-                    models.Organization.description.ilike(
-                        '%' + filter.get('term') + '%'
-                    ),
+                    models.Organization.description.ilike('%' + filter.get('term') + '%'),
                     models.Organization.tags.contains(f"{{{filter.get('term')}}}"),
                 )
             )
         return query
 
     @staticmethod
-    def paginated_user_organizations(
-        session, username, groups, uri, data=None, check_perm=None
-    ) -> dict:
+    def paginated_user_organizations(session, username, groups, uri, data=None, check_perm=None) -> dict:
         return paginate(
-            query=Organization.query_user_organizations(
-                session, username, groups, data
-            ),
+            query=Organization.query_user_organizations(session, username, groups, data),
             page=data.get('page', 1),
             page_size=data.get('pageSize', 10),
         ).to_dict()
 
     @staticmethod
     def query_organization_environments(session, uri, filter) -> Query:
-        query = session.query(models.Environment).filter(
-            models.Environment.organizationUri == uri
-        )
+        query = session.query(models.Environment).filter(models.Environment.organizationUri == uri)
         if filter and filter.get('term'):
             query = query.filter(
                 or_(
@@ -158,9 +147,7 @@ class Organization:
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_perm(permissions.GET_ORGANIZATION)
-    def paginated_organization_environments(
-        session, username, groups, uri, data=None, check_perm=None
-    ) -> dict:
+    def paginated_organization_environments(session, username, groups, uri, data=None, check_perm=None) -> dict:
         return paginate(
             query=Organization.query_organization_environments(session, uri, data),
             page=data.get('page', 1),
@@ -170,16 +157,10 @@ class Organization:
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_perm(permissions.DELETE_ORGANIZATION)
-    def archive_organization(
-        session, username, groups, uri, data=None, check_perm=None
-    ) -> bool:
+    def archive_organization(session, username, groups, uri, data=None, check_perm=None) -> bool:
 
         org = Organization.get_organization_by_uri(session, uri)
-        environments = (
-            session.query(models.Environment)
-            .filter(models.Environment.organizationUri == uri)
-            .count()
-        )
+        environments = session.query(models.Environment).filter(models.Environment.organizationUri == uri).count()
         if environments:
             raise exceptions.UnauthorizedOperation(
                 action='ARCHIVE_ORGANIZATION',
@@ -208,9 +189,7 @@ class Organization:
 
         organization = Organization.get_organization_by_uri(session, uri)
 
-        group_membership = Organization.find_group_membership(
-            session, group, organization
-        )
+        group_membership = Organization.find_group_membership(session, group, organization)
         if group_membership:
             raise exceptions.UnauthorizedOperation(
                 action='INVITE_TEAM',
@@ -239,8 +218,7 @@ class Organization:
                 (
                     and_(
                         models.OrganizationGroup.groupUri == group,
-                        models.OrganizationGroup.organizationUri
-                        == organization.organizationUri,
+                        models.OrganizationGroup.organizationUri == organization.organizationUri,
                     )
                 )
             )
@@ -290,9 +268,7 @@ class Organization:
                 message=f'Team: {group} has {group_env_objects_count} linked environments on this environment.',
             )
 
-        group_membership = Organization.find_group_membership(
-            session, group, organization
-        )
+        group_membership = Organization.find_group_membership(session, group, organization)
         if group_membership:
             session.delete(group_membership)
             session.commit()
@@ -307,15 +283,11 @@ class Organization:
 
     @staticmethod
     def query_organization_groups(session, uri, filter) -> Query:
-        query = session.query(models.OrganizationGroup).filter(
-            models.OrganizationGroup.organizationUri == uri
-        )
+        query = session.query(models.OrganizationGroup).filter(models.OrganizationGroup.organizationUri == uri)
         if filter and filter.get('term'):
             query = query.filter(
                 or_(
-                    models.OrganizationGroup.groupUri.ilike(
-                        '%' + filter.get('term') + '%'
-                    ),
+                    models.OrganizationGroup.groupUri.ilike('%' + filter.get('term') + '%'),
                 )
             )
         return query
@@ -323,9 +295,7 @@ class Organization:
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_perm(permissions.GET_ORGANIZATION)
-    def paginated_organization_groups(
-        session, username, groups, uri, data=None, check_perm=None
-    ) -> dict:
+    def paginated_organization_groups(session, username, groups, uri, data=None, check_perm=None) -> dict:
         return paginate(
             query=Organization.query_organization_groups(session, uri, data),
             page=data.get('page', 1),
@@ -338,23 +308,19 @@ class Organization:
             session.query(models.OrganizationGroup)
             .join(
                 models.Organization,
-                models.OrganizationGroup.organizationUri
-                == models.Organization.organizationUri,
+                models.OrganizationGroup.organizationUri == models.Organization.organizationUri,
             )
             .filter(
                 and_(
                     models.Organization.organizationUri == organization.organizationUri,
-                    models.OrganizationGroup.groupUri
-                    != models.Organization.SamlGroupName,
+                    models.OrganizationGroup.groupUri != models.Organization.SamlGroupName,
                 )
             )
         )
         if filter and filter.get('term'):
             query = query.filter(
                 or_(
-                    models.OrganizationGroup.groupUri.ilike(
-                        '%' + filter.get('term') + '%'
-                    ),
+                    models.OrganizationGroup.groupUri.ilike('%' + filter.get('term') + '%'),
                 )
             )
         return query
@@ -362,14 +328,10 @@ class Organization:
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_perm(permissions.GET_ORGANIZATION)
-    def paginated_organization_invited_groups(
-        session, username, groups, uri, data=None, check_perm=False
-    ) -> dict:
+    def paginated_organization_invited_groups(session, username, groups, uri, data=None, check_perm=False) -> dict:
         organization = Organization.get_organization_by_uri(session, uri)
         return paginate(
-            query=Organization.query_organization_invited_groups(
-                session, organization, data
-            ),
+            query=Organization.query_organization_invited_groups(session, organization, data),
             page=data.get('page', 1),
             page_size=data.get('pageSize', 10),
         ).to_dict()
@@ -377,9 +339,7 @@ class Organization:
     @staticmethod
     @has_tenant_perm(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_perm(permissions.GET_ORGANIZATION)
-    def not_organization_groups(
-        session, username, groups, uri, data=None, check_perm=False
-    ) -> dict:
+    def not_organization_groups(session, username, groups, uri, data=None, check_perm=False) -> dict:
         org_groups: [] = (
             session.query(models.OrganizationGroup).filter(
                 and_(
@@ -389,9 +349,7 @@ class Organization:
             )
         ).all()
         org_groups = [g.groupUri for g in org_groups]
-        not_invited_groups = [
-            {'groupUri': group} for group in groups if group not in org_groups
-        ]
+        not_invited_groups = [{'groupUri': group} for group in groups if group not in org_groups]
         return Page(not_invited_groups, 1, 1000, len(not_invited_groups)).to_dict()
 
     @staticmethod

--- a/backend/dataall/db/api/organization.py
+++ b/backend/dataall/db/api/organization.py
@@ -138,8 +138,8 @@ class Organization:
         if filter and filter.get('term'):
             query = query.filter(
                 or_(
-                    models.Group.label.ilike('%' + filter.get('term') + '%'),
-                    models.Group.description.ilike('%' + filter.get('term') + '%'),
+                    models.Environment.label.ilike('%' + filter.get('term') + '%'),
+                    models.Environment.description.ilike('%' + filter.get('term') + '%'),
                 )
             )
         return query

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -18,9 +18,7 @@ def patch_check_env(module_mocker):
 
 @pytest.fixture(scope='module', autouse=True)
 def patch_check_env(module_mocker):
-    module_mocker.patch(
-        'dataall.utils.Parameter.get_parameter', return_value='unknownvalue'
-    )
+    module_mocker.patch('dataall.utils.Parameter.get_parameter', return_value='unknownvalue')
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -28,15 +26,11 @@ def patch_es(module_mocker):
     module_mocker.patch('dataall.searchproxy.connect', return_value={})
     module_mocker.patch('dataall.searchproxy.search', return_value={})
     module_mocker.patch('dataall.searchproxy.upsert', return_value={})
-    module_mocker.patch(
-        'dataall.searchproxy.indexers.upsert_dataset_tables', return_value={}
-    )
+    module_mocker.patch('dataall.searchproxy.indexers.upsert_dataset_tables', return_value={})
     module_mocker.patch('dataall.searchproxy.indexers.upsert_dataset', return_value={})
     module_mocker.patch('dataall.searchproxy.indexers.upsert_table', return_value={})
     module_mocker.patch('dataall.searchproxy.indexers.upsert_folder', return_value={})
-    module_mocker.patch(
-        'dataall.searchproxy.indexers.upsert_dashboard', return_value={}
-    )
+    module_mocker.patch('dataall.searchproxy.indexers.upsert_dashboard', return_value={})
     module_mocker.patch('dataall.searchproxy.indexers.delete_doc', return_value={})
 
 
@@ -73,9 +67,7 @@ def user(db):
 @pytest.fixture(scope='module')
 def group(db, user):
     with db.scoped_session() as session:
-        group = dataall.db.models.Group(
-            name='testadmins', label='testadmins', owner='alice'
-        )
+        group = dataall.db.models.Group(name='testadmins', label='testadmins', owner='alice')
         session.add(group)
         session.commit()
         member = dataall.db.models.GroupMember(
@@ -98,9 +90,7 @@ def user2(db):
 @pytest.fixture(scope='module')
 def group2(db, user2):
     with db.scoped_session() as session:
-        group = dataall.db.models.Group(
-            name='dataengineers', label='dataengineers', owner=user2.userName
-        )
+        group = dataall.db.models.Group(name='dataengineers', label='dataengineers', owner=user2.userName)
         session.add(group)
         session.commit()
         member = dataall.db.models.GroupMember(
@@ -123,9 +113,7 @@ def user3(db):
 @pytest.fixture(scope='module')
 def group3(db, user3):
     with db.scoped_session() as session:
-        group = dataall.db.models.Group(
-            name='datascientists', label='datascientists', owner=user3.userName
-        )
+        group = dataall.db.models.Group(name='datascientists', label='datascientists', owner=user3.userName)
         session.add(group)
         session.commit()
         member = dataall.db.models.GroupMember(
@@ -140,9 +128,7 @@ def group3(db, user3):
 @pytest.fixture(scope='module')
 def group4(db, user3):
     with db.scoped_session() as session:
-        group = dataall.db.models.Group(
-            name='externals', label='externals', owner=user3.userName
-        )
+        group = dataall.db.models.Group(name='externals', label='externals', owner=user3.userName)
         session.add(group)
         session.commit()
         member = dataall.db.models.GroupMember(
@@ -157,9 +143,7 @@ def group4(db, user3):
 @pytest.fixture(scope='module')
 def tenant(db, group, group2, permissions, user, user2, user3, group3, group4):
     with db.scoped_session() as session:
-        tenant = dataall.db.api.Tenant.save_tenant(
-            session, name='dataall', description='Tenant dataall'
-        )
+        tenant = dataall.db.api.Tenant.save_tenant(session, name='dataall', description='Tenant dataall')
         dataall.db.api.TenantPolicy.attach_group_tenant_policy(
             session=session,
             group=group.name,
@@ -355,9 +339,7 @@ def env(client):
 def location(db):
     cache = {}
 
-    def factory(
-        dataset: models.Dataset, name, username
-    ) -> models.DatasetStorageLocation:
+    def factory(dataset: models.Dataset, name, username) -> models.DatasetStorageLocation:
         key = f'{dataset.datasetUri}-{name}'
         if cache.get(key):
             return cache.get(key)
@@ -448,17 +430,13 @@ def org_fixture(org, user, group, tenant):
 @pytest.fixture(scope='module')
 def env_fixture(env, org_fixture, user, group, tenant, module_mocker):
     module_mocker.patch('requests.post', return_value=True)
-    module_mocker.patch(
-        'dataall.api.Objects.Environment.resolvers.check_environment', return_value=True
-    )
+    module_mocker.patch('dataall.api.Objects.Environment.resolvers.check_environment', return_value=True)
     env1 = env(org_fixture, 'dev', 'alice', 'testadmins', '111111111111', 'eu-west-1')
     yield env1
 
 
 @pytest.fixture(scope='module')
-def dataset_fixture(
-    env_fixture, org_fixture, dataset, group
-) -> dataall.db.models.Dataset:
+def dataset_fixture(env_fixture, org_fixture, dataset, group) -> dataall.db.models.Dataset:
     yield dataset(
         org=org_fixture,
         env=env_fixture,
@@ -520,9 +498,7 @@ def cluster(env_fixture, org_fixture, client, group):
 
 
 @pytest.fixture(scope='module')
-def sgm_notebook(
-    client, tenant, group, env_fixture
-) -> dataall.db.models.SagemakerNotebook:
+def sgm_notebook(client, tenant, group, env_fixture) -> dataall.db.models.SagemakerNotebook:
     response = client.query(
         """
         mutation createSagemakerNotebook($input:NewSagemakerNotebookInput){
@@ -591,9 +567,7 @@ def pipeline(client, tenant, group, env_fixture) -> models.DataPipeline:
 
 
 @pytest.fixture(scope='module')
-def sgm_studio(
-    client, tenant, group, env_fixture, module_mocker
-) -> models.SagemakerStudioUserProfile:
+def sgm_studio(client, tenant, group, env_fixture, module_mocker) -> models.SagemakerStudioUserProfile:
     module_mocker.patch(
         'dataall.aws.handlers.sagemaker_studio.SagemakerStudio.get_sagemaker_studio_domain',
         return_value={'DomainId': 'test'},

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -296,7 +296,7 @@ def dataset(client, patch_es):
 def env(client):
     cache = {}
 
-    def factory(org, envname, owner, group, account, region):
+    def factory(org, envname, owner, group, account, region, desc='test'):
         key = f"{org.organizationUri}{envname}{owner}{''.join(group or '-')}{account}{region}"
         if cache.get(key):
             return cache[key]
@@ -319,7 +319,7 @@ def env(client):
             groups=[group],
             input={
                 'label': f'{envname}',
-                'description': f'test',
+                'description': f'{desc}',
                 'organizationUri': org.organizationUri,
                 'AwsAccountId': account,
                 'tags': ['a', 'b', 'c'],

--- a/tests/api/test_organization.py
+++ b/tests/api/test_organization.py
@@ -116,9 +116,7 @@ def test_list_organizations_alice(client, org1, group):
     )
 
     assert response.data.listOrganizations.count == 1
-    assert (
-        response.data.listOrganizations.nodes[0].organizationUri == org1.organizationUri
-    )
+    assert response.data.listOrganizations.nodes[0].organizationUri == org1.organizationUri
 
 
 def test_list_organizations_admin(client, org1, group):
@@ -138,9 +136,7 @@ def test_list_organizations_admin(client, org1, group):
     )
     print(response)
     assert response.data.listOrganizations.count == 1
-    assert (
-        response.data.listOrganizations.nodes[0].organizationUri == org1.organizationUri
-    )
+    assert response.data.listOrganizations.nodes[0].organizationUri == org1.organizationUri
 
 
 def test_list_organizations_anyone(client, org1):
@@ -162,9 +158,7 @@ def test_list_organizations_anyone(client, org1):
     assert response.data.listOrganizations.count == 0
 
 
-def test_group_invitation(
-    db, client, org1, group2, user, group3, group, dataset, env, module_mocker
-):
+def test_group_invitation(db, client, org1, group2, user, group3, group, dataset, env, module_mocker):
     response = client.query(
         """
         mutation inviteGroupToOrganization($input:InviteGroupToOrganizationInput){
@@ -263,9 +257,7 @@ def test_group_invitation(
     assert response.data.listOrganizationGroups.count == 2
 
     module_mocker.patch('requests.post', return_value=True)
-    module_mocker.patch(
-        'dataall.api.Objects.Environment.resolvers.check_environment', return_value=True
-    )
+    module_mocker.patch('dataall.api.Objects.Environment.resolvers.check_environment', return_value=True)
     env2 = env(org1, 'devg2', user.userName, group2.name, '111111111112', 'eu-west-1')
     assert env2.environmentUri
 

--- a/tests/api/test_organization.py
+++ b/tests/api/test_organization.py
@@ -8,6 +8,36 @@ def org1(org, user, group, tenant):
     yield org1
 
 
+@pytest.fixture(scope='module', autouse=True)
+def org2(org, user2, group2, tenant):
+    org2 = org('anothertestorg', user2.userName, group2.name)
+    yield org2
+
+
+@pytest.fixture(scope='module', autouse=True)
+def env_dev(env, org2, user2, group2, tenant, module_mocker):
+    module_mocker.patch('requests.post', return_value=True)
+    module_mocker.patch('dataall.api.Objects.Environment.resolvers.check_environment', return_value=True)
+    env2 = env(org2, 'dev', user2.userName, group2.name, '222222222222', 'eu-west-1', 'description')
+    yield env2
+
+
+@pytest.fixture(scope='module', autouse=True)
+def env_other(env, org2, user2, group2, tenant, module_mocker):
+    module_mocker.patch('requests.post', return_value=True)
+    module_mocker.patch('dataall.api.Objects.Environment.resolvers.check_environment', return_value=True)
+    env2 = env(org2, 'other', user2.userName, group2.name, '222222222222', 'eu-west-1')
+    yield env2
+
+
+@pytest.fixture(scope='module', autouse=True)
+def env_prod(env, org2, user2, group2, tenant, module_mocker):
+    module_mocker.patch('requests.post', return_value=True)
+    module_mocker.patch('dataall.api.Objects.Environment.resolvers.check_environment', return_value=True)
+    env2 = env(org2, 'prod', user2.userName, group2.name, '111111111111', 'eu-west-1', 'description')
+    yield env2
+
+
 def test_get_org(client, org1, group):
     response = client.query(
         """
@@ -372,3 +402,79 @@ def test_archive_org(client, org1, group, group2):
     )
     print(response)
     assert response.data.archiveOrganization
+
+
+def test_list_organization_environments(org2, client, group2):
+    response = client.query(
+        """
+        query GetOrg($organizationUri:String!, $filter: EnvironmentFilter){
+            getOrganization(organizationUri:$organizationUri){
+                environments(filter: $filter) {
+                    count
+                    nodes {
+                        label
+                        description
+                    }
+                }
+            }
+        }
+        """,
+        username='alice',
+        organizationUri=org2.organizationUri,
+        groups=[group2.name],
+        filter={'term': ''},
+    )
+
+    assert response.data.getOrganization.environments.count == 3
+
+
+def test_list_organization_environments_filter_by_label(org2, env_other, client, group2):
+    response = client.query(
+        """
+        query GetOrg($organizationUri:String!, $filter: EnvironmentFilter){
+            getOrganization(organizationUri:$organizationUri){
+                environments(filter: $filter) {
+                    count
+                    nodes {
+                        label
+                        description
+                    }
+                }
+            }
+        }
+        """,
+        username='alice',
+        organizationUri=org2.organizationUri,
+        groups=[group2.name],
+        filter={'term': 'other'},
+    )
+
+    assert response.data.getOrganization.environments.count == 1
+    assert response.data.getOrganization.environments.nodes[0].label == env_other.label
+
+
+def test_list_organization_environments_filter_by_desc(org2, env_dev, env_prod, client, group2):
+    response = client.query(
+        """
+        query GetOrg($organizationUri:String!, $filter: EnvironmentFilter){
+            getOrganization(organizationUri:$organizationUri){
+                environments(filter: $filter) {
+                    count
+                    nodes {
+                        label
+                        description
+                    }
+                }
+            }
+        }
+        """,
+        username='alice',
+        organizationUri=org2.organizationUri,
+        groups=[group2.name],
+        filter={'term': 'description'},
+    )
+
+    assert response.data.getOrganization.environments.count == 2
+    envs = set(map(lambda n: n.label, response.data.getOrganization.environments.nodes))
+    assert env_dev.label in envs
+    assert env_prod.label in envs


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
When entering any filter criteria for environments on organisation view the result in empty. Expected to filter environments with name containing entered term. 
Added integration test to check this and fixed query (the was wrong table used for filter condition) 

### Relates
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
