### PR TITLE
Rename glue-handler to previous name to avoid CloudFormation unexpected deletions

### DIFF
--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -356,7 +356,7 @@ class Dataset(Stack):
 
         glue_db = CustomResource(
             self,
-            f'{env.resourcePrefix}DatabaseCustomResource',
+            f'{env.resourcePrefix}DatasetDatabase',
             service_token=glue_db_provider_service_token.string_value,
             resource_type='Custom::GlueDatabase',
             properties={
@@ -372,8 +372,6 @@ class Dataset(Stack):
                 'DatabaseAdministrators': dataset_admins
             },
         )
-
-        # Support resources: GlueCrawler for the dataset, Profiling Job and Trigger
 
         # Support resources: GlueCrawler for the dataset, Profiling Job and Trigger
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Giving a more descriptive name to the logical ID of the glue-handler custom resource results in CloudFormation recreating it. That means that CFN:
1) creates new custom resource and tries to create db and grant permissions (db already exists, so it skips)
2) deletes old custom resource and in this action it deleted the db --> we cannot allow this as it is removing the database and tables from Glue which will break our sharing and LF permissions

### Relates
- #409 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
