### PR TITLE
solve deployment bug #433 CloudFront logs does not enable ACL access

### DIFF
--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -226,6 +226,7 @@ class CloudfrontDistro(pyNestedClass):
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             enforce_ssl=True,
             versioned=True,
+            object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
         )
 
         frontend_alternate_domain = None
@@ -240,6 +241,7 @@ class CloudfrontDistro(pyNestedClass):
             removal_policy=RemovalPolicy.DESTROY,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             enforce_ssl=True,
+            object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
         )
 
         origin_access_identity = cloudfront.OriginAccessIdentity(
@@ -545,6 +547,7 @@ class CloudfrontDistro(pyNestedClass):
             removal_policy=RemovalPolicy.DESTROY,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             enforce_ssl=True,
+            object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
         )
 
         origin_access_identity = cloudfront.OriginAccessIdentity(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Solved bug 433, starting from April 2023 S3 default configurations changed, the default for s3 is set to disable ACL. Which is giving an issue for cloudfront logging on s3. The solution was to change the ownership of the object to object writer (enabling ACL for object writer as stated in cloudfront documentation).

### Relates
[- <URL or Ticket>](https://github.com/awslabs/aws-dataall/issues/433)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
