### PR TITLE
167 rename cdkjson to cdkjsontemplate to avoid merging issues

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,9 @@
+{
+  "app": "python ./deploy/app.py",
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
+    "@aws-cdk/core:stackRelativeExports": false
+  }
+}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- removing the cdk.json, in the case users use SSM to store cdk.json context results in failure of the deployment pipeline because some information is still needed (e.g. app.py)

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
