### PR TITLE
Added missing groupUri from get credentials

### DIFF
--- a/frontend/src/api/Environment/generateEnvironmentAccessToken.js
+++ b/frontend/src/api/Environment/generateEnvironmentAccessToken.js
@@ -1,12 +1,19 @@
 import { gql } from 'apollo-boost';
 
-const generateEnvironmentAccessToken = ({ environmentUri }) => ({
+const generateEnvironmentAccessToken = ({ environmentUri, groupUri }) => ({
   variables: {
-    environmentUri
+    environmentUri,
+    groupUri
   },
   query: gql`
-    query GenerateEnvironmentAccessToken($environmentUri: String) {
-      generateEnvironmentAccessToken(environmentUri: $environmentUri)
+    query GenerateEnvironmentAccessToken(
+      $environmentUri: String!
+      $groupUri: String
+    ) {
+      generateEnvironmentAccessToken(
+        environmentUri: $environmentUri
+        groupUri: $groupUri
+      )
     }
   `
 });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Get credentials access token was missing groupUri input variable, as a result all users appeared as Unauthorized

### Relates
- #389 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
