### PR TITLE
Pin alembic version to 'alembic==1.9.4'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ assume-role:
 	rm .assume_role_json
 
 drop-tables: upgrade-pip install-backend
-	pip install alembic
+	pip install 'alembic==1.9.4'
 	export PYTHONPATH=./backend && \
 	python backend/migrations/drop_tables.py
 
 upgrade-db: upgrade-pip install-backend
-	pip install alembic
+	pip install 'alembic==1.9.4'
 	export PYTHONPATH=./backend && \
 	alembic -c backend/alembic.ini upgrade head
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- pinned alembic version when installing with pip. Alembic is currently installed directly in CodeBuild because it is only used in the migration CodeBuild environments. In this PR the version of alembic is pinned in the makefile that is used in these stages.

### Relates
- #353 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
