### PR TITLE
Added value returned when working with locally with Docker

### DIFF
--- a/backend/dataall/aws/handlers/sts.py
+++ b/backend/dataall/aws/handlers/sts.py
@@ -99,7 +99,7 @@ class SessionHelper:
         """
         return SessionHelper.get_secret(
             secret_name=f'dataall-externalId-{os.getenv("envname", "local")}'
-        )
+        ) or 'localNoExternalId'
 
     @classmethod
     def get_delegation_role_name(cls):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
When running docker compose in graphql we always get the error "secret not found" for the externalId secret.

### Detail
#### Alternative 1 (implemented in the PR)
- Added return value for when a secret externalId is not found - for dkrcompose.
- linked environments need to create a pivotRole whose trust policy does not include externalId condition

Pros: does not need a deployment of data.all

#### Alternative 2
- Manually create a secret called dataall-externalId-dkrcompose --> add documentation in GitHub pages
- linked environments work with a pivotRole whose trust policy includes the externalId condition

Pros: No changes in the pre-reqs of linking an environment

#### Alternative 3
- Automatic creation of a secret called dataall-externalId-dkrcompose, as part of the backend stack
- linked environments work with a pivotRole whose trust policy includes the externalId condition

Pros: No changes in the pre-reqs of linking an environment. No manual steps.
Cons: additional secrets

### Conclusion
Alternative 1 can be implemented in conjunction with 2/3. I will document alternative 2 in gh-pages and 3 can be considered for next steps.

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
