### PR TITLE
Add cross-region sharing error message/exception

### DIFF
--- a/backend/dataall/db/api/share_object.py
+++ b/backend/dataall/db/api/share_object.py
@@ -351,6 +351,13 @@ class ShareObject:
             'environment',
             api.Environment.get_environment_by_uri(session, environmentUri),
         )
+
+        if environment.region != dataset.region:
+            raise exceptions.UnauthorizedOperation(
+                action=permissions.CREATE_SHARE_OBJECT,
+                message=f'Requester Team {groupUri} works in region {environment.region} and the requested dataset is stored in region {dataset.region}',
+            )
+
         if principalType == models.PrincipalType.ConsumptionRole.value:
             consumption_role: models.ConsumptionRole = api.Environment.get_environment_consumption_role(
                 session,


### PR DESCRIPTION
### Feature or Bugfix
- Feature/Bugfix

### Detail
- Cross-region sharing is not possible for table sharing because Lake Formation does not allow (yet) cross region sharing. 
- Cross-region sharing of folders using access points currently includes errors in the implemented policy
For this reason for the time being we display an error for cross-region sharing to disallow this behaviour

### Relates
- #318

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
