### PR TITLE
fix: Dashboard Quicksight button leads to an inaccessibility page

### DIFF
--- a/frontend/src/views/Dashboards/DashboardViewer.js
+++ b/frontend/src/views/Dashboards/DashboardViewer.js
@@ -21,7 +21,10 @@ const DashboardViewer = ({ dashboard }) => {
       getReaderSession(dashboard.dashboardUri)
     );
     if (!response.errors) {
-      setSessionUrl(response.data.getReaderSession);
+      // the API operation provides the URL with an auth_code value that enables one (and only one) sign-on to a user session
+      // Auth_code is consumed by the embedDashboard so subsequent opening in the new tab will fail. We are removing
+      // the code from the url (part after '?') used by the button because the user session is already authenticated.
+      setSessionUrl(response.data.getReaderSession.split('?')[0]);
       const options = {
         url: response.data.getReaderSession,
         scrolling: 'no',
@@ -65,7 +68,7 @@ const DashboardViewer = ({ dashboard }) => {
               startIcon={<FaExternalLinkAlt size={15} />}
               variant="outlined"
             >
-              View in Quicksight
+              View in new tab
             </Button>
           </Box>
           <div ref={dashboardRef} />


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Dashboard Quicksight button leads to an inaccessibility page on every first hit

**WHEN** user hits button “View in Quicksight” on any dashboard in the platform

Expected Result:
**THEN** the user gets directed to the requested dashboard in a new full size browser tab

Actual Result:
**THEN** the user gets directed to a page that displays an error message: “Embedding failed because of invalid URL or authorization code. Both of these must be valid and the authorization code must not be expired for embedding to work.”

NOTE: When the page gets refreshed via the browser button, it will show the dashboard. But without any hint, users will not know or try this.

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
