### PR TITLE
Fix issue with duplicate resources - backwards compatibility

### DIFF
--- a/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
+++ b/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
@@ -42,7 +42,7 @@ class SageMakerDomain(NestedStack):
             )
             dataall_created_domain = ParameterStoreManager.client(
                 AwsAccountId=environment.AwsAccountId, region=environment.region, role=cdk_look_up_role_arn
-            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domainId')
+            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id')
             return False
         except ClientError as e:
             logger.info(f'check sagemaker studio domain created outside of data.all. Parameter data.all not found: {e}')
@@ -62,7 +62,7 @@ class SageMakerDomain(NestedStack):
                 self,
                 'RoleForSagemakerStudioUsers',
                 assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
-                role_name='RoleForSagemakerStudioUsers',
+                role_name='RoleSagemakerStudioUsers',
                 managed_policies=[
                     iam.ManagedPolicy.from_managed_policy_arn(
                         self,
@@ -117,7 +117,7 @@ class SageMakerDomain(NestedStack):
                 self,
                 'SagemakerStudioDomainId',
                 string_value=sagemaker_domain.attr_domain_id,
-                parameter_name=f'/dataall/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domainId',
+                parameter_name=f'/dataall/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
             )
 
 

--- a/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
+++ b/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
@@ -1,7 +1,5 @@
 import logging
 import os
-import pathlib
-from constructs import Construct
 from aws_cdk import (
     cloudformation_include as cfn_inc,
     Stack

--- a/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
+++ b/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
@@ -4,121 +4,16 @@ import pathlib
 from constructs import Construct
 from aws_cdk import (
     cloudformation_include as cfn_inc,
-    aws_ec2 as ec2,
-    aws_iam as iam,
-    aws_kms as kms,
-    aws_lambda as _lambda,
-    aws_sagemaker as sagemaker,
-    aws_ssm as ssm,
-    CustomResource,
-    Duration,
-    NestedStack,
     Stack
 )
-from botocore.exceptions import ClientError
 from .manager import stack
 from ... import db
 from ...db import models
 from ...db.api import Environment
-from ...aws.handlers.parameter_store import ParameterStoreManager
-from ...aws.handlers.sts import SessionHelper
-from ...aws.handlers.sagemaker_studio import (
-    SagemakerStudio,
-)
 from ...utils.cdk_nag_utils import CDKNagUtil
 from ...utils.runtime_stacks_tagging import TagsUtil
 
 logger = logging.getLogger(__name__)
-
-
-class SageMakerDomain(NestedStack):
-
-    def check_existing_sagemaker_studio_domain(self, environment: models.Environment):
-        logger.info('Check if there is an existing sagemaker studio domain in the account')
-        try:
-            logger.info('check sagemaker studio domain created as part of data.all environment stack.')
-            cdk_look_up_role_arn = SessionHelper.get_cdk_look_up_role_arn(
-                accountid=environment.AwsAccountId, region=environment.region
-            )
-            dataall_created_domain = ParameterStoreManager.client(
-                AwsAccountId=environment.AwsAccountId, region=environment.region, role=cdk_look_up_role_arn
-            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id')
-            return False
-        except ClientError as e:
-            logger.info(f'check sagemaker studio domain created outside of data.all. Parameter data.all not found: {e}')
-            existing_domain = SagemakerStudio.get_sagemaker_studio_domain(
-                AwsAccountId=environment.AwsAccountId, region=environment.region, role=cdk_look_up_role_arn
-            )
-            return existing_domain.get('DomainId', False)
-
-    def __init__(self, scope: Construct, construct_id: str, environment: models.Environment, sagemaker_principals, vpc_id, subnet_ids, **kwargs) -> None:
-        super().__init__(scope, construct_id, **kwargs)
-
-        self._environment = environment
-        self.existing_sagemaker_domain = self.check_existing_sagemaker_studio_domain(environment=self._environment)
-
-        if self._environment.mlStudiosEnabled and not self.existing_sagemaker_domain:
-            sagemaker_domain_role = iam.Role(
-                self,
-                'RoleForSagemakerStudioUsers',
-                assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
-                role_name='RoleSagemakerStudioUsers',
-                managed_policies=[
-                    iam.ManagedPolicy.from_managed_policy_arn(
-                        self,
-                        id='SagemakerFullAccess',
-                        managed_policy_arn='arn:aws:iam::aws:policy/AmazonSageMakerFullAccess',
-                    ),
-                    iam.ManagedPolicy.from_managed_policy_arn(
-                        self, id='S3FullAccess', managed_policy_arn='arn:aws:iam::aws:policy/AmazonS3FullAccess'
-                    ),
-                ],
-            )
-
-            sagemaker_domain_key = kms.Key(
-                self,
-                'SagemakerDomainKmsKey',
-                alias='SagemakerStudioDomain',
-                enable_key_rotation=True,
-                policy=iam.PolicyDocument(
-                    assign_sids=True,
-                    statements=[
-                        iam.PolicyStatement(
-                            resources=['*'],
-                            effect=iam.Effect.ALLOW,
-                            principals=[iam.AccountPrincipal(account_id=self._environment.AwsAccountId), sagemaker_domain_role] + sagemaker_principals,
-                            actions=['kms:*'],
-                        )
-                    ],
-                ),
-            )
-
-            sagemaker_domain = sagemaker.CfnDomain(
-                self,
-                'SagemakerStudioDomain',
-                domain_name=f'SagemakerStudioDomain-{self._environment.region}-{self._environment.AwsAccountId}',
-                auth_mode='IAM',
-                default_user_settings=sagemaker.CfnDomain.UserSettingsProperty(
-                    execution_role=sagemaker_domain_role.role_arn,
-                    security_groups=[],
-                    sharing_settings=sagemaker.CfnDomain.SharingSettingsProperty(
-                        notebook_output_option='Allowed',
-                        s3_kms_key_id=sagemaker_domain_key.key_id,
-                        s3_output_path=f's3://sagemaker-{self._environment.region}-{self._environment.AwsAccountId}',
-                    ),
-                ),
-                vpc_id=vpc_id,
-                subnet_ids=subnet_ids,
-                app_network_access_type='VpcOnly',
-                kms_key_id=sagemaker_domain_key.key_id,
-            )
-
-            ssm.StringParameter(
-                self,
-                'SagemakerStudioDomainId',
-                string_value=sagemaker_domain.attr_domain_id,
-                parameter_name=f'/dataall/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
-            )
 
 
 @stack(stack='sagemakerstudiouserprofile')

--- a/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
+++ b/backend/dataall/cdkproxy/stacks/sagemakerstudio.py
@@ -42,7 +42,7 @@ class SageMakerDomain(NestedStack):
             )
             dataall_created_domain = ParameterStoreManager.client(
                 AwsAccountId=environment.AwsAccountId, region=environment.region, role=cdk_look_up_role_arn
-            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id')
+            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domainId')
             return False
         except ClientError as e:
             logger.info(f'check sagemaker studio domain created outside of data.all. Parameter data.all not found: {e}')
@@ -62,7 +62,7 @@ class SageMakerDomain(NestedStack):
                 self,
                 'RoleForSagemakerStudioUsers',
                 assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
-                role_name='RoleSagemakerStudioUsers',
+                role_name='RoleForSagemakerStudioUsers',
                 managed_policies=[
                     iam.ManagedPolicy.from_managed_policy_arn(
                         self,
@@ -117,7 +117,7 @@ class SageMakerDomain(NestedStack):
                 self,
                 'SagemakerStudioDomainId',
                 string_value=sagemaker_domain.attr_domain_id,
-                parameter_name=f'/dataall/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
+                parameter_name=f'/dataall/{self._environment.environmentUri}/sagemaker/sagemakerstudio/domainId',
             )
 
 

--- a/tests/cdkproxy/test_environment_stack.py
+++ b/tests/cdkproxy/test_environment_stack.py
@@ -29,7 +29,7 @@ def patch_methods(mocker, db, env, another_group, permissions):
         return_value=[another_group],
     )
     mocker.patch(
-        'dataall.cdkproxy.stacks.sagemakerstudio.SageMakerDomain.check_existing_sagemaker_studio_domain',
+        'dataall.cdkproxy.stacks.environment.EnvironmentSetup.check_existing_sagemaker_studio_domain',
         return_value=True,
     )
     mocker.patch(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- In v1.5.0 SageMaker Studio base infra is moved out in a nested stack. As a consequence sometimes there are conflicts with already existing AWS resources that the nested stack is trying to re-create. But the issue is bigger than that, the new nested stack would create a new Sagemaker domain and delete the previous one. If there are existing Sagemaker studio users this results in errors because it cannot delete a domain with existing users. We have 2 alternatives: 1) migrate existing users to the new profile 2) revert the changes and put the Sagemaker resources inside the environment stack, this will keep the previous resources.

Alternative 1 is quite complex (and I am not sure it is even possible). The benefit that it brings, which is "logical separation of environment-module resources" is not worth the effort.


### Relates
#409 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
