### PR TITLE
189 acm certificate

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -819,11 +819,20 @@ class PipelineStack(Stack):
                     vpc=self.vpc,
                 ),
             ],
+            post=self.evaluate_post_albfront_stage(target_env)
+        )
+
+    def evaluate_post_albfront_stage(self, target_env):
+        if target_env.get("enable_cw_rum", False):
             post=[
                 self.cognito_config_action(target_env),
                 self.cw_rum_config_action(target_env),
             ],
-        )
+        else:
+            post=[
+                self.cognito_config_action(target_env),
+            ]
+        return post
 
     def set_release_stage(
         self,


### PR DESCRIPTION
Bug Fix
- For `internet_facing=False` deployments allows creation and import of ACM Certificate for ALB to use for the application to circumvent stuck in Pending Validation state (originally caused due to validating an ACM public certificate using a domain record in a Route53 private hosted zone)

Relate to Issue - https://github.com/awslabs/aws-dataall/issues/189

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
