### PR TITLE
Check quicksight subscription at environment creation

### DIFF
--- a/backend/dataall/api/Objects/Environment/resolvers.py
+++ b/backend/dataall/api/Objects/Environment/resolvers.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_
 from ..Organization.resolvers import *
 from ..Stack import stack_helper
 from ...constants import *
-from ....aws.handlers.sts import SessionHelper
+from ....aws.handlers.sts import SessionHelper, CloudFormation, Quicksight
 from ....db import exceptions, permissions
 from ....db.api import Environment, ResourcePolicy, Stack
 from ....utils.naming_convention import (
@@ -33,26 +33,12 @@ def check_environment(context: Context, source, input=None):
         return 'CdkRoleName'
     account = input.get('AwsAccountId')
     region = input.get('region')
-    aws = SessionHelper.remote_session(accountid=account)
-    cfn = aws.client('cloudformation', region_name=region)
-    try:
-        response = cfn.describe_stacks(StackName='CDKToolkit')
-    except cfn.exceptions.ClientError as e:
-        print(e)
-        raise Exception('CDKToolkitNotFound')
+    cdk_role_name = CloudFormation.check_existing_cdk_toolkit_stack(AwsAccountId=account, region=region)
 
-    stacks = response['Stacks']
-    if not len(stacks):
-        raise Exception('CDKToolkitNotFound')
+    if input.get('dashboardsEnabled'):
+        existing_quicksight = Quicksight.check_quicksight_enterprise_subscription(AwsAccountId=account)
 
-    try:
-        response = cfn.describe_stack_resource(
-            StackName='CDKToolkit', LogicalResourceId='CloudFormationExecutionRole'
-        )
-        cdk_role_name = response['StackResourceDetail']['PhysicalResourceId']
-        return cdk_role_name
-    except cfn.exceptions.ClientError as e:
-        raise Exception('CDKToolkitDeploymentActionRoleNotFound')
+    return cdk_role_name
 
 
 def create_environment(context: Context, source, input=None):

--- a/backend/dataall/api/Objects/Environment/resolvers.py
+++ b/backend/dataall/api/Objects/Environment/resolvers.py
@@ -10,7 +10,9 @@ from sqlalchemy import and_
 from ..Organization.resolvers import *
 from ..Stack import stack_helper
 from ...constants import *
-from ....aws.handlers.sts import SessionHelper, CloudFormation, Quicksight
+from ....aws.handlers.sts import SessionHelper
+from ....aws.handlers.quicksight import Quicksight
+from ....aws.handlers.cloudformation import CloudFormation
 from ....db import exceptions, permissions
 from ....db.api import Environment, ResourcePolicy, Stack
 from ....utils.naming_convention import (

--- a/backend/dataall/aws/handlers/cloudformation.py
+++ b/backend/dataall/aws/handlers/cloudformation.py
@@ -14,11 +14,12 @@ log = logging.getLogger(__name__)
 class CloudFormation:
     def __init__(self):
         pass
+
     @staticmethod
     def client(AwsAccountId, region):
         session = SessionHelper.remote_session(AwsAccountId)
         return session.client('cloudformation', region_name=region)
-        
+
     @staticmethod
     def check_existing_cdk_toolkit_stack(AwsAccountId, region):
         cfn = CloudFormation.client(AwsAccountId=AwsAccountId, region=region)

--- a/backend/dataall/aws/handlers/cloudformation.py
+++ b/backend/dataall/aws/handlers/cloudformation.py
@@ -14,6 +14,32 @@ log = logging.getLogger(__name__)
 class CloudFormation:
     def __init__(self):
         pass
+    @staticmethod
+    def client(AwsAccountId, region):
+        session = SessionHelper.remote_session(AwsAccountId)
+        return session.client('cloudformation', region_name=region)
+        
+    @staticmethod
+    def check_existing_cdk_toolkit_stack(AwsAccountId, region):
+        cfn = CloudFormation.client(AwsAccountId=AwsAccountId, region=region)
+        try:
+            response = cfn.describe_stacks(StackName='CDKToolkit')
+        except cfn.exceptions.ClientError as e:
+            print(e)
+            raise Exception('CDKToolkitNotFound')
+
+        stacks = response['Stacks']
+        if not len(stacks):
+            raise Exception('CDKToolkitNotFound')
+
+        try:
+            response = cfn.describe_stack_resource(
+                StackName='CDKToolkit', LogicalResourceId='CloudFormationExecutionRole'
+            )
+            cdk_role_name = response['StackResourceDetail']['PhysicalResourceId']
+            return cdk_role_name
+        except cfn.exceptions.ClientError as e:
+            raise Exception('CDKToolkitDeploymentActionRoleNotFound')
 
     @staticmethod
     @Worker.handler(path='cloudformation.stack.delete')

--- a/backend/dataall/aws/handlers/quicksight.py
+++ b/backend/dataall/aws/handlers/quicksight.py
@@ -15,6 +15,7 @@ logger.setLevel(logging.DEBUG)
 class Quicksight:
     def __init__(self):
         pass
+
     @staticmethod
     def get_quicksight_client(AwsAccountId, region='eu-west-1'):
         """Returns a boto3 quicksight client in the provided account/region
@@ -68,10 +69,7 @@ class Quicksight:
 
     @staticmethod
     def check_quicksight_enterprise_subscription(AwsAccountId):
-        """
-        Use the DescribeAccountSubscription operation to receive a description of a Amazon QuickSight account's 
-        subscription. A successful API call returns an AccountInfo object that includes an account's name, 
-        subscription status, authentication type, edition, and notification email address.
+        """Use the DescribeAccountSubscription operation to receive a description of a Amazon QuickSight account's subscription. A successful API call returns an AccountInfo object that includes an account's name, subscription status, authentication type, edition, and notification email address.
         Args:
             AwsAccountId(str) : aws account id
         Returns: bool
@@ -92,7 +90,6 @@ class Quicksight:
                     else:
                         raise Exception(
                             f"Quicksight Subscription found in Account: {AwsAccountId} not active. Status = {response['AccountInfo']['AccountSubscriptionStatus']}")
-
 
         except client.exceptions.ResourceNotFoundException:
             raise Exception('Quicksight Enterprise Subscription not found')

--- a/backend/dataall/aws/handlers/quicksight.py
+++ b/backend/dataall/aws/handlers/quicksight.py
@@ -4,7 +4,6 @@ import os
 import ast
 
 from botocore.exceptions import ClientError
-from ....db import exceptions
 from .sts import SessionHelper
 from .secrets_manager import SecretsManager
 from .parameter_store import ParameterStoreManager
@@ -16,6 +15,16 @@ logger.setLevel(logging.DEBUG)
 class Quicksight:
     def __init__(self):
         pass
+    @staticmethod
+    def get_quicksight_client(AwsAccountId, region='eu-west-1'):
+        """Returns a boto3 quicksight client in the provided account/region
+        Args:
+            AwsAccountId(str) : aws account id
+            region(str) : aws region
+        Returns : boto3.client ("quicksight")
+        """
+        session = SessionHelper.remote_session(AwsAccountId)
+        return session.client('quicksight', region_name=region)
 
     @staticmethod
     def get_identity_region(AwsAccountId):
@@ -56,18 +65,6 @@ class Quicksight:
         identity_region = Quicksight.get_identity_region(AwsAccountId)
         session = SessionHelper.remote_session(AwsAccountId)
         return session.client('quicksight', region_name=identity_region)
-
-    @staticmethod
-    def get_quicksight_client(AwsAccountId, region='eu-west-1'):
-        """Returns a boto3 quicksight client in the provided account/region
-        Args:
-            AwsAccountId(str) : aws account id
-            region(str) : aws region
-        Returns : boto3.client ("quicksight")
-        """
-        identity_region = Quicksight.get_identity_region(AwsAccountId)
-        session = SessionHelper.remote_session(AwsAccountId)
-        return session.client('quicksight', region_name=region)
 
     @staticmethod
     def check_quicksight_enterprise_subscription(AwsAccountId):

--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -1,7 +1,7 @@
 aws-cdk-lib==2.14.0
 aws_cdk.aws_redshift_alpha==2.14.0a0
-boto3==1.20.20
-boto3-stubs==1.20.20
+boto3==1.24.85
+botocore==1.27.85
 botocore==1.23.20
 cdk-nag==2.7.2
 constructs==10.0.73

--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -2,7 +2,6 @@ aws-cdk-lib==2.14.0
 aws_cdk.aws_redshift_alpha==2.14.0a0
 boto3==1.24.85
 botocore==1.27.85
-botocore==1.23.20
 cdk-nag==2.7.2
 constructs==10.0.73
 fastapi==0.78.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 ariadne==0.13.0
 aws-xray-sdk==2.4.3
-boto3==1.20.20
-botocore==1.23.20
+boto3==1.24.85
+botocore==1.27.85
 Flask==2.0.2
 flask-cors==3.0.10
 nanoid==2.0.0

--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -586,10 +586,12 @@ Resources:
             - !Sub "arn:aws:quicksight:*:${AWS::AccountId}:user/*"
             - !Sub "arn:aws:quicksight:*:${AWS::AccountId}:dashboard/*"
             - !Sub "arn:aws:quicksight:*:${AWS::AccountId}:namespace/default"
+            - !Sub "arn:aws:quicksight:*:${AWS::AccountId}:account/*"
           - Sid: QuickSightSession
             Effect: Allow
             Action:
               - 'quicksight:GetSessionEmbedUrl'
+              - "quicksight:DescribeAccountSubscription"
             Resource: '*'
       ManagedPolicyName: !Sub ${EnvironmentResourcePrefix}-pivotrole-policy-2
       Roles:

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,6 +1,6 @@
 aws-cdk-lib==2.14.0
-boto3==1.20.20
 boto3-stubs==1.20.20
-botocore==1.23.20
+boto3==1.24.85
+botocore==1.27.85
 cdk-nag==2.7.2
 constructs==10.0.73


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- upgraded boto3 version (needed for Quicksight calls)

- It calls the Quicksight [Describe account subscription API](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeAccountSubscription.html) call before we create environments in the case "Dashboards" are enabled. This way we check the possibility of having that feature in the environment without waiting until the environment fails.

IMPORTANT! To use this feature the data.all Pivot Role deployed in the new accounts must have the required Quicksight permissions. The yaml template has been updated accordingly.

- CDK toolkit CloudFormation calls have been refactored to the CloudFormation class in AWS handlers

### Relates
- #150 #148 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
