### PR TITLE
205 replace anonymous sessions by reader sessions in dashboard sharing viewer

### DIFF
--- a/backend/dataall/api/Objects/Dashboard/resolvers.py
+++ b/backend/dataall/api/Objects/Dashboard/resolvers.py
@@ -42,7 +42,7 @@ def get_quicksight_reader_url(context, source, dashboardUri: str = None):
             if not shared_groups:
                 raise db.exceptions.UnauthorizedOperation(
                     action=permissions.GET_DASHBOARD,
-                    message=f'Dashboard has not been shared with your Teams',
+                    message='Dashboard has not been shared with your Teams',
                 )
 
             url = Quicksight.get_shared_reader_session(

--- a/backend/dataall/api/Objects/Dashboard/resolvers.py
+++ b/backend/dataall/api/Objects/Dashboard/resolvers.py
@@ -1,3 +1,4 @@
+import os
 from .... import db
 from ....api.constants import DashboardRole
 from ....api.context import Context
@@ -53,7 +54,7 @@ def get_quicksight_reader_url(context, source, dashboardUri: str = None):
             session_type = ParameterStoreManager.get_parameter_value(
                 AwsAccountId=current_account,
                 region=region,
-                parameter_path=f"/dataall/{envname}/quicksight/sharedDashboardsSessions"
+                parameter_path=f"/dataall/{os.getenv('envname', 'local')}/quicksight/sharedDashboardsSessions"
             )
             if session_type == 'reader':
                 url = Quicksight.get_shared_reader_session(

--- a/backend/dataall/api/Objects/Dashboard/resolvers.py
+++ b/backend/dataall/api/Objects/Dashboard/resolvers.py
@@ -48,14 +48,10 @@ def get_quicksight_reader_url(context, source, dashboardUri: str = None):
                     message='Dashboard has not been shared with your Teams',
                 )
 
-            current_account = SessionHelper.get_account()
-            region = os.getenv('AWS_REGION', 'eu-west-1')
-
             session_type = ParameterStoreManager.get_parameter_value(
-                AwsAccountId=current_account,
-                region=region,
                 parameter_path=f"/dataall/{os.getenv('envname', 'local')}/quicksight/sharedDashboardsSessions"
             )
+
             if session_type == 'reader':
                 url = Quicksight.get_shared_reader_session(
                     AwsAccountId=env.AwsAccountId,

--- a/backend/dataall/api/Objects/Dashboard/resolvers.py
+++ b/backend/dataall/api/Objects/Dashboard/resolvers.py
@@ -4,7 +4,6 @@ from ....api.constants import DashboardRole
 from ....api.context import Context
 from ....aws.handlers.quicksight import Quicksight
 from ....aws.handlers.parameter_store import ParameterStoreManager
-from ....aws.handlers.sts import SessionHelper
 from ....db import permissions, models
 from ....db.api import ResourcePolicy, Glossary, Vote
 from ....searchproxy import indexers

--- a/backend/dataall/api/Objects/Dashboard/resolvers.py
+++ b/backend/dataall/api/Objects/Dashboard/resolvers.py
@@ -33,12 +33,32 @@ def get_quicksight_reader_url(context, source, dashboardUri: str = None):
                 DashboardId=dash.DashboardId,
             )
         else:
-            url = Quicksight.get_anonymous_session(
+            shared_groups = db.api.Dashboard.query_all_user_groups_shareddashboard(
+                session=session,
+                username=context.username,
+                groups=context.groups,
+                uri=dashboardUri
+            )
+            if not shared_groups:
+                raise db.exceptions.UnauthorizedOperation(
+                    action=permissions.GET_DASHBOARD,
+                    message=f'Dashboard has not been shared with your Teams',
+                )
+
+            url = Quicksight.get_shared_reader_session(
                 AwsAccountId=env.AwsAccountId,
                 region=env.region,
                 UserName=context.username,
+                GroupName=shared_groups[0],
                 DashboardId=dash.DashboardId,
             )
+
+            # url = Quicksight.get_anonymous_session(
+            #     AwsAccountId=env.AwsAccountId,
+            #     region=env.region,
+            #     UserName=context.username,
+            #     DashboardId=dash.DashboardId,
+            # )
     return url
 
 

--- a/backend/dataall/api/Objects/Tenant/resolvers.py
+++ b/backend/dataall/api/Objects/Tenant/resolvers.py
@@ -76,7 +76,7 @@ def get_monitoring_vpc_connection_id(context, source):
 def create_quicksight_data_source_set(context, source, vpcConnectionId: str = None):
     current_account = SessionHelper.get_account()
     region = os.getenv('AWS_REGION', 'eu-west-1')
-    user = Quicksight.register_user(AwsAccountId=current_account, UserName=context.username, UserRole='AUTHOR')
+    user = Quicksight.register_user_in_group(AwsAccountId=current_account, UserName=context.username, GroupName='dataall', UserRole='AUTHOR')
 
     datasourceId = Quicksight.create_data_source_vpc(AwsAccountId=current_account, region=region, UserName=context.username, vpcConnectionId=vpcConnectionId)
     # Data sets are not created programmatically. Too much overhead for the value added. However, an example API is provided:

--- a/backend/dataall/aws/handlers/parameter_store.py
+++ b/backend/dataall/aws/handlers/parameter_store.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from botocore.exceptions import ClientError
 
@@ -16,12 +17,15 @@ class ParameterStoreManager:
         pass
 
     @staticmethod
-    def client(AwsAccountId, region):
-        session = SessionHelper.remote_session(AwsAccountId)
+    def client(AwsAccountId=None, region=None):
+        if AwsAccountId:
+            session = SessionHelper.remote_session(AwsAccountId)
+        else:
+            session = SessionHelper.get_session()
         return session.client('ssm', region_name=region)
 
     @staticmethod
-    def get_parameter_value(AwsAccountId, region, parameter_path):
+    def get_parameter_value(AwsAccountId=None, region=None, parameter_path=None):
         if not parameter_path:
             raise Exception('Parameter name is None')
         try:

--- a/backend/dataall/aws/handlers/parameter_store.py
+++ b/backend/dataall/aws/handlers/parameter_store.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from botocore.exceptions import ClientError
 

--- a/backend/dataall/aws/handlers/quicksight.py
+++ b/backend/dataall/aws/handlers/quicksight.py
@@ -135,8 +135,7 @@ class Quicksight:
         """
         client = Quicksight.get_quicksight_client_in_identity_region(AwsAccountId)
         group = Quicksight.describe_group(client, AwsAccountId, GroupName)
-        print("inside create groups")
-        print(group)
+
         if not group:
             logger.info(f'Attempting to create Quicksight group `{GroupName}...')
             response = client.create_group(
@@ -244,8 +243,9 @@ class Quicksight:
         response = client.list_user_groups(
             UserName=UserName, AwsAccountId=AwsAccountId, Namespace='default'
         )
-        print(f'list_user_groups {UserName}')
-        print(response)
+        logger.info(
+            f'list_user_groups for {UserName}: {response})'
+        )
         if 'dataall' not in [g['GroupName'] for g in response['GroupList']]:
             logger.warning(f'Adding {UserName} to Quicksight dataall on {AwsAccountId}')
             response = client.create_group_membership(
@@ -263,7 +263,7 @@ class Quicksight:
         )
         exists = False
         user = Quicksight.describe_user(AwsAccountId, UserName=UserName)
-        print(user)
+
         if user is not None:
             exists = True
 
@@ -290,8 +290,9 @@ class Quicksight:
         response = client.list_user_groups(
             UserName=UserName, AwsAccountId=AwsAccountId, Namespace='default'
         )
-        print(f'list_user_groups {UserName}')
-        print(response)
+        logger.info(
+            f'list_user_groups for {UserName}: {response})'
+        )
         if GroupName not in [g['GroupName'] for g in response['GroupList']]:
             logger.warning(f'Adding {UserName} to Quicksight group {GroupName} on {AwsAccountId}')
             response = client.create_group_membership(
@@ -330,15 +331,15 @@ class Quicksight:
             AwsAccountId=AwsAccountId,
             DashboardId=DashboardId
         )['Permissions']
-        print(response)
+        logger.info(f"Dashboard initial permissions: {response}")
         read_principals = []
         write_principals = []
 
         for a, p in zip([p["Actions"] for p in response], [p["Principal"] for p in response]):
             write_principals.append(p) if "Update" in str(a) else read_principals.append(p)
 
-        print(f"Read principals: {read_principals}")
-        print(f"Write principals: {write_principals}")
+        logger.info(f"Dashboard updated permissions, Read principals: {read_principals}")
+        logger.info(f"Dashboard updated permissions, Write principals: {write_principals}")
 
         return read_principals, write_principals
 
@@ -376,7 +377,7 @@ class Quicksight:
                     },
                 ]
             )
-            print(f"Permissions granted: {permissions}")
+            logger.info(f"Permissions granted: {permissions}")
 
         response = client.get_dashboard_embed_url(
             AwsAccountId=AwsAccountId,

--- a/backend/dataall/aws/handlers/quicksight.py
+++ b/backend/dataall/aws/handlers/quicksight.py
@@ -352,8 +352,8 @@ class Quicksight:
         groupPrincipal = f"arn:aws:quicksight:{identity_region}:{AwsAccountId}:group/default/{GroupName}"
 
         user = Quicksight.register_user_in_group(
-                AwsAccountId=AwsAccountId, UserName=UserName, GroupName=GroupName, UserRole=UserRole
-            )
+            AwsAccountId=AwsAccountId, UserName=UserName, GroupName=GroupName, UserRole=UserRole
+        )
 
         read_principals, write_principals = Quicksight.check_dashboard_permissions(
             AwsAccountId=AwsAccountId,

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -195,8 +195,8 @@ class Dataset(Stack):
 
         quicksight_default_group_arn = None
         if env.dashboardsEnabled:
-            quicksight_default_group = Quicksight.create_quicksight_default_group(
-                dataset.AwsAccountId
+            quicksight_default_group = Quicksight.create_quicksight_group(
+                dataset.AwsAccountId, 'dataall'
             )
             quicksight_default_group_arn = quicksight_default_group['Group']['Arn']
 

--- a/backend/dataall/cdkproxy/stacks/environment.py
+++ b/backend/dataall/cdkproxy/stacks/environment.py
@@ -66,7 +66,7 @@ class EnvironmentSetup(Stack):
             return db.api.Vpc.get_environment_default_vpc(session, environmentUri)
 
     def init_quicksight(self, environment: models.Environment):
-        Quicksight.create_quicksight_default_group(environment.AwsAccountId)
+        Quicksight.create_quicksight_group(environment.AwsAccountId, 'dataall')
 
     def check_sagemaker_studio(self, engine, environment: models.Environment):
         logger.info('check sagemaker studio domain creation')

--- a/backend/dataall/db/api/dashboard.py
+++ b/backend/dataall/db/api/dashboard.py
@@ -197,6 +197,23 @@ class Dashboard:
         return query
 
     @staticmethod
+    def query_all_user_groups_shareddashboard(session, username, groups, uri) -> Query:
+        query = (
+            session.query(models.DashboardShare)
+            .filter(
+                and_(
+                    models.DashboardShare.dashboardUri == uri,
+                    models.DashboardShare.SamlGroupName.in_(groups),
+                )
+            )
+        )
+
+        return [
+            share.SamlGroupName
+            for share in query.all()
+        ]
+
+    @staticmethod
     @has_tenant_perm(permissions.MANAGE_DASHBOARDS)
     @has_resource_perm(permissions.SHARE_DASHBOARD)
     def paginated_dashboard_shares(

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -42,6 +42,7 @@ class BackendStack(Stack):
         quicksight_enabled=False,
         enable_cw_canaries=False,
         enable_cw_rum=False,
+        shared_dashboard_sessions='anonymous',
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -66,6 +67,7 @@ class BackendStack(Stack):
             custom_domain=custom_domain,
             enable_cw_canaries=enable_cw_canaries,
             quicksight_enabled=quicksight_enabled,
+            shared_dashboard_sessions=shared_dashboard_sessions,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -26,6 +26,7 @@ class BackendStage(Stage):
         quicksight_enabled=False,
         enable_cw_canaries=False,
         enable_cw_rum=False,
+        shared_dashboard_sessions='anonymous',
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -49,6 +50,7 @@ class BackendStage(Stage):
             quicksight_enabled=quicksight_enabled,
             enable_cw_canaries=enable_cw_canaries,
             enable_cw_rum=enable_cw_rum,
+            shared_dashboard_sessions='anonymous',
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -50,7 +50,7 @@ class BackendStage(Stage):
             quicksight_enabled=quicksight_enabled,
             enable_cw_canaries=enable_cw_canaries,
             enable_cw_rum=enable_cw_rum,
-            shared_dashboard_sessions='anonymous',
+            shared_dashboard_sessions=shared_dashboard_sessions,
             **kwargs,
         )
 

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -15,6 +15,7 @@ class ParamStoreStack(pyNestedClass):
         custom_domain=None,
         enable_cw_canaries=False,
         quicksight_enabled=False,
+        shared_dashboard_sessions='anonymous'
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -72,3 +73,10 @@ class ParamStoreStack(pyNestedClass):
                 parameter_name=f'/dataall/{envname}/quicksightmonitoring/DashboardId',
                 string_value='updateme',
             )
+
+        aws_ssm.StringParameter(
+            self,
+            f'dataallQuicksightConfiguration{envname}',
+            parameter_name=f"/dataall/{envname}/quicksight/sharedDashboardsSessions",
+            string_value=shared_dashboard_sessions,
+        )

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -15,7 +15,7 @@ class ParamStoreStack(pyNestedClass):
         custom_domain=None,
         enable_cw_canaries=False,
         quicksight_enabled=False,
-        shared_dashboard_sessions='anonymous'
+        shared_dashboard_sessions='anonymous',
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -555,6 +555,7 @@ class PipelineStack(Stack):
                 quicksight_enabled=target_env.get('enable_quicksight_monitoring', False),
                 enable_cw_rum=target_env.get('enable_cw_rum', False),
                 enable_cw_canaries=target_env.get('enable_cw_canaries', False),
+                shared_dashboard_sessions=target_env.get('shared_dashboard_sessions', 'anonymous'),
             )
         )
         return backend_stage

--- a/template_cdk.json
+++ b/template_cdk.json
@@ -29,7 +29,8 @@
         "apig_vpce": "string_USE_AN_EXISTING_VPCE_FOR_APIG_IF_NOT_INTERNET_FACING|DEFAULT=None",
         "prod_sizing": "boolean_SET_INFRA_SIZING_TO_PROD_VALUES_IF_TRUE|DEFAULT=true",
         "enable_cw_rum":  "boolean_SET_CLOUDWATCH_RUM_APP_MONITOR|DEFAULT=false",
-        "enable_cw_canaries": "boolean_SET_CLOUDWATCH_CANARIES_FOR_FRONTEND_TESTING|DEFAULT=false"
+        "enable_cw_canaries": "boolean_SET_CLOUDWATCH_CANARIES_FOR_FRONTEND_TESTING|DEFAULT=false",
+        "shared_dashboards_sessions": "string_TYPE_SESSION_SHARED_DASHBOARDS|(reader, anonymous) DEFAULT=anonymous"
       }
     ]
   }


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Added a configuration parameter in cdk.json. This configurable parameter can take 2 values ["reader", "anonymous"]
- When a Dashboard that is **SHARED** is embedded in the UI we read the value of this configuration and depending on the setup we use the corresponding Quicksight API calls:
- For the `anonymous` configuration, we use a Quicksight `ANONYMOUS` session to display the Dashboard in the UI. No Quicksight user is created in the Dashboard Quicksight account.
- For the `reader` configuration, we create a Quicksight user and Quicksight group (if they don't exist yet) for this user that got access to a shared dashboard. We grant "read" Quicksight permissions to the specific Dashboard to the Quicksight **GROUP**. Then in the UI we use a `READER` session to embed the Dashboard in data.all UI

#### Recommendations
This implementation tries to satisfy different customer scenarios. The decision to use 'anonymous' or 'reader' sessions depends on your constraints. With `reader` sessions you have more control over the users accessing the dashboard and you can apply data filter and permissions on those users, however if you expect thousands of users accesing a single view of a dashboard, `anonymous` sessions might scale better. Check the [embedding documentation](https://docs.aws.amazon.com/quicksight/latest/user/embedding-overview.html) and the [pricing](https://aws.amazon.com/quicksight/pricing/) to understand the differences and find which solution fits better to your needs.

### Relates
- #205 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
