### PR TITLE
Remove comma which creates a tuple and duplicate SSM parameters.

### DIFF
--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -255,21 +255,6 @@ class CloudfrontDistro(pyNestedClass):
             frontend_alternate_domain = custom_domain_name
             userguide_alternate_domain = 'userguide.' + custom_domain_name
 
-            ssm.StringParameter(
-                self,
-                f'FrontendCustomDomain{envname}',
-                parameter_name=f'/dataall/{envname}/frontend/custom_domain_name',
-                string_value=frontend_alternate_domain,
-            )
-
-            ssm.StringParameter(
-                self,
-                f'UserGuideCustomDomain{envname}',
-                parameter_name=f'/dataall/{envname}/userguide/custom_domain_name',
-                string_value=userguide_alternate_domain,
-            )
-
-
             hosted_zone = route53.HostedZone.from_hosted_zone_attributes(
                 self,
                 'CustomDomainHostedZone',

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -827,7 +827,7 @@ class PipelineStack(Stack):
             post=[
                 self.cognito_config_action(target_env),
                 self.cw_rum_config_action(target_env),
-            ],
+            ]
         else:
             post=[
                 self.cognito_config_action(target_env),


### PR DESCRIPTION
### Bugfix

### Detail
- Extra comma in assignment causes array to be wrapped in a 2-element tuple and then JSII cannot convert it. See https://github.com/awslabs/aws-dataall/issues/216
- SSM parameters are duplicated if `custom_domain` is used. First they are created in the backend stack, then later when the front end is deployed it recreates the SSM parameters with the same name. This only happens when `custom_domain` and `internet_facing` are both being used.

### Relates
- https://github.com/awslabs/aws-dataall/issues/216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
