### PR TITLE
Fix handlers v1m5m0 + documentation

### DIFF
--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from .sts import SessionHelper
 
 log = logging.getLogger('aws:lakeformation')
-
+PIVOT_ROLE_NAME_PREFIX = "datallPivotRole"
 
 class LakeFormation:
     def __init__(self):
@@ -25,7 +25,7 @@ class LakeFormation:
             registered_role_name = response['ResourceInfo']['RoleArn'].lstrip(f"arn:aws:iam::{accountid}:role/")
             pivot_role_name = SessionHelper.get_delegation_role_name()
             log.info(f'LF data location already registered: {response}, registered with role {registered_role_name}')
-            if registered_role_name[:11] == pivot_role_name[:11]:
+            if registered_role_name[:14] == PIVOT_ROLE_NAME_PREFIX:
                 log.info('The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
                 return False
             return response['ResourceInfo']

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -13,18 +13,18 @@ class LakeFormation:
         pass
 
     @staticmethod
-    def describe_resource(resource_arn, role_arn, accountid, region):
+    def check_existing_lf_registered_location(resource_arn, accountid, region):
         """
         Describes a LF data location
         """
         try:
             session = SessionHelper.remote_session(accountid)
             lf_client = session.client('lakeformation', region_name=region)
-
             response = lf_client.describe_resource(ResourceArn=resource_arn)
-
-            log.info(f'LF data location already registered: {response}, checking if data.all registered it ...')
-            if response['ResourceInfo']['RoleArn'] == role_arn:
+            registered_role_name = response['ResourceInfo']['RoleArn'].lstrip(f"arn:aws:iam::{accountid}:role/")
+            pivot_role_name = SessionHelper.get_delegation_role_name()
+            log.info(f'LF data location already registered: {response}, registered with role {registered_role_name}')
+            if registered_role_name[:11] == pivot_role_name[:11]:
                 log.info('The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
                 return False
             return response['ResourceInfo']

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -23,9 +23,8 @@ class LakeFormation:
             lf_client = session.client('lakeformation', region_name=region)
             response = lf_client.describe_resource(ResourceArn=resource_arn)
             registered_role_name = response['ResourceInfo']['RoleArn'].lstrip(f"arn:aws:iam::{accountid}:role/")
-            pivot_role_name = SessionHelper.get_delegation_role_name()
             log.info(f'LF data location already registered: {response}, registered with role {registered_role_name}')
-            if registered_role_name[:14] == PIVOT_ROLE_NAME_PREFIX:
+            if registered_role_name.startswith(PIVOT_ROLE_NAME_PREFIX):
                 log.info('The existing data location was created as part of the dataset stack. There was no pre-existing data location.')
                 return False
             return response['ResourceInfo']

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -15,7 +15,8 @@ class LakeFormation:
     @staticmethod
     def check_existing_lf_registered_location(resource_arn, accountid, region):
         """
-        Describes a LF data location
+        Checks if there is a non-dataall-created registered location for the Dataset
+        Returns False is already existing location else return the resource info
         """
         try:
             session = SessionHelper.remote_session(accountid)
@@ -30,9 +31,7 @@ class LakeFormation:
             return response['ResourceInfo']
 
         except ClientError as e:
-            log.info(
-                f'LF data location for resource {resource_arn} not found due to {e}'
-            )
+            log.info(f'LF data location for resource {resource_arn} not found due to {e}')
             return False
 
     @staticmethod

--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource_nodelete/__init__.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource_nodelete/__init__.py
@@ -1,0 +1,1 @@
+from .index import *

--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource_nodelete/index.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource_nodelete/index.py
@@ -1,0 +1,118 @@
+import os
+import json
+import boto3
+from botocore.exceptions import ClientError
+import uuid
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+log = logging.getLogger(__name__)
+
+AWS_ACCOUNT = os.environ.get('AWS_ACCOUNT')
+AWS_REGION = os.environ.get('AWS_REGION')
+DEFAULT_ENV_ROLE_ARN = os.environ.get('DEFAULT_ENV_ROLE_ARN')
+DEFAULT_CDK_ROLE_ARN = os.environ.get('DEFAULT_CDK_ROLE_ARN')
+
+glue_client = boto3.client('glue', region_name=AWS_REGION)
+lf_client = boto3.client('lakeformation', region_name=AWS_REGION)
+
+
+def clean_props(**props):
+    data = {k: props[k] for k in props.keys() if k != 'ServiceToken'}
+    return data
+
+
+def on_event(event, context):
+
+    request_type = event['RequestType']
+    if request_type == 'Create':
+        return on_create(event)
+    if request_type == 'Update':
+        return on_update(event)
+    if request_type == 'Delete':
+        return on_delete(event)
+    raise Exception('Invalid request type: %s' % request_type)
+
+
+def on_create(event):
+    """Creates if it does not exist Glue database for the data.all Dataset
+    Grants permissions to Database Administrators = dataset Admin team IAM role, pivotRole, dataset IAM role
+    """
+    props = clean_props(**event['ResourceProperties'])
+    log.info('Create new resource with props %s' % props)
+
+    exists = False
+    try:
+        glue_client.get_database(Name=props['DatabaseInput']['Name'])
+        exists = True
+    except ClientError as e:
+        pass
+
+    if not exists:
+        try:
+            response = glue_client.create_database(
+                CatalogId=props.get('CatalogId'),
+                DatabaseInput=props.get('DatabaseInput'),
+            )
+        except ClientError as e:
+            log.exception(f"Could not create Glue Database {props['DatabaseInput']['Name']} in aws://{AWS_ACCOUNT}/{AWS_REGION}, received {str(e)}")
+            raise Exception(f"Could not create Glue Database {props['DatabaseInput']['Name']} in aws://{AWS_ACCOUNT}/{AWS_REGION}, received {str(e)}")
+
+    Entries = []
+    for i, role_arn in enumerate(props.get('DatabaseAdministrators')):
+        Entries.append(
+            {
+                'Id': str(uuid.uuid4()),
+                'Principal': {'DataLakePrincipalIdentifier': role_arn},
+                'Resource': {
+                    'Database': {
+                        # 'CatalogId': AWS_ACCOUNT,
+                        'Name': props['DatabaseInput']['Name']
+                    }
+                },
+                'Permissions': [
+                    'Alter'.upper(),
+                    'Create_table'.upper(),
+                    'Drop'.upper(),
+                    'Describe'.upper(),
+                ],
+                'PermissionsWithGrantOption': [
+                    'Alter'.upper(),
+                    'Create_table'.upper(),
+                    'Drop'.upper(),
+                    'Describe'.upper(),
+                ],
+            }
+        )
+        Entries.append(
+            {
+                'Id': str(uuid.uuid4()),
+                'Principal': {'DataLakePrincipalIdentifier': role_arn},
+                'Resource': {
+                    'Table': {
+                        'DatabaseName': props['DatabaseInput']['Name'],
+                        'TableWildcard': {},
+                        'CatalogId': props.get('CatalogId'),
+                    }
+                },
+                'Permissions': ['SELECT', 'ALTER', 'DESCRIBE'],
+                'PermissionsWithGrantOption': ['SELECT', 'ALTER', 'DESCRIBE'],
+            }
+        )
+    lf_client.batch_grant_permissions(CatalogId=props['CatalogId'], Entries=Entries)
+    physical_id = props['DatabaseInput']['Name']
+
+    return {'PhysicalResourceId': physical_id}
+
+
+def on_update(event):
+    return on_create(event)
+
+
+def on_delete(event):
+    """ Does not Delete the created Glue database.
+    This is a risky action which would be done manually by customers
+    """
+    physical_id = event['PhysicalResourceId']
+    log.info('Keeping resources %s' % physical_id)

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -17,12 +17,10 @@ from aws_cdk import (
     Tags,
 )
 from aws_cdk.aws_glue import CfnCrawler
-from botocore.exceptions import ClientError
 
 from .manager import stack
 from ... import db
 from ...aws.handlers.lakeformation import LakeFormation
-from ...aws.handlers.parameter_store import ParameterStoreManager
 from ...aws.handlers.quicksight import Quicksight
 from ...aws.handlers.sts import SessionHelper
 from ...db import models
@@ -31,6 +29,7 @@ from ...utils.cdk_nag_utils import CDKNagUtil
 from ...utils.runtime_stacks_tagging import TagsUtil
 
 logger = logging.getLogger(__name__)
+
 
 @stack(stack='dataset')
 class Dataset(Stack):
@@ -355,7 +354,6 @@ class Dataset(Stack):
         # )
 
         # Define dataset admin groups (those with data access grant)
-
         dataset_admins = [
             dataset_admin_role.role_arn,
             f'arn:aws:iam::{env.AwsAccountId}:role/{self.pivot_role_name}',

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -162,14 +162,6 @@ class Dataset(Stack):
                 bucket_key_enabled=True,
             )
 
-            # dataset_bucket.add_to_resource_policy(
-            #     permission=iam.PolicyStatement(
-            #         actions=['s3:*'],
-            #         resources=[dataset_bucket.bucket_arn],
-            #         principals=[iam.AccountPrincipal(account_id=dataset.AwsAccountId)],
-            #     )
-            # )
-
             dataset_bucket.add_lifecycle_rule(
                 abort_incomplete_multipart_upload_after=Duration.days(7),
                 noncurrent_version_transitions=[
@@ -332,27 +324,6 @@ class Dataset(Stack):
                 },
             )
 
-        # Using a custom resource instead of Cfn resource just because it causes Cfn issues when handling upgrades of pivotRole
-        # Get the Provider service token from SSM, the Lambda and Provider are created as part of the environment stack
-
-        # datalake_location_service_token = ssm.StringParameter.from_string_parameter_name(
-        #     self,
-        #     'DataLocationHandlerProviderServiceToken',
-        #     string_parameter_name=f'/dataall/{dataset.environmentUri}/cfn/custom-resources/datalocationhandler/provider/servicetoken',
-        # )
-        #
-        # datalake_location = CustomResource(
-        #     self,
-        #     f'{env.resourcePrefix}DatalakeLocationCustomResource',
-        #     service_token=datalake_location_service_token.string_value,
-        #     resource_type='Custom::DataLakeLocation',
-        #     properties={
-        #         "ResourceArn": f"arn:aws:s3:::{dataset.S3BucketName}",
-        #         "UseServiceLinkedRole": False,
-        #         "RoleArn": f"arn:aws:iam::{env.AwsAccountId}:role/{self.pivot_role_name}"
-        #     },
-        # )
-
         # Define dataset admin groups (those with data access grant)
         dataset_admins = [
             dataset_admin_role.role_arn,
@@ -428,7 +399,6 @@ class Dataset(Stack):
         )
 
         # Support resources: GlueCrawler for the dataset, Profiling Job and Trigger
-
         crawler = glue.CfnCrawler(
             self,
             dataset.GlueCrawlerName,

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -356,7 +356,7 @@ class Dataset(Stack):
 
         glue_db = CustomResource(
             self,
-            f'{env.resourcePrefix}DatabaseCustomResource',
+            f'{env.resourcePrefix}DatasetDatabase',
             service_token=glue_db_provider_service_token.string_value,
             resource_type='Custom::GlueDatabase',
             properties={
@@ -372,8 +372,6 @@ class Dataset(Stack):
                 'DatabaseAdministrators': dataset_admins
             },
         )
-
-        # Support resources: GlueCrawler for the dataset, Profiling Job and Trigger
 
         # Support resources: GlueCrawler for the dataset, Profiling Job and Trigger
 

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -367,7 +367,7 @@ class Dataset(Stack):
         glue_db_handler_arn = ssm.StringParameter.from_string_parameter_name(
             self,
             'GlueDbCRArnParameter',
-            string_parameter_name=f'/dataall/{dataset.environmentUri}/cfn/custom-resources/gluehandler/lambda/arn'',
+            string_parameter_name=f'/dataall/{dataset.environmentUri}/cfn/custom-resources/lambda/arn',
         )
 
         glue_db_handler = _lambda.Function.from_function_attributes(
@@ -400,7 +400,6 @@ class Dataset(Stack):
                 'DatabaseAdministrators': dataset_admins,
             },
         )
-
 
         # Get the Provider service token from SSM, the Lambda and Provider are created as part of the environment stack
         glue_db_provider_service_token = ssm.StringParameter.from_string_parameter_name(

--- a/documentation/userguide/docs/environments.md
+++ b/documentation/userguide/docs/environments.md
@@ -105,6 +105,27 @@ to enable Dashboard Embedding on <span style="color:grey">*data.all*</span> UI. 
 
 ![quicksight_domain](pictures/environments/boot_qs_3.png#zoom#shadow)
 
+### 5. (For ML Studio) Delete or adapt the default VPC
+If ML Studio is enabled, data.all checks if there is an existing SageMaker Studio domain. If there is an existing domain
+it will use it to create ML Studio profiles. If no pre-existing domain is found, data.all will create a new one.
+
+Prior to V1.5.0 data.all always used the default VPC to create a new SageMaker domain. The default VPC had then to be
+customized to fulfill the networking requirements specified in the Sagemaker
+[documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-notebooks-and-internet-access.html) for VPCOnly 
+domains.
+
+In V1.5.0 we introduce the creation of a suitable VPC for SageMaker as part of the environment stack. However, it is not possible to edit the VPC used by a SageMaker domain, it requires deletion and re-creation. To allow backwards
+compatibility and not delete the pre-existing domains, in V1.5.0 the default behavior is still to use the default VPC.
+
+Data.all will create a SageMaker VPC:
+- For new environments: (link environment)
+  - if there is not a pre-existing SageMaker Studio domain
+  - if there is not a default VPC in the account
+- For pre-existing environments: (update environment)
+  - if all ML Studio profiles have been deleted (from CloudFormation as well)
+  - if there is not a pre-existing SageMaker Studio domain
+  - if the default VPC has been deleted in the account
+
 ## :material-new-box: **Link an environment**
 ### Necessary permissions
 !!! note "Environment permissions"

--- a/documentation/userguide/docs/mlstudio.md
+++ b/documentation/userguide/docs/mlstudio.md
@@ -1,18 +1,19 @@
 # **ML Studio**
-With ML Studio Notebooks we can add users to our SageMaker domain and open Amazon SageMaker Studio
+With ML Studio Profiles we can add users to our SageMaker domain and open Amazon SageMaker Studio.
+The SageMaker Studio domain is created as part of the environment stack. 
 
 
-## :material-new-box: **Create a ML Notebook**
-To create a new Notebook, go to ML Studio on the left side pane and click on Create. Then fill in the creation form
+## :material-new-box: **Create an ML Studio profile**
+To create a new ML Studio profile, go to ML Studio on the left side pane and click on Create. Then fill in the creation form
 with its corresponding information.
 
-![notebooks](pictures/mlstudio/ml_studio.png#zoom#shadow)
+![notebooks](pictures/mlstudio/ml_studio.png)
 
 
 | Field                         | Description                                 | Required | Editable |Example
 |-------------------------------|---------------------------------------------|----------|----------|-------------
 | Sagemaker Studio profile name | Name of the user to add to SageMaker domain | Yes      | No       |johndoe
-| Short description             | Short description about the notebook        | No       | No       |Notebook for Cannes exploration
+| Short description             | Short description about the user profile    | No       | No       |Notebook for Cannes exploration
 | Tags                          | Tags                                        | No       | No       |deleteme
 | Environment                   | Environment (and mapped AWS account)        | Yes      | No       |Data Science
 | Region (auto-filled)          | AWS region                                  | Yes      | No       |Europe (Ireland)
@@ -22,19 +23,19 @@ with its corresponding information.
 
 
 ## :material-cloud-check-outline: **Check CloudFormation stack**
-In the **Stack** tab of the ML Studio Notebook, is where we check the AWS resources provisioned by data.all as well as its status.
+In the **Stack** tab of the ML Studio Profile, is where we check the AWS resources provisioned by data.all as well as its status.
 As part of the CloudFormation stack deployed using CDK, data.all will deploy some CDK metadata and a SageMaker User Profile.
 
 
-## :material-trash-can-outline: **Delete a Notebook**
+## :material-trash-can-outline: **Delete an ML Studio user**
 
-To delete a Notebook, simply select it and click on the **Delete** button in the top right corner. It is possible to
-keep the CloudFormation stack associated with the Notebook by selecting this option in the confirmation
+To delete a SageMaker user, simply select it and click on the **Delete** button in the top right corner. It is possible to
+keep the CloudFormation stack associated with the User by selecting this option in the confirmation
 delete window that appears after clicking on delete.
 
-![notebooks](pictures/mlstudio/ml_studio_3.png#zoom#shadow)
+![notebooks](pictures/mlstudio/ml_studio_3.png)
 
 ## :material-file-code-outline: **Open Amazon SageMaker Studio**
 Click on the **Open ML Studio** button of the ML Studio notebook window to open Amazon SageMaker Studio.
 
-![notebooks](pictures/mlstudio/ml_studio_2.png#zoom#shadow)
+![notebooks](pictures/mlstudio/ml_studio_2.png)

--- a/tests/cdkproxy/test_dataset_stack.py
+++ b/tests/cdkproxy/test_dataset_stack.py
@@ -17,7 +17,7 @@ def patch_methods(mocker, db, dataset, env, org):
         return_value="dataall-pivot-role-name-pytest",
     )
     mocker.patch(
-        'dataall.aws.handlers.lakeformation.LakeFormation.describe_resource',
+        'dataall.aws.handlers.lakeformation.LakeFormation.check_existing_lf_registered_location',
         return_value=False,
     )
     mocker.patch(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Detail
- Reverted LakeFormation registering location to a CloudFormation resource instead of using a custom resource. There was a bug on the CloudFormation LakeFormation resource and a storage location could not be updated. The bug has been fixed and we can now update the LakeFormation resources (which was needed to update from PivotRole to PivotRole-cdk)
- Readded the original custom resource that creates the dataset Glue database and grants permissions in Lake Formation. We wanted to replace the custom resource service token because it was causing Lambda policies to reach their maximum size; but it is not possible to update the service token of a custom resource, one has to recreate it. The issue is that when we directly replace the custom resource it deletes the database (on_delete) when the CloudFormation stack cleans up the resources. Deleting the Glue database does not delete the S3 data, but it deletes all Lake Formation permissions, which is critical for production use-cases. We cannot introduce this risk, so we have updated the old custom resource Lambda to not delete anything on the on_delete event and we will leave the deprecated custom resource until the next minor release where we will safely remove it from the dataset stack. In V1.6.0 we will ensure to notify that upgrading to V1.5.0 is a requirement before upgrading to V1.6.0.
- Added documentation for ML Studio networking requirements and new features
- Added UserGuide as pdf for V1.5.0

### Relates
- #409 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
