### PR TITLE
Fixed unresolved reference for ShareObjectPermission

### DIFF
--- a/backend/dataall/api/Objects/ShareObject/resolvers.py
+++ b/backend/dataall/api/Objects/ShareObject/resolvers.py
@@ -231,16 +231,6 @@ def resolve_user_role(context: Context, source: models.ShareObject, **kwargs):
             or dataset.SamlAdminGroupName in context.groups
         ):
             return ShareObjectPermission.Requesters.value
-        if (
-            dataset and dataset.stewards in context.groups
-            and (
-                source.owner == context.username
-                or source.principalId in context.groups
-                or dataset.owner == context.username
-                or dataset.SamlAdminGroupName in context.groups
-            )
-        ):
-            return ShareObjectPermission.Approvers.value
         else:
             return ShareObjectPermission.NoPermission.value
 

--- a/backend/dataall/api/Objects/ShareObject/resolvers.py
+++ b/backend/dataall/api/Objects/ShareObject/resolvers.py
@@ -222,13 +222,15 @@ def resolve_user_role(context: Context, source: models.ShareObject, **kwargs):
         return None
     with context.engine.scoped_session() as session:
         dataset: models.Dataset = db.api.Dataset.get_dataset_by_uri(session, source.datasetUri)
-        if dataset and dataset.stewards in context.groups:
-            return ShareObjectPermission.Approvers.value
-        if (
-            source.owner == context.username
-            or source.principalId in context.groups
+        if dataset and (
+            dataset.stewards in context.groups
             or dataset.owner == context.username
             or dataset.SamlAdminGroupName in context.groups
+        ):
+            return ShareObjectPermission.Approvers.value
+        if dataset and (
+            source.owner == context.username
+            or source.principalId in context.groups
         ):
             return ShareObjectPermission.Requesters.value
         else:

--- a/backend/dataall/api/Objects/ShareObject/resolvers.py
+++ b/backend/dataall/api/Objects/ShareObject/resolvers.py
@@ -240,7 +240,7 @@ def resolve_user_role(context: Context, source: models.ShareObject, **kwargs):
                 or dataset.SamlAdminGroupName in context.groups
             )
         ):
-            return ShareObjectPermission.ApproversAndRequesters.value
+            return ShareObjectPermission.Approvers.value
         else:
             return ShareObjectPermission.NoPermission.value
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Working on datasets, I found that there was no `ApproversAndRequesters` value in `ShareObjectPermission`. Whenever the code reaches this point there will be an error. 

I added the other value to avoid an exception. But this is just for awareness.
We might need to add `ApproversAndRequesters` to `ShareObjectPermission`
I also considered that It might be dead code that we could delete.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
