### PR TITLE
Fix glue update table call with column metadata

### DIFF
--- a/backend/dataall/aws/handlers/glue.py
+++ b/backend/dataall/aws/handlers/glue.py
@@ -531,6 +531,7 @@ class Glue:
                     if k
                     not in [
                         'CatalogId',
+                        'VersionId',
                         'DatabaseName',
                         'CreateTime',
                         'UpdateTime',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix call to update table so column descriptions persisted

### Relates
- [#243](https://github.com/awslabs/aws-dataall/issues/243)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
