### PR TITLE
Added kms:createGrant to environmentGroups (no admin groups)

### DIFF
--- a/backend/dataall/cdkproxy/stacks/policies/service_policy.py
+++ b/backend/dataall/cdkproxy/stacks/policies/service_policy.py
@@ -72,6 +72,7 @@ class ServicePolicy(object):
                             'kms:Encrypt',
                             'kms:ReEncrypt*',
                             'kms:GenerateDataKey*',
+                            'kms:CreateGrant',
                             'secretsmanager:GetSecretValue',
                             'secretsmanager:DescribeSecret',
                             'secretsmanager:ListSecrets',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Added kms:createGrant permission for all environment IAM roles. 

Comment: we have noticed that for the environment admin team IAM role the following is added whenever they create a dataset (`backend/dataall/cdkproxy/stacks/policies/data_policy.py`)
```
iam.PolicyStatement(
                    actions=['athena:*', 'lakeformation:*', 'glue:*', 'kms:*'],
                    resources=['*'],
                ),
```
Maybe it is a good moment to re-review the IAM policies of:
- pivotRole
- environmentGroup IAM roles (Admin and non-admin)
- dataset IAM role
But this can be handled in a different PR
### Relates
- #326 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
