### PR TITLE
Change open search service to use correct principal.

### DIFF
--- a/deploy/stacks/opensearch.py
+++ b/deploy/stacks/opensearch.py
@@ -64,7 +64,7 @@ class OpenSearchStack(pyNestedClass):
             enable_key_rotation=True,
         )
         iam.CfnServiceLinkedRole(
-            self, 'ServiceLinkedForElasticSearch', aws_service_name='es.amazonaws.com'
+            self, 'ServiceLinkedForElasticSearch', aws_service_name='opensearchservice.amazonaws.com'
         )
 
         es_app_log_group = logs.LogGroup(


### PR DESCRIPTION
### Bugfix

### Detail
- The `es.amazonaws.com` service principal in `us-east-1` does not work for new environments. This may need more testing to see if other partitions still use `es.amazonaws.com`, but since its been over a year now since it looks like it went live I think it should be ok to change this now. I have been unable to find any documentation stating this switch, other than the current documentation which says this is the correct service principal: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
