### PR TITLE
frontend: simplify dev dockerfile

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+build
+

--- a/frontend/docker/dev/Dockerfile
+++ b/frontend/docker/dev/Dockerfile
@@ -1,38 +1,19 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/docker/library/node:18-slim
 
-ARG NODE_VERSION=16
-ARG NGINX_VERSION=1.12
-ARG NVM_VERSION=v0.37.0
+WORKDIR /app
 
-RUN yum update -y && \
-    yum install -y tar gzip openssl && \
-    yum clean all -y
-RUN amazon-linux-extras install nginx$NGINX_VERSION
+COPY package.json ./
+COPY yarn.lock ./
 
-RUN touch ~/.bashrc
+RUN yarn install
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
-RUN . ~/.nvm/nvm.sh && nvm install node
-RUN echo '. ~/.nvm/nvm.sh' >>  ~/.bashrc
+COPY ./docker/dev/.env .
+COPY . .
 
-RUN . ~/.nvm/nvm.sh && npm install -g npm yarn
+# Disable linting before starting the server
+ENV DISABLE_ESLINT_PLUGIN=true
 
-COPY package.json yarn.lock ./
+# Set the port to serve the application
+ENV PORT=80
 
-RUN . ~/.nvm/nvm.sh && yarn install
-
-ENV PATH="./node_modules/.bin:$PATH"
-
-COPY ./docker/dev/.env ./
-
-COPY ./docker/dev/nginx.config /etc/nginx/nginx.template
-
-RUN cp /etc/nginx/nginx.template /etc/nginx/nginx.conf
-
-COPY . ./
-
-RUN . ~/.nvm/nvm.sh && yarn build
-
-RUN cp -a build/. /usr/share/nginx/html/
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD yarn start


### PR DESCRIPTION
### Feature or Bug-fix
- Refactoring

### Detail
For the development dockerfile in the frontend, instead of starting from amazon linux image and installing everything manually, it's a lot simpler to start from node image (that is also from ECR for security) and have all node-related environment pre-installed and just focus the dockerfile on project-related configuration.

This PR does not introduce any update in the logic, it just updates the development dockerfile and adds a `.dockerignore` file for frontend to ignore `node_modules` and `build` folders.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
