### PR TITLE
Upgrade sqlalchemy 13.16 -> 1.3.24 and starlette 0.19.1 -> 0.25.0, ariadne 0.13 -> 0.18, fastapi 0.78 -> 0.92

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ assume-role:
 	rm .assume_role_json
 
 drop-tables: upgrade-pip install-backend
-	pip install 'alembic==1.9.4'
+	pip install 'alembic'
 	export PYTHONPATH=./backend && \
 	python backend/migrations/drop_tables.py
 
 upgrade-db: upgrade-pip install-backend
-	pip install 'alembic==1.9.4'
+	pip install 'alembic'
 	export PYTHONPATH=./backend && \
 	alembic -c backend/alembic.ini upgrade head
 

--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -5,7 +5,8 @@ boto3-stubs==1.24.85
 botocore==1.27.85
 cdk-nag==2.7.2
 constructs==10.0.73
-fastapi==0.78.0
+starlette==0.25.0
+fastapi == 0.92.0
 Flask==2.0.3
 PyYAML==6.0
 requests==2.27.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,8 @@
-ariadne==0.13.0
+ariadne==0.18.0
 aws-xray-sdk==2.4.3
 boto3==1.24.85
 botocore==1.27.85
+fastapi == 0.92.0
 Flask==2.0.3
 flask-cors==3.0.10
 nanoid==2.0.0
@@ -12,4 +13,5 @@ pyjwt==2.4.0
 PyYAML==6.0
 requests==2.27.1
 requests_aws4auth==1.1.1
-sqlalchemy==1.3.16
+sqlalchemy==1.3.24
+starlette==0.25.0

--- a/deploy/stacks/dbmigration.py
+++ b/deploy/stacks/dbmigration.py
@@ -108,7 +108,7 @@ class DBMigrationStack(pyNestedClass):
                                 'python -m venv env',
                                 '. env/bin/activate',
                                 'pip install -r backend/requirements.txt',
-                                'pip install "alembic==1.9.4"',
+                                'pip install alembic',
                                 'export PYTHONPATH=backend',
                                 f'export envname={envname}',
                                 f'alembic -c backend/alembic.ini upgrade head',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Upgrade starlette version: vulnerability found in starlette <0.25 (https://security.snyk.io/vuln/SNYK-PYTHON-STARLETTE-3319937). It does not affect data.all as we do not use `python-multipart` but nevertheless it is better to be in a non-vulnerable version.
- Upgrade sqlalchemy version: the vulnerability is not stopping the CICD pipeline, but by upgrading we are able to use the latest version of alembic and we can revert the pinning of the version which happened in https://github.com/awslabs/aws-dataall/pull/354
- Upgrade ariadne

I have tested

### Relates
- #378 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
