### PR TITLE
Modify docker-compose yaml to read region and default region from env…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,8 @@ services:
       - db
     environment:
       envname: 'dkrcompose'
-      AWS_DEFAULT_REGION: "eu-west-1"
+      AWS_REGION: "${AWS_REGION}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
     volumes:
       - ./backend:/code
       - $HOME/.aws/credentials:/root/.aws/credentials:ro
@@ -36,7 +37,8 @@ services:
       - 5000:5000
     environment:
       envname: 'dkrcompose'
-      AWS_DEFAULT_REGION: "eu-west-1"
+      AWS_REGION: "${AWS_REGION}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
     volumes:
       - ./backend:/code
       - $HOME/.aws/credentials:/root/.aws/credentials:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
       - db
     environment:
       envname: 'dkrcompose'
-      AWS_REGION: "${AWS_REGION}"
-      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
+      AWS_REGION: "${AWS_REGION:-eu-west-1}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION:-eu-west-1}"
     volumes:
       - ./backend:/code
       - $HOME/.aws/credentials:/root/.aws/credentials:ro
@@ -37,8 +37,8 @@ services:
       - 5000:5000
     environment:
       envname: 'dkrcompose'
-      AWS_REGION: "${AWS_REGION}"
-      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
+      AWS_REGION: "${AWS_REGION:-eu-west-1}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION:-eu-west-1}"
     volumes:
       - ./backend:/code
       - $HOME/.aws/credentials:/root/.aws/credentials:ro


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Detail
Added `AWS_REGION` to the environment variables of the Docker containers for local development. Set both`AWS_DEFAULT_REGION` and `AWS_REGION` to their values set on the terminal where `docker-compose up` is run.
If these values are not set, `eu-west-1` is used as default
Another PR with better instructions to the github pages documentation (deploy locally) will follow.

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
