### PR TITLE
Glossaries association permissions

### DIFF
--- a/documentation/userguide/docs/datasets.md
+++ b/documentation/userguide/docs/datasets.md
@@ -68,7 +68,7 @@ On left pane choose **Datasets**, then click on the **Create** button. Fill the 
 | Region (auto-filled)            | AWS region of the environment                             | Yes             | No       |Europe (Ireland)
 | Organization (auto-filled)     | Organization of the environment                           | Yes             | No       | AnyCompany EMEA
 | Owners    | Team that owns the dataset                                | Yes             |   No       | DataScienceTeam
-| Stewards    | Team that can manage share requests on behalf of owners   | No              |  No        |  FinanceBITeam, FinanceMgmtTeam
+| Stewards    | Team that can manage share requests on behalf of owners   | No              |  Yes        |  FinanceBITeam, FinanceMgmtTeam
 | Confidentiality  | Level of confidentiality: Unclassified, Oficial or Secret | Yes             | Yes      | Secret
 | Topics           | Topics that can later be used in the Catalog              | Yes, at least 1 | Yes       | Finance
 | Tags             | Tags that can later be used in the Catalog                | Yes, at least 1 | Yes      | deleteme, ds

--- a/frontend/src/api/Glossary/listGlossaryAssociations.js
+++ b/frontend/src/api/Glossary/listGlossaryAssociations.js
@@ -19,6 +19,7 @@ const listGlossaryAssociations = ({ nodeUri, filter }) => ({
         status
         path
         admin
+        userRoleForGlossary
         associations(filter: $filter) {
           count
           page

--- a/frontend/src/views/Glossaries/GlossaryAssociations.js
+++ b/frontend/src/views/Glossaries/GlossaryAssociations.js
@@ -38,8 +38,7 @@ const GlossaryAssociations = ({ glossary }) => {
   const [filter, setFilter] = useState(Defaults.DefaultFilter);
   const [approving, setApproving] = useState(false);
   const [loading, setLoading] = useState(true);
-  const isAdmin =
-    glossary.owner === user.email || glossary.admin === user.email;
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const fetchItems = useCallback(async () => {
     setLoading(true);
@@ -50,6 +49,11 @@ const GlossaryAssociations = ({ glossary }) => {
       })
     );
     if (!response.errors) {
+      setIsAdmin(
+        ['Admin'].indexOf(
+          response.data.getGlossary.userRoleForGlossary
+        ) !== -1
+      );
       setItems(response.data.getGlossary.associations);
     } else {
       dispatch({ type: SET_ERROR, error: response.errors[0].message });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In the current version, only the glossary owner (the user that created the gloassary) can manage glossary associations.
With this PR, any member of the group owning the glossary can manage its associations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
