### PR TITLE
Configurable restricted VPC for tooling account

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -46,6 +46,7 @@ class PipelineStack(Stack):
             cidr='10.0.0.0/16',
             resource_prefix=resource_prefix,
             vpc_id=self.node.try_get_context('tooling_vpc_id'),
+            restricted_nacl=self.node.try_get_context('tooling_vpc_restricted_nacl'),
             **kwargs,
         )
         self.vpc = self.vpc_stack.vpc

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -391,11 +391,13 @@ class PipelineStack(Stack):
                         build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
                     ),
                     commands=[
+                        f'aws codeartifact login --tool pip --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',
                         'pip install --upgrade pip',
                         'python -m venv env',
                         '. env/bin/activate',
                         'make lint',
                         'cd frontend',
+                        f'aws codeartifact login --tool npm --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}'
                         'npm install',
                         'npm run lint',
                     ],

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -398,7 +398,7 @@ class PipelineStack(Stack):
                         '. env/bin/activate',
                         'make lint',
                         'cd frontend',
-                        f'aws codeartifact login --tool npm --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',
+                        f'aws codeartifact login --tool npm --repository {self.codeartifact.npm_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',
                         'npm install',
                         'npm run lint',
                     ],

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -398,7 +398,7 @@ class PipelineStack(Stack):
                         '. env/bin/activate',
                         'make lint',
                         'cd frontend',
-                        f'aws codeartifact login --tool npm --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}'
+                        f'aws codeartifact login --tool npm --repository {self.codeartifact.pip_repo.attr_name} --domain {self.codeartifact.domain.attr_name} --domain-owner {self.codeartifact.domain.attr_owner}',
                         'npm install',
                         'npm run lint',
                     ],

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -130,9 +130,9 @@ class VpcStack(pyNestedClass):
             nacl = ec2.NetworkAcl(
                 self, "RestrictedNACL",
                 vpc=self.vpc,
-                network_acl_name=f'{resource_prefix}-{envname}-restrictedNACL'
+                network_acl_name=f'{resource_prefix}-{envname}-restrictedNACL',
+                subnet_selection=ec2.SubnetSelection(subnets=self.vpc.private_subnets + self.vpc.public_subnets),
             )
-            #TODO: COMPLETE NACL RULES
             nacl.add_entry(
                 "entryOutbound",
                 cidr=ec2.AclCidr.any_ipv4(),

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -259,7 +259,6 @@ class VpcStack(pyNestedClass):
                 private_dns_enabled=True,
                 security_groups=[cast(ec2.ISecurityGroup, self.vpce_security_group)],
             )
-        #TODO: test that changing private_dns_enabled=True does not affect previous settings. Needed for restricted nacl
         self.vpc.add_interface_endpoint(
             id='code_artifact_repo_endpoint',
             service=cast(

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -134,13 +134,46 @@ class VpcStack(pyNestedClass):
             )
             #TODO: COMPLETE NACL RULES
             nacl.add_entry(
-                "entry1",
-                cidr=,
+                "entryOutbound",
+                cidr=ec2.AclCidr.any_ipv4(),
                 traffic=ec2.AclTraffic.all_traffic(),
                 rule_number=100,
-                traffic=ec2.TrafficDirection.INGRESS,
-                direction=None,
+                direction=ec2.TrafficDirection.EGRESS,
+                rule_action=ec2.Action.ALLOW
             )
+            nacl.add_entry(
+                "entryInboundHTTPS",
+                cidr=ec2.AclCidr.any_ipv4(),
+                traffic=ec2.AclTraffic.tcp_port(443),
+                rule_number=100,
+                direction=ec2.TrafficDirection.INGRESS,
+                rule_action=ec2.Action.ALLOW
+            )
+            nacl.add_entry(
+                "entryInboundHTTP",
+                cidr=ec2.AclCidr.any_ipv4(),
+                traffic=ec2.AclTraffic.tcp_port(80),
+                rule_number=101,
+                direction=ec2.TrafficDirection.INGRESS,
+                rule_action=ec2.Action.ALLOW
+            )
+            nacl.add_entry(
+                "entryInboundCustomTCP",
+                cidr=ec2.AclCidr.any_ipv4(),
+                traffic=ec2.AclTraffic.tcp_port_range(start_port=32768, end_port=65535),
+                rule_number=102,
+                direction=ec2.TrafficDirection.INGRESS,
+                rule_action=ec2.Action.ALLOW
+            )
+            nacl.add_entry(
+                "entryInboundAllInVPC",
+                cidr=ec2.AclCidr.ipv4("10.0.0.0/16"),
+                traffic=ec2.AclTraffic.all_traffic(),
+                rule_number=103,
+                direction=ec2.TrafficDirection.INGRESS,
+                rule_action=ec2.Action.ALLOW
+            )
+
 
         flowlog_log_group = logs.LogGroup(
             self,

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -167,7 +167,7 @@ class VpcStack(pyNestedClass):
             )
             nacl.add_entry(
                 "entryInboundAllInVPC",
-                cidr=self.vpc.vpc_cidr_block,
+                cidr=ec2.AclCidr.ipv4(self.vpc.vpc_cidr_block),
                 traffic=ec2.AclTraffic.all_traffic(),
                 rule_number=103,
                 direction=ec2.TrafficDirection.INGRESS,

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -167,7 +167,7 @@ class VpcStack(pyNestedClass):
             )
             nacl.add_entry(
                 "entryInboundAllInVPC",
-                cidr=ec2.AclCidr.ipv4("10.0.0.0/16"),
+                cidr=self.vpc.vpc_cidr_block,
                 traffic=ec2.AclTraffic.all_traffic(),
                 rule_number=103,
                 direction=ec2.TrafficDirection.INGRESS,

--- a/deploy/stacks/vpc.py
+++ b/deploy/stacks/vpc.py
@@ -160,7 +160,7 @@ class VpcStack(pyNestedClass):
             nacl.add_entry(
                 "entryInboundCustomTCP",
                 cidr=ec2.AclCidr.any_ipv4(),
-                traffic=ec2.AclTraffic.tcp_port_range(start_port=32768, end_port=65535),
+                traffic=ec2.AclTraffic.tcp_port_range(start_port=1024, end_port=65535),
                 rule_number=102,
                 direction=ec2.TrafficDirection.INGRESS,
                 rule_action=ec2.Action.ALLOW

--- a/template_cdk.json
+++ b/template_cdk.json
@@ -7,6 +7,7 @@
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_region": "string_TOOLING_REGION|DEFAULT=eu-west-1",
     "tooling_vpc_id": "string_IMPORT_AN_EXISTING_VPC_FROM_TOOLING|DEFAULT=None",
+    "tooling_vpc_restricted_nacl": "boolean_CREATE_CUSTOM_NACL|DEFAULT=false",
     "git_branch": "string_GIT_BRANCH_NAME|DEFAULT=dataall",
     "git_release": "boolean_MANAGE_GIT_RELEASE|DEFAULT=false",
     "quality_gate": "boolean_MANAGE_QUALITY_GATE_STAGE|DEFAULT=true",


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- New cdk.json configuration parameter `tooling_vpc_restricted_nacl`
- If set to `true` we create a custom NACL for the tooling data.all created VPC with the following inbound rules. Outbound allows all traffic.

![image](https://user-images.githubusercontent.com/71252798/222077893-69329834-e8a0-4b6e-97e5-2ea2c7833d72.png)

- We have enabled DNS private names for CodeArtifact endpoints, to correctly resolve them inside the VPC and keep traffic within the VPC.
- Modified some CodeBuild steps to install pip and npm packages from CodeArtifact instead of from the internet.
- In #323, CodeBuild Linux images were updated, eliminating the need to install yum packages and node.

### Relates
- #307 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
