### PR TITLE
Fix removed_folders none object for no Access point

### DIFF
--- a/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
@@ -172,3 +172,5 @@ class S3ShareApproval(S3ShareManager):
                     ) for prefix in removed_prefixes
                 ]
                 return removed_folders
+            return []
+        return []

--- a/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
+++ b/backend/dataall/tasks/data_sharing/common/s3_approve_share.py
@@ -172,5 +172,4 @@ class S3ShareApproval(S3ShareManager):
                     ) for prefix in removed_prefixes
                 ]
                 return removed_folders
-            return []
         return []


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- if we are sharing tables only, there are no pre-existing access points and the get_removed_folders method returns a NoneType object that is then treated as a list, therefore failing.

By explicitly returning an empty list for this case we avoid the error.
It has been tested in branch v1m2m0

### Relates
- #199 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
