### PR TITLE
388 race condition occurs when adding folder to shared items in shares and errors out

### DIFF
--- a/backend/dataall/tasks/data_sharing/share_managers/s3_share_manager.py
+++ b/backend/dataall/tasks/data_sharing/share_managers/s3_share_manager.py
@@ -196,7 +196,11 @@ class S3ShareManager:
             )
             access_point_arn = S3.create_bucket_access_point(self.source_account_id, self.source_environment.region, self.bucket_name, self.access_point_name)
             # Access point creation is slow
-            time.sleep(5)
+            while not S3.get_bucket_access_point_arn(self.source_account_id, self.source_environment.region, self.access_point_name):
+                logger.info(
+                    'Waiting 30s for access point creation to complete..'
+                )
+                time.sleep(30)
         existing_policy = S3.get_access_point_policy(self.source_account_id, self.source_environment.region, self.access_point_name)
         # requester will use this role to access resources
         target_requester_id = SessionHelper.get_role_id(self.target_account_id, self.target_requester_IAMRoleName)

--- a/tests/tasks/test_s3_share_manager.py
+++ b/tests/tasks/test_s3_share_manager.py
@@ -658,6 +658,11 @@ def test_manage_access_point_and_policy_1(
     )
 
     mocker.patch(
+        "dataall.aws.handlers.s3.S3.get_bucket_access_point_arn",
+        return_value="new-access-point-arn"
+    )
+
+    mocker.patch(
         "dataall.aws.handlers.s3.S3.get_access_point_policy",
         return_value=None,
     )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- The creation of S3 access points is asynchronous and can take more than 5 seconds to complete. When the share managers tries attaching the policy to the access points it fails in certain cases. This PR replaces the waiting time of 5 seconds for a while loop that checks that the access points has been created and if not it waits for 30s

### Relates
- #388 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
