### PR TITLE
Refactor S3 sharing logic in new version of sharing management

### DIFF
--- a/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
@@ -2,40 +2,50 @@ import logging
 import json
 
 
+from s3_share_manager import S3ShareManager
 from ....db import models, api
-from ....aws.handlers.sts import SessionHelper
 from ....aws.handlers.s3 import S3
-from ....aws.handlers.kms import KMS
-from ....aws.handlers.iam import IAM
+from ....aws.handlers.sts import SessionHelper
 
-from ....utils.alarm_service import AlarmService
 
 log = logging.getLogger(__name__)
 
 
-class S3ShareApproval:
+class S3ShareApproval(S3ShareManager):
     def __init__(
         self,
         session,
         dataset: models.Dataset,
         share: models.ShareObject,
-        shared_folders: [models.DatasetTable],
+        share_folder: models.DatasetStorageLocation,
         source_environment: models.Environment,
         target_environment: models.Environment,
         source_env_group: models.EnvironmentGroup,
         env_group: models.EnvironmentGroup,
     ):
-        self.session = session
-        self.source_env_group = source_env_group
-        self.env_group = env_group
-        self.dataset = dataset
-        self.share = share
-        self.shared_folders = shared_folders
-        self.source_environment = source_environment
-        self.target_environment = target_environment
 
+        super().__init__(
+            session,
+            dataset,
+            share,
+            share_folder,
+            source_environment,
+            target_environment,
+            source_env_group,
+            env_group,
+        )
+
+    @classmethod
     def approve_share(
-            self,
+        cls,
+        session,
+        dataset: models.Dataset,
+        share: models.ShareObject,
+        share_folders: [models.DatasetStorageLocation],
+        source_environment: models.Environment,
+        target_environment: models.Environment,
+        source_env_group: models.EnvironmentGroup,
+        env_group: models.EnvironmentGroup,
     ) -> bool:
         """
         1) (one time only) manage_bucket_policy - grants permission in the bucket policy
@@ -51,137 +61,95 @@ class S3ShareApproval:
         log.info(
             '##### Starting Sharing folders #######'
         )
-        self.share_folders(
-            self.session,
-            self.share,
-            self.source_env_group,
-            self.env_group,
-            self.target_environment,
-            self.shared_folders,
-            self.dataset,
-        )
-
-        self.clean_shared_folders(
-            self.session,
-            self.share,
-            self.source_env_group,
-            self.env_group,
-            self.target_environment,
-            self.shared_folders,
-            self.dataset,
-        )
-
-        return True
-
-    @classmethod
-    def share_folders(
-        cls,
-        session,
-        share: models.ShareObject,
-        source_env_group: models.EnvironmentGroup,
-        target_env_group: models.EnvironmentGroup,
-        target_environment: models.Environment,
-        shared_folders: [models.DatasetStorageLocation],
-        dataset: models.Dataset,
-    ):
-        """
-
-        :param session:
-        :param share:
-        :param source_env_group:
-        :param target_env_group:
-        :param target_environment:
-        :param shared_folders:
-        :param dataset:
-        :return:
-        """
-        for folder in shared_folders:
-            share_item = api.ShareObject.find_share_item_by_folder(
-                session, share, folder
+        for folder in share_folders:
+            sharing_item = api.ShareObject.find_share_item_by_folder(
+                session,
+                share,
+                folder,
             )
-
             api.ShareObject.update_share_item_status(
                 session,
-                share_item,
+                sharing_item,
                 models.ShareObjectStatus.Share_In_Progress.value,
             )
 
-            source_account_id = folder.AWSAccountId
-            access_point_name = share_item.S3AccessPointName
-            bucket_name = folder.S3BucketName
-            target_account_id = target_environment.AwsAccountId
-            source_env_admin = source_env_group.environmentIAMRoleArn
-            dataset_admin = dataset.IAMDatasetAdminRoleArn
-            target_env_admin = target_env_group.environmentIAMRoleName
-            s3_prefix = folder.S3Prefix
+            sharing_folder = cls(
+                session,
+                dataset,
+                share,
+                folder,
+                source_environment,
+                target_environment,
+                source_env_group,
+                env_group,
+            )
 
             try:
-                S3ShareApproval.manage_bucket_policy(
-                    dataset_admin,
-                    source_account_id,
-                    bucket_name,
-                    source_env_admin,
-                )
-
-                S3ShareApproval.grant_target_role_access_policy(
-                    bucket_name,
-                    access_point_name,
-                    target_account_id,
-                    target_env_admin,
-                    dataset,
-                )
-                S3ShareApproval.manage_access_point_and_policy(
-                    dataset_admin,
-                    source_account_id,
-                    target_account_id,
-                    source_env_admin,
-                    target_env_admin,
-                    bucket_name,
-                    s3_prefix,
-                    access_point_name,
-                )
-
-                S3ShareApproval.update_dataset_bucket_key_policy(
-                    source_account_id,
-                    target_account_id,
-                    target_env_admin,
-                    dataset
-                )
-
+                sharing_folder.manage_bucket_policy()
+                sharing_folder.grant_target_role_access_policy()
+                sharing_folder.manage_access_point_and_policy()
+                sharing_folder.update_dataset_bucket_key_policy()
                 api.ShareObject.update_share_item_status(
                     session,
-                    share_item,
+                    sharing_item,
                     models.ShareObjectStatus.Share_Succeeded.value,
                 )
             except Exception as e:
-                S3ShareApproval.handle_share_failure(folder=folder, share_item=share_item, error=e)
+                sharing_folder.handle_share_failure(e)
 
-    @classmethod
-    def clean_shared_folders(
-        cls,
+        removed_folders = S3ShareApproval.get_removed_prefixes(
+            dataset,
+            share,
+            share_folders,
+            target_environment,
+            env_group,
+        )
+        for folder in removed_folders:
+            removing_item = api.ShareObject.find_share_item_by_folder(
+                session,
+                share,
+                folder,
+            )
+            api.ShareObject.update_share_item_status(
+                session,
+                removing_item,
+                models.ShareObjectStatus.Revoke_In_Progress.value,
+            )
+
+            removing_folder = cls(
+                session,
+                dataset,
+                share,
+                folder,
+                source_environment,
+                target_environment,
+                source_env_group,
+                env_group,
+            )
+
+            try:
+                removing_folder.delete_access_point_policy()
+                cleanup = removing_folder.delete_access_point()
+                if cleanup:
+                    removing_folder.delete_target_role_access_policy()
+                    removing_folder.delete_dataset_bucket_key_policy()
+            except Exception as e:
+                removing_folder.handle_revoke_failure(e)
+        return True
+
+    @staticmethod
+    def get_removed_prefixes(
         session,
-        share: models.ShareObject,
-        source_env_group: models.EnvironmentGroup,
-        target_env_group: models.EnvironmentGroup,
-        target_environment: models.Environment,
         dataset: models.Dataset,
-        shared_folders: [models.DatasetStorageLocation],
-    ):
-        """
-
-        :param session:
-        :param share:
-        :param source_env_group:
-        :param target_env_group:
-        :param target_environment:
-        :param dataset:
-        :param shared_folders:
-        :return:
-        """
+        share: models.ShareObject,
+        share_folders: [models.DatasetStorageLocation],
+        target_environment: models.Environment,
+        env_group: models.EnvironmentGroup,
+    ) -> [models.DatasetStorageLocation]:
         source_account_id = dataset.AwsAccountId
         access_point_name = f"{dataset.datasetUri}-{share.principalId}".lower()
         target_account_id = target_environment.AwsAccountId
-        target_env_admin = target_env_group.environmentIAMRoleName
+        target_env_admin = env_group.environmentIAMRoleName
         access_point_policy = S3.get_access_point_policy(source_account_id, access_point_name)
         if access_point_policy:
             policy = json.loads(access_point_policy)
@@ -192,316 +160,14 @@ class S3ShareApproval:
                 if isinstance(prefix_list, str):
                     prefix_list = [prefix_list]
                 prefix_list = [prefix[:-2] for prefix in prefix_list]
-                shared_prefix = [folder.S3Prefix for folder in shared_folders]
+                shared_prefix = [folder.S3Prefix for folder in share_folders]
                 removed_prefixes = [prefix for prefix in prefix_list if prefix not in shared_prefix]
-                for prefix in removed_prefixes:
-                    bucket_name = dataset.S3BucketName
-                    try:
-                        S3ShareApproval.delete_access_point_policy(
-                            source_account_id,
-                            target_account_id,
-                            access_point_name,
-                            target_env_admin,
-                            prefix,
-                        )
-                        cleanup = S3ShareApproval.delete_access_point(source_account_id, access_point_name)
-                        if cleanup:
-                            S3ShareApproval.delete_target_role_access_policy(
-                                target_account_id,
-                                target_env_admin,
-                                bucket_name,
-                                access_point_name,
-                                dataset,
-                            )
-                            S3ShareApproval.delete_dataset_bucket_key_policy(
-                                source_account_id,
-                                target_account_id,
-                                target_env_admin,
-                                dataset,
-                            )
-                    except Exception as e:
-                        log.error(
-                            f'Failed to revoke folder {prefix} '
-                            f'from source account {dataset.AwsAccountId}//{dataset.region} '
-                            f'with target account {target_account_id}//{target_environment.region} '
-                            f'due to: {e}'
-                        )
-                        location = api.DatasetStorageLocation.get_location_by_s3_prefix(
-                            session,
-                            prefix,
-                            dataset.AwsAccountId,
-                            dataset.region,
-                        )
-                        AlarmService().trigger_revoke_folder_sharing_failure_alarm(
-                            location, share, target_environment
-                        )
-                    except Exception as e:
-                        S3ShareApproval.handle_share_failure(prefix, share_item, e)
-
-
-    @staticmethod
-    def manage_bucket_policy(
-        dataset_admin: str,
-        source_account_id: str,
-        bucket_name: str,
-        source_env_admin: str,
-    ):
-        """
-        This function will manage bucket policy by grant admin access to dataset admin, pivot role
-        and environment admin. All of the policies will only be added once.
-        :param dataset_admin: data.all team IAM role of Dataset Owners
-        :param source_account_id:
-        :param bucket_name:
-        :param source_env_admin: data.all team IAM role of Environment Admins
-        :return:
-        """
-        bucket_policy = json.loads(S3.get_bucket_policy(source_account_id, bucket_name))
-        for statement in bucket_policy["Statement"]:
-            if statement.get("Sid") in ["AllowAllToAdmin", "DelegateAccessToAccessPoint"]:
-                return
-        exceptions_roleId = [f'{item}:*' for item in SessionHelper.get_role_ids(
-            source_account_id,
-            [dataset_admin, source_env_admin, SessionHelper.get_delegation_role_arn(source_account_id)]
-        )]
-        allow_owner_access = {
-            "Sid": "AllowAllToAdmin",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "s3:*",
-            "Resource": [
-                f"arn:aws:s3:::{bucket_name}",
-                f"arn:aws:s3:::{bucket_name}/*"
-            ],
-            "Condition": {
-                "StringLike": {
-                    "aws:userId": exceptions_roleId
-                }
-            }
-        }
-        delegated_to_accesspoint = {
-            "Sid": "DelegateAccessToAccessPoint",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "s3:*",
-            "Resource": [
-                f"arn:aws:s3:::{bucket_name}",
-                f"arn:aws:s3:::{bucket_name}/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "s3:DataAccessPointAccount": f"{source_account_id}"
-                }
-            }
-        }
-        bucket_policy["Statement"].append(allow_owner_access)
-        bucket_policy["Statement"].append(delegated_to_accesspoint)
-        S3.create_bucket_policy(source_account_id, bucket_name, json.dumps(bucket_policy))
-
-    @staticmethod
-    def grant_target_role_access_policy(
-        bucket_name: str,
-        access_point_name: str,
-        target_account_id: str,
-        target_env_admin: str,
-        dataset: models.Dataset,
-    ):
-        """
-        Updates requester IAM role policy to include requested S3 bucket and access point
-        :param bucket_name:
-        :param access_point_name:
-        :param target_account_id:
-        :param target_env_admin:
-        :param dataset:
-        :return:
-        """
-        existing_policy = IAM.get_role_policy(
-            target_account_id,
-            target_env_admin,
-            "targetDatasetAccessControlPolicy",
-        )
-        if existing_policy:  # type dict
-            if bucket_name not in ",".join(existing_policy["Statement"][0]["Resource"]):
-                target_resources = [
-                    f"arn:aws:s3:::{bucket_name}",
-                    f"arn:aws:s3:::{bucket_name}/*",
-                    f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}",
-                    f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}/*"
+                removed_folders = [
+                    api.DatasetStorageLocation.get_location_by_s3_prefix(
+                        session,
+                        prefix,
+                        source_account_id,
+                        dataset.region,
+                    ) for prefix in removed_prefixes
                 ]
-                policy = existing_policy["Statement"][0]["Resource"].extend(target_resources)
-            else:
-                return
-        else:
-            policy = {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:*"
-                        ],
-                        "Resource": [
-                            f"arn:aws:s3:::{bucket_name}",
-                            f"arn:aws:s3:::{bucket_name}/*",
-                            f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}",
-                            f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}/*"
-                        ]
-                    }
-                ]
-            }
-        IAM.update_role_policy(
-            target_account_id,
-            target_env_admin,
-            "targetDatasetAccessControlPolicy",
-            json.dumps(policy),
-        )
-
-    @staticmethod
-    def manage_access_point_and_policy(
-        dataset_admin: str,
-        source_account_id: str,
-        target_account_id: str,
-        source_env_admin: str,
-        target_env_admin: str,
-        bucket_name: str,
-        s3_prefix: str,
-        access_point_name: str,
-    ):
-        """
-
-        :param dataset_admin:
-        :param source_account_id:
-        :param target_account_id:
-        :param source_env_admin:
-        :param target_env_admin:
-        :param bucket_name:
-        :param s3_prefix:
-        :param access_point_name:
-        :return:
-        """
-        access_point_arn = S3.get_bucket_access_point_arn(source_account_id, access_point_name)
-        if not access_point_arn:
-            access_point_arn = S3.create_bucket_access_point(source_account_id, bucket_name, access_point_name)
-        existing_policy = S3.get_access_point_policy(source_account_id, access_point_name)
-        # requester will use this role to access resources
-        target_env_admin_id = SessionHelper.get_role_id(target_account_id, target_env_admin)
-        if existing_policy:
-            # Update existing access point policy
-            existing_policy = json.loads(existing_policy)
-            statements = {item["Sid"]: item for item in existing_policy["Statement"]}
-            if f"{target_env_admin_id}0" in statements.keys():
-                prefix_list = statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"]
-                if isinstance(prefix_list, str):
-                    prefix_list = [prefix_list]
-                if f"{s3_prefix}/*" not in prefix_list:
-                    prefix_list.append(f"{s3_prefix}/*")
-                    statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"] = prefix_list
-                resource_list = statements[f"{target_env_admin_id}1"]["Resource"]
-                if isinstance(resource_list, str):
-                    resource_list = [resource_list]
-                if f"{access_point_arn}/object/{s3_prefix}/*" not in resource_list:
-                    resource_list.append(f"{access_point_arn}/object/{s3_prefix}/*")
-                    statements[f"{target_env_admin_id}1"]["Resource"] = resource_list
-                existing_policy["Statement"] = list(statements.values())
-            else:
-                additional_policy = S3.generate_access_point_policy_template(
-                    target_env_admin_id,
-                    access_point_arn,
-                    s3_prefix,
-                )
-                existing_policy["Statement"].extend(additional_policy["Statement"])
-            access_point_policy = existing_policy
-        else:
-            # First time to create access point policy
-            access_point_policy = S3.generate_access_point_policy_template(
-                target_env_admin_id,
-                access_point_arn,
-                s3_prefix,
-            )
-            exceptions_roleId = [f'{item}:*' for item in SessionHelper.get_role_ids(
-                source_account_id,
-                [dataset_admin, source_env_admin, SessionHelper.get_delegation_role_arn(source_account_id)]
-            )]
-            admin_statement = {
-                "Sid": "AllowAllToAdmin",
-                "Effect": "Allow",
-                "Principal": "*",
-                "Action": "s3:*",
-                "Resource": f"{access_point_arn}",
-                "Condition": {
-                    "StringLike": {
-                        "aws:userId": exceptions_roleId
-                    }
-                }
-            }
-            access_point_policy["Statement"].append(admin_statement)
-        S3.attach_access_point_policy(source_account_id, access_point_name, json.dumps(access_point_policy))
-
-    @staticmethod
-    def update_dataset_bucket_key_policy(
-        source_account_id: str,
-        target_account_id: str,
-        target_env_admin: str,
-        dataset: models.Dataset,
-    ):
-        key_alias = f"alias/{dataset.KmsAlias}"
-        kms_keyId = KMS.get_key_id(source_account_id, key_alias)
-        existing_policy = KMS.get_key_policy(source_account_id, kms_keyId, "default")
-        target_env_admin_id = SessionHelper.get_role_id(target_account_id, target_env_admin)
-        if existing_policy and f'{target_env_admin_id}:*' not in existing_policy:
-            policy = json.loads(existing_policy)
-            policy["Statement"].append(
-                {
-                    "Sid": f"{target_env_admin_id}",
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": "*"
-                    },
-                    "Action": "kms:Decrypt",
-                    "Resource": "*",
-                    "Condition": {
-                        "StringLike": {
-                            "aws:userId": f"{target_env_admin_id}:*"
-                        }
-                    }
-                }
-            )
-            KMS.put_key_policy(
-                source_account_id,
-                kms_keyId,
-                "default",
-                json.dumps(policy)
-            )
-
-    @staticmethod
-    def handle_share_failure(
-        folder: models.DatasetStorageLocation,
-        share_item: models.ShareObjectItem,
-        error: Exception,
-    ) -> bool:
-        """
-        Handles share failure by raising an alarm to alarmsTopic
-        Parameters
-        ----------
-        folder : dataset folder
-        share_item : failed item
-        error : share error
-
-        Returns
-        -------
-        True if alarm published successfully
-        """
-        logging.error(
-            f'Failed to share folder {folder.S3Prefix} '
-            f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
-            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
-            f'due to: {error}'
-        )
-        api.ShareObject.update_share_item_status(
-            self.session,
-            share_item,
-            models.ShareObjectStatus.Share_Failed.value,
-        )
-        AlarmService().trigger_folder_sharing_failure_alarm(
-            folder, self.share, self.target_environment
-        )
-        return True
+                return removed_folders

--- a/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
@@ -2,8 +2,8 @@ import logging
 import json
 
 
-from s3_share_manager import S3ShareManager
 from ....db import models, api
+from .s3_share_manager import S3ShareManager
 from ....aws.handlers.s3 import S3
 from ....aws.handlers.sts import SessionHelper
 
@@ -98,6 +98,7 @@ class S3ShareApproval(S3ShareManager):
                 sharing_folder.handle_share_failure(e)
 
         removed_folders = S3ShareApproval.get_removed_prefixes(
+            session,
             dataset,
             share,
             share_folders,

--- a/backend/dataall/tasks/data_sharing/common/s3_revoke_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_revoke_share.py
@@ -1,41 +1,47 @@
 import logging
-import json
 
 
+from s3_share_manager import S3ShareManager
 from ....db import models, api
-from ....aws.handlers.sts import SessionHelper
-from ....aws.handlers.s3 import S3
-from ....aws.handlers.kms import KMS
-from ....aws.handlers.iam import IAM
 
-from ....utils.alarm_service import AlarmService
 
 log = logging.getLogger(__name__)
 
 
-class S3ShareRevoke:
+class S3ShareRevoke(S3ShareManager):
     def __init__(
         self,
         session,
         dataset: models.Dataset,
         share: models.ShareObject,
-        rejected_folders: [models.DatasetTable],
+        revoke_folder: models.DatasetStorageLocation,
         source_environment: models.Environment,
         target_environment: models.Environment,
         source_env_group: models.EnvironmentGroup,
         env_group: models.EnvironmentGroup,
     ):
-        self.session = session
-        self.source_env_group = source_env_group
-        self.env_group = env_group
-        self.dataset = dataset
-        self.share = share
-        self.rejected_folders = rejected_folders
-        self.source_environment = source_environment
-        self.target_environment = target_environment
+        super().__init__(
+            session,
+            dataset,
+            share,
+            revoke_folder,
+            source_environment,
+            target_environment,
+            source_env_group,
+            env_group,
+        )
 
+    @classmethod
     def revoke_share(
-            self,
+        cls,
+        session,
+        dataset: models.Dataset,
+        share: models.ShareObject,
+        revoke_folders: [models.DatasetStorageLocation],
+        source_environment: models.Environment,
+        target_environment: models.Environment,
+        source_env_group: models.EnvironmentGroup,
+        env_group: models.EnvironmentGroup,
     ) -> bool:
         """
         1) Shares folders, for each shared folder:
@@ -46,195 +52,38 @@ class S3ShareRevoke:
         -------
         True if share is approved successfully
         """
-        self.revoke_shared_folders(
-            self.session,
-            self.share,
-            self.source_env_group,
-            self.env_group,
-            self.target_environment,
-            self.rejected_folders,
-            self.dataset,
-        )
-
-        return True
-
-    @classmethod
-    def revoke_shared_folders(
-        cls,
-        session,
-        share: models.ShareObject,
-        source_env_group: models.EnvironmentGroup,
-        target_env_group: models.EnvironmentGroup,
-        target_environment: models.Environment,
-        rejected_folders: [models.DatasetStorageLocation],
-        dataset: models.Dataset,
-    ):
-        for folder in rejected_folders:
-            rejected_item = api.ShareObject.find_share_item_by_folder(
+        for folder in revoke_folders:
+            revoking_item = api.ShareObject.find_share_item_by_folder(
                 session, share, folder
             )
 
             api.ShareObject.update_share_item_status(
                 session,
-                rejected_item,
+                revoking_item,
                 models.ShareObjectStatus.Revoke_In_Progress.value
             )
-
-            source_account_id = folder.AWSAccountId
-            access_point_name = rejected_item.S3AccessPointName
-            bucket_name = folder.S3BucketName
-            target_account_id = target_environment.AwsAccountId
-            target_env_admin = target_env_group.environmentIAMRoleName
-            s3_prefix = folder.S3Prefix
+            revoking_folder = cls(
+                session,
+                dataset,
+                share,
+                folder,
+                source_environment,
+                target_environment,
+                source_env_group,
+                env_group,
+            )
 
             try:
-                S3ShareRevoke.delete_access_point_policy(
-                    source_account_id,
-                    target_account_id,
-                    access_point_name,
-                    target_env_admin,
-                    s3_prefix,
-                )
-                cleanup = S3ShareRevoke.delete_access_point(source_account_id, access_point_name)
+                revoking_folder.delete_access_point_policy()
+                cleanup = revoking_folder.delete_access_point()
                 if cleanup:
-                    S3ShareRevoke.delete_target_role_access_policy(
-                        target_account_id,
-                        target_env_admin,
-                        bucket_name,
-                        access_point_name,
-                        dataset,
-                    )
-                    S3ShareRevoke.delete_dataset_bucket_key_policy(
-                        source_account_id,
-                        target_account_id,
-                        target_env_admin,
-                        dataset,
-                    )
+                    revoking_folder.delete_target_role_access_policy()
+                    revoking_folder.delete_dataset_bucket_key_policy()
                 api.ShareObject.update_share_item_status(
                     session,
-                    rejected_item,
+                    revoking_item,
                     models.ShareObjectStatus.Revoke_Share_Succeeded.value,
                 )
             except Exception as e:
-                S3ShareRevoke.handle_share_failure(folder, rejected_item, e)
-
-    @staticmethod
-    def delete_access_point_policy(
-        source_account_id: str,
-        target_account_id: str,
-        access_point_name: str,
-        target_env_admin: str,
-        s3_prefix: str,
-    ):
-        access_point_policy = json.loads(S3.get_access_point_policy(source_account_id, access_point_name))
-        access_point_arn = S3.get_bucket_access_point_arn(source_account_id, access_point_name)
-        target_env_admin_id = SessionHelper.get_role_id(target_account_id, target_env_admin)
-        statements = {item["Sid"]: item for item in access_point_policy["Statement"]}
-        if f"{target_env_admin_id}0" in statements.keys():
-            prefix_list = statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"]
-            if isinstance(prefix_list, list) and f"{s3_prefix}/*" in prefix_list:
-                prefix_list.remove(f"{s3_prefix}/*")
-                statements[f"{target_env_admin_id}1"]["Resource"].remove(f"{access_point_arn}/object/{s3_prefix}/*")
-                access_point_policy["Statement"] = list(statements.values())
-            else:
-                access_point_policy["Statement"].remove(statements[f"{target_env_admin_id}0"])
-                access_point_policy["Statement"].remove(statements[f"{target_env_admin_id}1"])
-        S3.attach_access_point_policy(source_account_id, access_point_name, json.dumps(access_point_policy))
-
-    @staticmethod
-    def delete_access_point(source_account_id: str, access_point_name: str):
-        access_point_policy = json.loads(S3.get_access_point_policy(source_account_id, access_point_name))
-        if len(access_point_policy["Statement"]) <= 1:
-            # At least we have the 'AllowAllToAdmin' statement
-            S3.delete_bucket_access_point(source_account_id, access_point_name)
-            return True
-        else:
-            return False
-
-    @staticmethod
-    def delete_target_role_access_policy(
-        target_account_id: str,
-        target_env_admin: str,
-        bucket_name: str,
-        access_point_name: str,
-        dataset: models.Dataset,
-    ):
-        existing_policy = IAM.get_role_policy(
-            target_account_id,
-            target_env_admin,
-            "targetDatasetAccessControlPolicy",
-        )
-        if existing_policy:
-            if bucket_name in ",".join(existing_policy["Statement"][0]["Resource"]):
-                target_resources = [
-                    f"arn:aws:s3:::{bucket_name}",
-                    f"arn:aws:s3:::{bucket_name}/*",
-                    f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}",
-                    f"arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{access_point_name}/*"
-                ]
-                for item in target_resources:
-                    existing_policy["Statement"][0]["Resource"].remove(item)
-                if not existing_policy["Statement"][0]["Resource"]:
-                    IAM.delete_role_policy(target_account_id, target_env_admin, "targetDatasetAccessControlPolicy")
-                else:
-                    IAM.update_role_policy(
-                        target_account_id,
-                        target_env_admin,
-                        "targetDatasetAccessControlPolicy",
-                        json.dumps(existing_policy),
-                    )
-
-    @staticmethod
-    def delete_dataset_bucket_key_policy(
-        source_account_id: str,
-        target_account_id: str,
-        target_env_admin: str,
-        dataset: models.Dataset,
-    ):
-        key_alias = f"alias/{dataset.KmsAlias}"
-        kms_keyId = KMS.get_key_id(source_account_id, key_alias)
-        existing_policy = KMS.get_key_policy(source_account_id, kms_keyId, "default")
-        target_env_admin_id = SessionHelper.get_role_id(target_account_id, target_env_admin)
-        if existing_policy and f'{target_env_admin_id}:*' in existing_policy:
-            policy = json.loads(existing_policy)
-            policy["Statement"] = [item for item in policy["Statement"] if item["Sid"] != f"{target_env_admin_id}"]
-            KMS.put_key_policy(
-                source_account_id,
-                kms_keyId,
-                "default",
-                json.dumps(policy)
-            )
-
-    def handle_share_failure(
-        self,
-        folder: models.DatasetStorageLocation,
-        share_item: models.ShareObjectItem,
-        error: Exception,
-    ) -> bool:
-        """
-        Handles share failure by raising an alarm to alarmsTopic
-        Parameters
-        ----------
-        folder : dataset folder
-        share_item : failed item
-        error : share error
-
-        Returns
-        -------
-        True if alarm published successfully
-        """
-        logging.error(
-            f'Failed to revoke S3 permissions to folder {folder.S3Prefix} '
-            f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
-            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
-            f'due to: {error}'
-        )
-        api.ShareObject.update_share_item_status(
-            self.session,
-            share_item,
-            models.ShareObjectStatus.Revoke_Share_Failed.value,
-        )
-        AlarmService().trigger_revoke_folder_sharing_failure_alarm(
-            folder, self.share, self.target_environment
-        )
+                revoking_folder.handle_revoke_failure(e)
         return True

--- a/backend/dataall/tasks/data_sharing/common/s3_revoke_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_revoke_share.py
@@ -1,8 +1,8 @@
 import logging
 
 
-from s3_share_manager import S3ShareManager
 from ....db import models, api
+from .s3_share_manager import S3ShareManager
 
 
 log = logging.getLogger(__name__)

--- a/backend/dataall/tasks/data_sharing/common/s3_share_manager.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_share_manager.py
@@ -1,0 +1,349 @@
+import logging
+import json
+
+
+from ....db import models, api
+from ....aws.handlers.sts import SessionHelper
+from ....aws.handlers.s3 import S3
+from ....aws.handlers.kms import KMS
+from ....aws.handlers.iam import IAM
+
+from ....utils.alarm_service import AlarmService
+
+log = logging.getLogger(__name__)
+
+class S3ShareManager:
+    def __init__(
+        self,
+        session,
+        dataset: models.Dataset,
+        share: models.ShareObject,
+        target_folder: models.DatasetStorageLocation,
+        source_environment: models.Environment,
+        target_environment: models.Environment,
+        source_env_group: models.EnvironmentGroup,
+        env_group: models.EnvironmentGroup,
+    ):
+        self.session = session
+        self.source_env_group = source_env_group
+        self.env_group = env_group
+        self.dataset = dataset
+        self.share = share
+        self.target_folder = target_folder
+        self.source_environment = source_environment
+        self.target_environment = target_environment
+        self.share_item = api.ShareObject.find_share_item_by_folder(
+            session,
+            share,
+            target_folder,
+        )
+        self.access_point_name = self.share_item.S3AccessPointName
+
+        self.source_account_id = dataset.AwsAccountId
+        self.target_account_id = target_environment.AwsAccountId
+        self.source_env_admin = source_env_group.environmentIAMRoleArn
+        self.target_env_admin = env_group.environmentIAMRoleName
+        self.bucket_name = target_folder.S3BucketName
+        self.dataset_admin = dataset.IAMDatasetAdminRoleArn
+        self.dataset_account_id = dataset.AwsAccountId
+        self.dataset_region = dataset.region
+        self.s3_prefix = target_folder.S3Prefix
+
+    def manage_bucket_policy(self):
+        """
+        This function will manage bucket policy by grant admin access to dataset admin, pivot role
+        and environment admin. All of the policies will only be added once.
+        :return:
+        """
+        bucket_policy = json.loads(S3.get_bucket_policy(self.source_account_id, self.bucket_name))
+        for statement in bucket_policy["Statement"]:
+            if statement.get("Sid") in ["AllowAllToAdmin", "DelegateAccessToAccessPoint"]:
+                return
+        exceptions_roleId = [f'{item}:*' for item in SessionHelper.get_role_ids(
+            self.source_account_id,
+            [self.dataset_admin, self.source_env_admin, SessionHelper.get_delegation_role_arn(self.source_account_id)]
+        )]
+        allow_owner_access = {
+            "Sid": "AllowAllToAdmin",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": [
+                f"arn:aws:s3:::{self.bucket_name}",
+                f"arn:aws:s3:::{self.bucket_name}/*"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "aws:userId": exceptions_roleId
+                }
+            }
+        }
+        delegated_to_accesspoint = {
+            "Sid": "DelegateAccessToAccessPoint",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": [
+                f"arn:aws:s3:::{self.bucket_name}",
+                f"arn:aws:s3:::{self.bucket_name}/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "s3:DataAccessPointAccount": f"{self.source_account_id}"
+                }
+            }
+        }
+        bucket_policy["Statement"].append(allow_owner_access)
+        bucket_policy["Statement"].append(delegated_to_accesspoint)
+        S3.create_bucket_policy(self.source_account_id, self.bucket_name, json.dumps(bucket_policy))
+
+    def grant_target_role_access_policy(self):
+        """
+        Updates requester IAM role policy to include requested S3 bucket and access point
+        :return:
+        """
+        existing_policy = IAM.get_role_policy(
+            self.target_account_id,
+            self.target_env_admin,
+            "targetDatasetAccessControlPolicy",
+        )
+        if existing_policy:  # type dict
+            if self.bucket_name not in ",".join(existing_policy["Statement"][0]["Resource"]):
+                target_resources = [
+                    f"arn:aws:s3:::{self.bucket_name}",
+                    f"arn:aws:s3:::{self.bucket_name}/*",
+                    f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}",
+                    f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}/*"
+                ]
+                policy = existing_policy["Statement"][0]["Resource"].extend(target_resources)
+            else:
+                return
+        else:
+            policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:*"
+                        ],
+                        "Resource": [
+                            f"arn:aws:s3:::{self.bucket_name}",
+                            f"arn:aws:s3:::{self.bucket_name}/*",
+                            f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}",
+                            f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}/*"
+                        ]
+                    }
+                ]
+            }
+        IAM.update_role_policy(
+            self.target_account_id,
+            self.target_env_admin,
+            "targetDatasetAccessControlPolicy",
+            json.dumps(policy),
+        )
+
+    def manage_access_point_and_policy(self):
+        """
+        :return:
+        """
+
+        access_point_arn = S3.get_bucket_access_point_arn(self.source_account_id, self.access_point_name)
+        if not access_point_arn:
+            access_point_arn = S3.create_bucket_access_point(self.source_account_id, self.bucket_name, self.access_point_name)
+        existing_policy = S3.get_access_point_policy(self.source_account_id, self.access_point_name)
+        # requester will use this role to access resources
+        target_env_admin_id = SessionHelper.get_role_id(self.target_account_id, self.target_env_admin)
+        if existing_policy:
+            # Update existing access point policy
+            existing_policy = json.loads(existing_policy)
+            statements = {item["Sid"]: item for item in existing_policy["Statement"]}
+            if f"{target_env_admin_id}0" in statements.keys():
+                prefix_list = statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"]
+                if isinstance(prefix_list, str):
+                    prefix_list = [prefix_list]
+                if f"{self.s3_prefix}/*" not in prefix_list:
+                    prefix_list.append(f"{self.s3_prefix}/*")
+                    statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"] = prefix_list
+                resource_list = statements[f"{target_env_admin_id}1"]["Resource"]
+                if isinstance(resource_list, str):
+                    resource_list = [resource_list]
+                if f"{access_point_arn}/object/{self.s3_prefix}/*" not in resource_list:
+                    resource_list.append(f"{access_point_arn}/object/{self.s3_prefix}/*")
+                    statements[f"{target_env_admin_id}1"]["Resource"] = resource_list
+                existing_policy["Statement"] = list(statements.values())
+            else:
+                additional_policy = S3.generate_access_point_policy_template(
+                    self.target_env_admin_id,
+                    self.access_point_arn,
+                    self.s3_prefix,
+                )
+                existing_policy["Statement"].extend(additional_policy["Statement"])
+            access_point_policy = existing_policy
+        else:
+            # First time to create access point policy
+            access_point_policy = S3.generate_access_point_policy_template(
+                self.target_env_admin_id,
+                self.access_point_arn,
+                self.s3_prefix,
+            )
+            exceptions_roleId = [f'{item}:*' for item in SessionHelper.get_role_ids(
+                self.source_account_id,
+                [self.dataset_admin, self.source_env_admin, SessionHelper.get_delegation_role_arn(self.source_account_id)]
+            )]
+            admin_statement = {
+                "Sid": "AllowAllToAdmin",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:*",
+                "Resource": f"{access_point_arn}",
+                "Condition": {
+                    "StringLike": {
+                        "aws:userId": exceptions_roleId
+                    }
+                }
+            }
+            access_point_policy["Statement"].append(admin_statement)
+        S3.attach_access_point_policy(self.source_account_id, self.access_point_name, json.dumps(access_point_policy))
+
+    def update_dataset_bucket_key_policy(self):
+        key_alias = f"alias/{self.dataset.KmsAlias}"
+        kms_keyId = KMS.get_key_id(self.source_account_id, key_alias)
+        existing_policy = KMS.get_key_policy(self.source_account_id, kms_keyId, "default")
+        target_env_admin_id = SessionHelper.get_role_id(self.target_account_id, self.target_env_admin)
+        if existing_policy and f'{target_env_admin_id}:*' not in existing_policy:
+            policy = json.loads(existing_policy)
+            policy["Statement"].append(
+                {
+                    "Sid": f"{target_env_admin_id}",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": "*"
+                    },
+                    "Action": "kms:Decrypt",
+                    "Resource": "*",
+                    "Condition": {
+                        "StringLike": {
+                            "aws:userId": f"{target_env_admin_id}:*"
+                        }
+                    }
+                }
+            )
+            KMS.put_key_policy(
+                self.source_account_id,
+                kms_keyId,
+                "default",
+                json.dumps(policy)
+            )
+
+    def delete_access_point_policy(self):
+        access_point_policy = json.loads(S3.get_access_point_policy(self.source_account_id, self.access_point_name))
+        access_point_arn = S3.get_bucket_access_point_arn(self.source_account_id, self.access_point_name)
+        target_env_admin_id = SessionHelper.get_role_id(self.target_account_id, self.target_env_admin)
+        statements = {item["Sid"]: item for item in access_point_policy["Statement"]}
+        if f"{target_env_admin_id}0" in statements.keys():
+            prefix_list = statements[f"{target_env_admin_id}0"]["Condition"]["StringLike"]["s3:prefix"]
+            if isinstance(prefix_list, list) and f"{self.s3_prefix}/*" in prefix_list:
+                prefix_list.remove(f"{self.s3_prefix}/*")
+                statements[f"{target_env_admin_id}1"]["Resource"].remove(f"{access_point_arn}/object/{self.s3_prefix}/*")
+                access_point_policy["Statement"] = list(statements.values())
+            else:
+                access_point_policy["Statement"].remove(statements[f"{target_env_admin_id}0"])
+                access_point_policy["Statement"].remove(statements[f"{target_env_admin_id}1"])
+        S3.attach_access_point_policy(self.source_account_id, self.access_point_name, json.dumps(access_point_policy))
+
+    def delete_access_point(self):
+        access_point_policy = json.loads(S3.get_access_point_policy(self.source_account_id, self.access_point_name))
+        if len(access_point_policy["Statement"]) <= 1:
+            # At least we have the 'AllowAllToAdmin' statement
+            S3.delete_bucket_access_point(self.source_account_id, self.access_point_name)
+            return True
+        else:
+            return False
+
+    def delete_target_role_access_policy(self):
+        existing_policy = IAM.get_role_policy(
+            self.target_account_id,
+            self.target_env_admin,
+            "targetDatasetAccessControlPolicy",
+        )
+        if existing_policy:
+            if self.bucket_name in ",".join(existing_policy["Statement"][0]["Resource"]):
+                target_resources = [
+                    f"arn:aws:s3:::{self.bucket_name}",
+                    f"arn:aws:s3:::{self.bucket_name}/*",
+                    f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}",
+                    f"arn:aws:s3:{self.dataset_region}:{self.dataset_account_id}:accesspoint/{self.access_point_name}/*"
+                ]
+                for item in target_resources:
+                    existing_policy["Statement"][0]["Resource"].remove(item)
+                if not existing_policy["Statement"][0]["Resource"]:
+                    IAM.delete_role_policy(self.target_account_id, self.target_env_admin, "targetDatasetAccessControlPolicy")
+                else:
+                    IAM.update_role_policy(
+                        self.target_account_id,
+                        self.target_env_admin,
+                        "targetDatasetAccessControlPolicy",
+                        json.dumps(existing_policy),
+                    )
+
+    def delete_dataset_bucket_key_policy(self):
+        key_alias = f"alias/{self.dataset.KmsAlias}"
+        kms_keyId = KMS.get_key_id(self.source_account_id, key_alias)
+        existing_policy = KMS.get_key_policy(self.source_account_id, kms_keyId, "default")
+        target_env_admin_id = SessionHelper.get_role_id(self.target_account_id, self.target_env_admin)
+        if existing_policy and f'{target_env_admin_id}:*' in existing_policy:
+            policy = json.loads(existing_policy)
+            policy["Statement"] = [item for item in policy["Statement"] if item["Sid"] != f"{target_env_admin_id}"]
+            KMS.put_key_policy(
+                self.source_account_id,
+                kms_keyId,
+                "default",
+                json.dumps(policy)
+            )
+
+    def handle_share_failure(self, error: Exception) -> bool:
+        """
+        Handles share failure by raising an alarm to alarmsTopic
+        Returns
+        -------
+        True if alarm published successfully
+        """
+        logging.error(
+            f'Failed to share folder {self.s3_prefix} '
+            f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
+            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
+            f'due to: {error}'
+        )
+        api.ShareObject.update_share_item_status(
+            self.session,
+            self.share_item,
+            models.ShareObjectStatus.Share_Failed.value,
+        )
+        AlarmService().trigger_folder_sharing_failure_alarm(
+            self.target_folder, self.share, self.target_environment
+        )
+        return True
+
+    def handle_revoke_failure(self, error: Exception) -> bool:
+        """
+        Handles share failure by raising an alarm to alarmsTopic
+        Returns
+        -------
+        True if alarm published successfully
+        """
+        logging.error(
+            f'Failed to revoke S3 permissions to folder {self.s3_prefix} '
+            f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
+            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
+            f'due to: {error}'
+        )
+        api.ShareObject.update_share_item_status(
+            self.session,
+            self.share_item,
+            models.ShareObjectStatus.Revoke_Share_Failed.value,
+        )
+        AlarmService().trigger_revoke_folder_sharing_failure_alarm(
+            self.target_folder, self.share, self.target_environment
+        )
+        return True

--- a/backend/dataall/tasks/data_sharing/common/s3_share_manager.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_share_manager.py
@@ -174,8 +174,8 @@ class S3ShareManager:
                 existing_policy["Statement"] = list(statements.values())
             else:
                 additional_policy = S3.generate_access_point_policy_template(
-                    self.target_env_admin_id,
-                    self.access_point_arn,
+                    target_env_admin_id,
+                    access_point_arn,
                     self.s3_prefix,
                 )
                 existing_policy["Statement"].extend(additional_policy["Statement"])
@@ -183,8 +183,8 @@ class S3ShareManager:
         else:
             # First time to create access point policy
             access_point_policy = S3.generate_access_point_policy_template(
-                self.target_env_admin_id,
-                self.access_point_arn,
+                target_env_admin_id,
+                access_point_arn,
                 self.s3_prefix,
             )
             exceptions_roleId = [f'{item}:*' for item in SessionHelper.get_role_ids(
@@ -312,7 +312,7 @@ class S3ShareManager:
         logging.error(
             f'Failed to share folder {self.s3_prefix} '
             f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
-            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
+            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
         api.ShareObject.update_share_item_status(
@@ -335,7 +335,7 @@ class S3ShareManager:
         logging.error(
             f'Failed to revoke S3 permissions to folder {self.s3_prefix} '
             f'from source account {self.source_environment.AwsAccountId}//{self.source_environment.region} '
-            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region}'
+            f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
         api.ShareObject.update_share_item_status(

--- a/backend/dataall/tasks/data_sharing/data_sharing_service.py
+++ b/backend/dataall/tasks/data_sharing/data_sharing_service.py
@@ -80,7 +80,7 @@ class DataSharingService:
             dataset.GlueDatabaseName,
         )
 
-        share_folders_succeed = S3ShareApproval(
+        share_folders_succeed = S3ShareApproval.approve_share(
             session,
             dataset,
             share,
@@ -89,7 +89,7 @@ class DataSharingService:
             target_environment,
             source_env_group,
             env_group,
-        ).approve_share()
+        )
 
         if source_environment.AwsAccountId != target_environment.AwsAccountId:
             return CrossAccountShareApproval(
@@ -155,7 +155,7 @@ class DataSharingService:
                 dataset.GlueDatabaseName,
             )
 
-            revoke_folders_succeed = S3ShareRevoke(
+            revoke_folders_succeed = S3ShareRevoke.revoke_share(
                 session,
                 dataset,
                 share,
@@ -164,7 +164,7 @@ class DataSharingService:
                 target_environment,
                 source_env_group,
                 env_group,
-            ).revoke_share()
+            )
 
             if source_environment.AwsAccountId != target_environment.AwsAccountId:
                 return CrossAccountShareRevoke(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Refactoring

### Detail
- Refactor s3 folder sharing. Include all the s3 manipulate actions into a parent class called 'S3ShareManager' in s3_share_manager.py. S3ShareApproval and S3ShareRevoke will inherit S3ShareManager and perform the specific workflow. 

### Relates
- #66 
- #176 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
