### PR TITLE
Added missing 'glue:DeleteResourcePolicy' to pivotRole in YAML and CDK

### DIFF
--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -403,6 +403,7 @@ Resources:
             Effect: Allow
             Action:
               - 'glue:PutResourcePolicy'
+              - 'glue:DeleteResourcePolicy'
               - 'ram:Get*'
               - 'ram:List*'
             Resource: '*'

--- a/deploy/pivot_role/pivotRoleCDK/dataall_base_infra.py
+++ b/deploy/pivot_role/pivotRoleCDK/dataall_base_infra.py
@@ -492,6 +492,7 @@ class dataAllBaseInfra(Stack):
                                          sid="RamRead", effect=iam.Effect.ALLOW,
                                          actions=[
                                              "glue:PutResourcePolicy",
+                                             "glue:DeleteResourcePolicy",
                                              "ram:Get*",
                                              "ram:List*"
                                          ],


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Added 'glue:DeleteResourcePolicy' in PivotRole stack (CloudFormation YAML and CDK)

### Relates
- #317 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
