### PR TITLE
Remove extra DBs and fix worksheet views for shared datasets

### DIFF
--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -467,44 +467,6 @@ class Dataset(Stack):
             },
         )
 
-        glue_db_dev = CustomResource(
-            self,
-            f'{env.resourcePrefix}DatasetDatabaseDev',
-            service_token=GlueDatabase.service_token,
-            resource_type='Custom::GlueDatabase',
-            properties={
-                'CatalogId': dataset.AwsAccountId,
-                'DatabaseInput': {
-                    'Description': 'dataall development database {} '.format(
-                        dataset.GlueDatabaseName
-                    ),
-                    'LocationUri': f's3://{dataset.S3BucketName}/dev/',
-                    'Name': f'{dataset.GlueDatabaseName}dev',
-                    'CreateTableDefaultPermissions': [],
-                },
-                'DatabaseAdministrators': dataset_admins,
-            },
-        )
-
-        glue_db_test = CustomResource(
-            self,
-            f'{env.resourcePrefix}DatasetDatabaseTest',
-            service_token=GlueDatabase.service_token,
-            resource_type='Custom::GlueDatabase',
-            properties={
-                'CatalogId': dataset.AwsAccountId,
-                'DatabaseInput': {
-                    'Description': 'dataall test database {} '.format(
-                        dataset.GlueDatabaseName
-                    ),
-                    'LocationUri': f's3://{dataset.S3BucketName}/test/',
-                    'Name': f'{dataset.GlueDatabaseName}test',
-                    'CreateTableDefaultPermissions': [],
-                },
-                'DatabaseAdministrators': dataset_admins,
-            },
-        )
-
         glue.CfnCrawler(
             self,
             dataset.GlueCrawlerName,

--- a/frontend/src/views/Worksheets/WorksheetView.js
+++ b/frontend/src/views/Worksheets/WorksheetView.js
@@ -30,7 +30,7 @@ import useClient from '../../hooks/useClient';
 import listEnvironments from '../../api/Environment/listEnvironments';
 import listEnvironmentGroups from '../../api/Environment/listEnvironmentGroups';
 import { SET_ERROR } from '../../store/errorReducer';
-import listDatasets from '../../api/Dataset/listDatasets';
+import listDatasetsOwnedByEnvGroup from '../../api/Environment/listDatasetsOwnedByEnvGroup';
 import listDatasetTables from '../../api/Dataset/listDatasetTables';
 import listDatasetTableColumns from '../../api/DatasetTable/listDatasetTableColumns';
 import searchEnvironmentDataItems from '../../api/Environment/listDatasetsPublishedInEnvironment';
@@ -128,17 +128,28 @@ const WorksheetView = () => {
   };
 
   const fetchDatabases = useCallback(
-    async (environment) => {
+    async (environment, team) => {
       setLoadingDatabases(true);
       let ownedDatabases = [];
       let sharedWithDatabases = [];
-      let response = await client.query(listDatasets({ term: '', page: 1, pageSize: 10000}));
+      console.log(environment)
+      console.log(team)
+      let response = await client.query(
+        listDatasetsOwnedByEnvGroup({
+          filter: { 
+            term: '', 
+            page: 1, 
+            pageSize: 10000
+          },
+          environmentUri: environment.environmentUri,
+          groupUri: team
+        }));
       if (response.errors) {
         dispatch({ type: SET_ERROR, error: response.errors[0].message });
       }
-      if (response.data.listDatasets.nodes) {
+      if (response.data.listDatasetsOwnedByEnvGroup.nodes) {
         ownedDatabases =
-          response.data.listDatasets.nodes?.map((d) => ({
+          response.data.listDatasetsOwnedByEnvGroup.nodes?.map((d) => ({
             ...d,
             value: d.datasetUri,
             label: d.GlueDatabaseName
@@ -163,8 +174,8 @@ const WorksheetView = () => {
           response.data.searchEnvironmentDataItems.nodes.map((d) => ({
             datasetUri: d.datasetUri,
             value: d.datasetUri,
-            label: `${d.GlueDatabaseName}shared`,
-            GlueDatabaseName: `${d.GlueDatabaseName}shared`
+            label: `${d.GlueDatabaseName}_shared_${d.shareUri}`,
+            GlueDatabaseName: `${d.GlueDatabaseName}_shared_${d.shareUri}`.substring(0,254)
           }));
       }
       setDatabaseOptions(ownedDatabases.concat(sharedWithDatabases));
@@ -336,7 +347,7 @@ const WorksheetView = () => {
     setDatabaseOptions([]);
     setTableOptions([]);
     setCurrentTeam(event.target.value);
-    fetchDatabases(currentEnv).catch((e) =>
+    fetchDatabases(currentEnv, event.target.value).catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
     );
   }


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Remove dev/test/ databases from dataset stack
- Worksheet View only shows 1 glue db name for shared datasets
-  Worksheet View add `shared_shareUri` to shared db name to match name of resource link 

### Relates
- [Issue #184](https://github.com/awslabs/aws-dataall/issues/184)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
