### PR TITLE
Fix sharing update

### DIFF
--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -24,7 +24,7 @@ class LakeFormation:
             response = lf_client.describe_resource(ResourceArn=resource_arn)
 
             log.info(f'LF data location already registered: {response}, checking if data.all registered it ...')
-            if response['RoleArn'] == role_arn:
+            if response['ResourceInfo']['RoleArn'] == role_arn:
                 log.info(f'LF data location already registered, with {role_arn}. Registration was part of the dataset stack')
                 return False
             return response['ResourceInfo']

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -25,7 +25,7 @@ class LakeFormation:
 
             log.info(f'LF data location already registered: {response}, checking if data.all registered it ...')
             if response['ResourceInfo']['RoleArn'] == role_arn:
-                log.info(f'The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
+                log.info('The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
                 return False
             return response['ResourceInfo']
 

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -13,7 +13,7 @@ class LakeFormation:
         pass
 
     @staticmethod
-    def describe_resource(resource_arn, accountid, region):
+    def describe_resource(resource_arn, role_arn, accountid, region):
         """
         Describes a LF data location
         """
@@ -23,8 +23,10 @@ class LakeFormation:
 
             response = lf_client.describe_resource(ResourceArn=resource_arn)
 
-            log.info(f'LF data location already registered: {response}')
-
+            log.info(f'LF data location already registered: {response}, checking if data.all registered it ...')
+            if response['RoleArn'] == role_arn:
+                log.info(f'LF data location already registered, with {role_arn}. Registration was part of the dataset stack')
+                return False
             return response['ResourceInfo']
 
         except ClientError as e:

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -25,7 +25,7 @@ class LakeFormation:
 
             log.info(f'LF data location already registered: {response}, checking if data.all registered it ...')
             if response['ResourceInfo']['RoleArn'] == role_arn:
-                log.info(f'LF data location already registered, with {role_arn}. Registration was part of the dataset stack')
+                log.info(f'The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
                 return False
             return response['ResourceInfo']
 

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -417,6 +417,7 @@ class Dataset(Stack):
 
         existing_location = LakeFormation.describe_resource(
             resource_arn=f'arn:aws:s3:::{dataset.S3BucketName}',
+            role_arn=f'arn:aws:iam::{env.AwsAccountId}:role/{pivot_role_name}',
             accountid=env.AwsAccountId,
             region=env.region
         )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
When we import a dataset stack, if the S3 location was already registered data.all does not create a storage location. The issue is that for datasets where data.all needs to create a storage location:
1. the first time that it creates the stack it detects that there is no storage location and it creates the corresponding CFN resource
2. the first time that it UPDATES the stack it detects the storage location from 1. and it deletes the CFN resource
3. the next time that it UPDATES the stack it does not detect any storage location (it was deleted in 2.) and it creates the CFN resource again. 

To fix this behavior, in V1.5 we will use Lambda custom resource to check the storage location and avoid CFN resources. But for previous versions, this PR includes:
- in the method that checks the existence of an storage location, we filter by the roleArn of the location. If the roleArn is the `dataallPivotRole` then we assume that it was created by the dataset, which means that `existing_storage_location = False`

I tested locally but with actual stacks being created. No additional policies are needed

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
