### PR TITLE
Update the region in which parameters are looked for

### DIFF
--- a/deploy/configs/cognito_urls_config.py
+++ b/deploy/configs/cognito_urls_config.py
@@ -24,11 +24,9 @@ def setup_cognito(
         'Parameter'
     ]['Value']
 
-    if internet_facing == 'True':
+    if custom_domain == 'False' and internet_facing == 'True':
         print('Switching to us-east-1 region...')
         ssm = boto3.client('ssm', region_name='us-east-1')
-
-    if custom_domain == 'False':
         signin_singout_link = ssm.get_parameter(
             Name=f'/dataall/{envname}/CloudfrontDistributionDomainName'
         )['Parameter']['Value']

--- a/deploy/configs/frontend_config.py
+++ b/deploy/configs/frontend_config.py
@@ -33,11 +33,9 @@ def create_react_env_file(
     search_api_url = f'{api_url}search/api'
     print(f'Search API: {search_api_url}')
 
-    if internet_facing == 'True':
+    if custom_domain == 'False' and internet_facing == 'True':
         print('Switching to us-east-1 region...')
         ssm = boto3.client('ssm', region_name='us-east-1')
-
-    if custom_domain == 'False':
         signin_singout_link = ssm.get_parameter(
             Name=f'/dataall/{envname}/CloudfrontDistributionDomainName'
         )['Parameter']['Value']


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In the current version, if `internet_facing==True`, then `cognito_urls_configs.py` and `frontend_config.py` look for parameters in `us-east-1`.
But if `custom_domain` is configured, then the parameters `frontend/custom_domain_name` and `userguide/custom_domain_name` are created with the backend stack (thus in the region of the backend).
With this code changes, `cognito_urls_configs.py` and `frontend_config.py` look for parameters in `us-east-1` only if `internet_facing ==True` and `custom_domain==False`. If this is not the case, it uses parameter in the backend region.