### PR TITLE
Disabled Warehouses feature from UI

### DIFF
--- a/frontend/src/views/Environments/EnvironmentCreateForm.js
+++ b/frontend/src/views/Environments/EnvironmentCreateForm.js
@@ -606,7 +606,7 @@ const EnvironmentCreateForm = (props) => {
                                 />
                               </FormGroup>
                             </Box>
-                            <Box sx={{ ml: 2 }}>
+{/*                            <Box sx={{ ml: 2 }}>
                               <FormGroup>
                                 <FormControlLabel
                                   color="primary"
@@ -636,7 +636,7 @@ const EnvironmentCreateForm = (props) => {
                                   value={values.warehousesEnabled}
                                 />
                               </FormGroup>
-                            </Box>
+                            </Box>*/}
                           </CardContent>
                         </Card>
                       </Box>

--- a/frontend/src/views/Environments/EnvironmentEditForm.js
+++ b/frontend/src/views/Environments/EnvironmentEditForm.js
@@ -490,7 +490,7 @@ const EnvironmentEditForm = (props) => {
                                 />
                               </FormGroup>
                             </Box>
-                            <Box sx={{ ml: 2 }}>
+{/*                            <Box sx={{ ml: 2 }}>
                               <FormGroup>
                                 <FormControlLabel
                                   color="primary"
@@ -520,7 +520,7 @@ const EnvironmentEditForm = (props) => {
                                   value={values.warehousesEnabled}
                                 />
                               </FormGroup>
-                            </Box>
+                            </Box>*/}
                           </CardContent>
                         </Card>
                       </Box>

--- a/frontend/src/views/Environments/EnvironmentFeatures.js
+++ b/frontend/src/views/Environments/EnvironmentFeatures.js
@@ -90,7 +90,7 @@ const EnvironmentFeatures = (props) => {
               </Label>
             </Typography>
           </ListItem>
-          <ListItem
+{/*          <ListItem
             disableGutters
             divider
             sx={{
@@ -108,7 +108,7 @@ const EnvironmentFeatures = (props) => {
                 {environment.warehousesEnabled ? 'Enabled' : 'Disabled'}
               </Label>
             </Typography>
-          </ListItem>
+          </ListItem>*/}
         </List>
       </CardContent>
     </Card>

--- a/frontend/src/views/Environments/EnvironmentView.js
+++ b/frontend/src/views/Environments/EnvironmentView.js
@@ -60,7 +60,7 @@ const tabs = [
     icon: <FolderOpen fontSize="small" />
   },
   { label: 'Networks', value: 'networks', icon: <FaNetworkWired size={20} /> },
-  { label: 'Warehouses', value: 'warehouses', icon: <GoDatabase size={20} /> },
+  /*{ label: 'Warehouses', value: 'warehouses', icon: <GoDatabase size={20} /> },*/
   {
     label: 'Subscriptions',
     value: 'subscriptions',


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
It disables:
- the Warehouses tab from the Environment view
- the Warehouse switch from the Environment overview
- the Warehouse switch from the Environment create view and edit view

### Relates
- #196 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
