### PR TITLE
Added --ignore for SQLAlchemy vulnerability on all non-beta versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ check-security: upgrade-pip install-backend install-cdkproxy
 	pip install bandit
 	pip install safety
 	bandit -lll -r backend
-	safety check
+	safety check --ignore=51668
 
 test:
 	export PYTHONPATH=./backend:/./tests && \


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Added --ignore for the vulnerability https://pyup.io/vulnerabilities/PVE-2022-51668/51668/ It is explained in detail in #249 
- Once there is a production version of SQLAlchemy that we can upgrade to we will upgrade the library and remove this --ignore flag
### Relates
#249 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
