### PR TITLE
ignore styling commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Enforce frontend styling and remove dead code
+fefc45c2cdc4d3107369c4d70210894d098a775c


### PR DESCRIPTION
### Feature or Bug-fix
- Refactoring

### Detail
My recent PR https://github.com/awslabs/aws-dataall/pull/394 has a lot of changes but all of these changes are to styles only and not the code itself, this way the blame history for all the changed files is lost (it will always blame me).

This PR adds the file`.git-blame-ignore-revs` which contains the id of the styling commit and the command that you need to run once to fix the blame history for you.

Also Github understands that file and will show the history correctly.

This PR is based on [this article](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/) and is suggested by Raul.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
