### PR TITLE
Fix Dependabot alert (Prototype Pollution in JSON5 via Parse Method) …

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "dayjs": "^1.11.0",
     "formik": "^2.2.9",
     "graphql-tag": "^2.12.6",
+    "json5": "^2.2.2",
     "jwt-decode": "^3.1.2",
     "notistack": "^2.0.3",
     "nprogress": "^0.2.0",
@@ -58,8 +59,8 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
-    "prettier": "^2.6.1",
-    "env-cmd": "^10.1.0"
+    "env-cmd": "^10.1.0",
+    "prettier": "^2.6.1"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8629,10 +8629,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2, json5@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^2.1.2, json5@^2.2.0, json5@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonfile@^6.0.1:
   version "6.1.0"


### PR DESCRIPTION
…https://security.snyk.io/vuln/SNYK-JS-JSON5-3182856

### Feature or Bugfix
- Bugfix

### Detail
- Upgrade json5 (https://security.snyk.io/vuln/SNYK-JS-JSON5-3182856) 

### Relates
- [Dependabot
](https://github.com/awslabs/aws-dataall/security/dependabot/29)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
