### PR TITLE
fix: dev docker images base

### DIFF
--- a/backend/docker/dev/Dockerfile
+++ b/backend/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 ARG NODE_VERSION=16
 ARG NVM_VERSION=v0.37.2

--- a/frontend/docker/dev/Dockerfile
+++ b/frontend/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 ARG NODE_VERSION=16
 ARG NGINX_VERSION=1.12


### PR DESCRIPTION
### Feature or Bug-fix
- Bug-fix

### Detail
The latest version of dev docker images for FE and BE no-longer has `amazon-linux-extras`, this update changes the based of the docker image to use tag `2` (which is consistent with the rest of the images) instead of `latest` (which is a bad practice anyway -- see 2.4 [here](https://sysdig.com/blog/dockerfile-best-practices))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
