### PR TITLE
46 error while creating sagemaker notebook outside of the vpc

### DIFF
--- a/frontend/src/views/Notebooks/NotebookCreateForm.js
+++ b/frontend/src/views/Notebooks/NotebookCreateForm.js
@@ -242,8 +242,8 @@ const NotebookCreateForm = (props) => {
                   .required('*Team is required'),
                 environment: Yup.object().required('*Environment is required'),
                 tags: Yup.array().nullable(),
-                VpcId: Yup.string().nullable().required('*VPC ID is required'),
-                SubnetId: Yup.string().nullable().required('*Subnet ID is required'),
+                VpcId: Yup.string().min(1).required('*VPC ID is required'),
+                SubnetId: Yup.string().min(1).required('*Subnet ID is required'),
                 InstanceType: Yup.string()
                   .min(1)
                   .required('*Instance type is required'),

--- a/frontend/src/views/Notebooks/NotebookCreateForm.js
+++ b/frontend/src/views/Notebooks/NotebookCreateForm.js
@@ -242,8 +242,8 @@ const NotebookCreateForm = (props) => {
                   .required('*Team is required'),
                 environment: Yup.object().required('*Environment is required'),
                 tags: Yup.array().nullable(),
-                VpcId: Yup.string().nullable(),
-                SubnetId: Yup.string().nullable(),
+                VpcId: Yup.string().nullable().required('*VPC ID is required'),
+                SubnetId: Yup.string().nullable().required('*Subnet ID is required'),
                 InstanceType: Yup.string()
                   .min(1)
                   .required('*Instance type is required'),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- #46 - make VPC id and subnet ID required fields in the frontend - in the future we can work on enabling Sagemaker notebooks outside of a VPC

### Relates
- #46 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
