### PR TITLE
Move parameters from secrets manager to ssm

### DIFF
--- a/backend/dataall/api/Objects/Environment/resolvers.py
+++ b/backend/dataall/api/Objects/Environment/resolvers.py
@@ -731,6 +731,6 @@ def get_pivot_role_name(context: Context, source, organizationUri=None):
         if not pivot_role_name:
             raise exceptions.AWSResourceNotFound(
                 action='GET_PIVOT_ROLE_NAME',
-                message='Pivot role name could not be found on AWS Secretsmanager',
+                message='Pivot role name could not be found on AWS Systems Manager - Parameter Store',
             )
         return pivot_role_name

--- a/backend/dataall/aws/handlers/sts.py
+++ b/backend/dataall/aws/handlers/sts.py
@@ -66,24 +66,6 @@ class SessionHelper:
             return boto3.Session()
 
     @classmethod
-    def _get_secret(cls, secret_name):
-        """
-        Method to get secret_string from secrets manager
-        :return:
-        :rtype:
-        """
-        secret_string = None
-        region = os.getenv('AWS_REGION', 'eu-west-1')
-        try:
-            session = SessionHelper.get_session()
-            client = session.client('secretsmanager', region_name=region)
-            secret_string = client.get_secret_value(SecretId=secret_name).get('SecretString')
-            log.debug(f'Found Secret {secret_name}|{secret_string}')
-        except ClientError as e:
-            log.warning(f'Secret {secret_name} not found: {e}')
-        return secret_string
-
-    @classmethod
     def _get_parameter_value(cls, parameter_path=None):
         """
         Method to get parameter from System Manager Parameter Store
@@ -111,7 +93,6 @@ class SessionHelper:
         :return:
         :rtype:
         """
-        #return SessionHelper._get_secret(secret_name=f'dataall-externalId-{os.getenv("envname", "local")}')
         return SessionHelper._get_parameter_value(
             parameter_path=f'/dataall/{os.getenv("envname", "local")}/pivotRole/externalId')
 

--- a/backend/dataall/aws/handlers/sts.py
+++ b/backend/dataall/aws/handlers/sts.py
@@ -111,7 +111,9 @@ class SessionHelper:
         :return:
         :rtype:
         """
-        return SessionHelper._get_secret(secret_name=f'dataall-externalId-{os.getenv("envname", "local")}')
+        #return SessionHelper._get_secret(secret_name=f'dataall-externalId-{os.getenv("envname", "local")}')
+        return SessionHelper._get_parameter_value(
+            parameter_path=f'/dataall/{os.getenv("envname", "local")}/pivotRole/externalId')
 
     @classmethod
     def get_delegation_role_name(cls):
@@ -119,7 +121,8 @@ class SessionHelper:
         Returns:
             string: name of the assumed role
         """
-        return SessionHelper._get_parameter_value(parameter_path=f'/dataall/{os.getenv("envname", "local")}/pivotRole/pivotRoleName')
+        return SessionHelper._get_parameter_value(
+            parameter_path=f'/dataall/{os.getenv("envname", "local")}/pivotRole/pivotRoleName')
 
     @classmethod
     def get_console_access_url(cls, boto3_session, region='eu-west-1', bucket=None, redshiftcluster=None):

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -88,7 +88,6 @@ class BackendStack(Stack):
             envname=envname,
             resource_prefix=resource_prefix,
             enable_cw_canaries=enable_cw_canaries,
-            enable_pivot_role_auto_create=enable_pivot_role_auto_create,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -81,15 +81,14 @@ class BackendStack(Stack):
             pivot_role_name=self.pivot_role_name,
             **kwargs,
         )
-
-        SecretsManagerStack(
-            self,
-            f'Secrets',
-            envname=envname,
-            resource_prefix=resource_prefix,
-            enable_cw_canaries=enable_cw_canaries,
-            **kwargs,
-        )
+        if enable_cw_canaries:
+            SecretsManagerStack(
+                self,
+                f'Secrets',
+                envname=envname,
+                resource_prefix=resource_prefix,
+                **kwargs,
+            )
 
         s3_resources_stack = S3ResourcesStack(
             self,

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -88,6 +88,7 @@ class BackendStack(Stack):
             envname=envname,
             resource_prefix=resource_prefix,
             enable_cw_canaries=enable_cw_canaries,
+            enable_pivot_role_auto_create=enable_pivot_role_auto_create,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -78,6 +78,7 @@ class BackendStack(Stack):
             quicksight_enabled=quicksight_enabled,
             shared_dashboard_sessions=shared_dashboard_sessions,
             enable_pivot_role_auto_create=enable_pivot_role_auto_create,
+            pivot_role_name=self.pivot_role_name,
             **kwargs,
         )
 
@@ -87,7 +88,6 @@ class BackendStack(Stack):
             envname=envname,
             resource_prefix=resource_prefix,
             enable_cw_canaries=enable_cw_canaries,
-            pivot_role_name=self.pivot_role_name,
             **kwargs,
         )
 

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -17,6 +17,7 @@ class ParamStoreStack(pyNestedClass):
         quicksight_enabled=False,
         shared_dashboard_sessions='anonymous',
         enable_pivot_role_auto_create=False,
+        pivot_role_name='dataallPivotRole',
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -87,4 +88,12 @@ class ParamStoreStack(pyNestedClass):
             f'dataallCreationPivotRole{envname}',
             parameter_name=f"/dataall/{envname}/pivotRole/enablePivotRoleAutoCreate",
             string_value=str(enable_pivot_role_auto_create),
+        )
+
+        aws_ssm.StringParameter(
+            self,
+            f'dataallPivotRoleName{envname}',
+            parameter_name=f"/dataall/{envname}/pivotRole/pivotRoleName",
+            string_value=str(pivot_role_name),
+            description="Stores dataall pivot role name for environment dev",
         )

--- a/deploy/stacks/secrets_stack.py
+++ b/deploy/stacks/secrets_stack.py
@@ -18,6 +18,7 @@ class SecretsManagerStack(pyNestedClass):
         envname='dev',
         resource_prefix='dataall',
         enable_cw_canaries=False,
+        enable_pivot_role_auto_create=False,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -30,7 +31,7 @@ class SecretsManagerStack(pyNestedClass):
             removal_policy=RemovalPolicy.DESTROY,
         )
 
-        self.external_id_secret = sm.Secret(
+        external_id_secret = sm.Secret(
             self,
             f'ExternalIdSecret{envname}',
             secret_name=f'dataall-externalId-{envname}',
@@ -39,6 +40,11 @@ class SecretsManagerStack(pyNestedClass):
             description=f'Stores dataall external id for environment {envname}',
             removal_policy=RemovalPolicy.DESTROY,
         )
+
+        if enable_pivot_role_auto_create:
+            external_id_secret.add_rotation_schedule(
+                f"ExternalIdSecretRotationSchedule{envname}", automatically_after=Duration.days(365)
+            )
 
         self.cognito_default_user = kms.Key(
             self,

--- a/deploy/stacks/secrets_stack.py
+++ b/deploy/stacks/secrets_stack.py
@@ -18,7 +18,6 @@ class SecretsManagerStack(pyNestedClass):
         envname='dev',
         resource_prefix='dataall',
         enable_cw_canaries=False,
-        pivot_role_name=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -39,22 +38,6 @@ class SecretsManagerStack(pyNestedClass):
             encryption_key=self.external_id_key,
             description=f'Stores dataall external id for environment {envname}',
             removal_policy=RemovalPolicy.DESTROY,
-        )
-
-        self.pivot_role_name_key = kms.Key(
-            self,
-            f'PivotRoleNameSecretKey{envname}',
-            alias=f'{resource_prefix}-{envname}-pivotrolename-key',
-            enable_key_rotation=True,
-        )
-
-        self.pivot_role_name_secret = sm.CfnSecret(
-            self,
-            f'PivotRoleNameSecret{envname}',
-            name=f'dataall-pivot-role-name-{envname}',
-            secret_string=pivot_role_name,
-            kms_key_id=self.pivot_role_name_key.key_id,
-            description=f'Stores dataall pivot role name for environment {envname}',
         )
 
         self.cognito_default_user = kms.Key(

--- a/deploy/stacks/secrets_stack.py
+++ b/deploy/stacks/secrets_stack.py
@@ -17,54 +17,26 @@ class SecretsManagerStack(pyNestedClass):
         id,
         envname='dev',
         resource_prefix='dataall',
-        enable_cw_canaries=False,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
 
-        self.external_id_key = kms.Key(
+        self.canary_user = sm.Secret(
             self,
-            f'ExternalIdSecretKey{envname}',
-            alias=f'{resource_prefix}-{envname}-externalId-key',
-            enable_key_rotation=True,
-            removal_policy=RemovalPolicy.DESTROY,
-        )
-
-        external_id_secret = sm.Secret(
-            self,
-            f'ExternalIdSecret{envname}',
-            secret_name=f'dataall-externalId-{envname}',
-            generate_secret_string=sm.SecretStringGenerator(exclude_punctuation=True),
+            f'canary-user',
+            secret_name=f'{resource_prefix}-{envname}-cognito-canary-user',
+            generate_secret_string=sm.SecretStringGenerator(
+                secret_string_template=json.dumps({'username': f'cwcanary-{self.account}'}),
+                generate_string_key='password',
+                include_space=False,
+                password_length=12,
+            ),
             encryption_key=self.external_id_key,
-            description=f'Stores dataall external id for environment {envname}',
+            description=f'Stores dataall Cognito canary user',
             removal_policy=RemovalPolicy.DESTROY,
         )
-
-        self.cognito_default_user = kms.Key(
-            self,
-            f'{resource_prefix}-{envname}-cognito-defaultuser-key',
-            alias=f'{resource_prefix}-{envname}-cognito-defaultuser-key',
-            enable_key_rotation=True,
-            removal_policy=RemovalPolicy.DESTROY,
+        self.canary_user.add_rotation_schedule(
+            id=envname[:2],
+            automatically_after=Duration.days(90),
+            hosted_rotation=sm.HostedRotation.postgre_sql_single_user(),
         )
-
-        if enable_cw_canaries:
-            self.canary_user = sm.Secret(
-                self,
-                f'canary-user',
-                secret_name=f'{resource_prefix}-{envname}-cognito-canary-user',
-                generate_secret_string=sm.SecretStringGenerator(
-                    secret_string_template=json.dumps({'username': f'cwcanary-{self.account}'}),
-                    generate_string_key='password',
-                    include_space=False,
-                    password_length=12,
-                ),
-                encryption_key=self.external_id_key,
-                description=f'Stores dataall Cognito canary user',
-                removal_policy=RemovalPolicy.DESTROY,
-            )
-            self.canary_user.add_rotation_schedule(
-                id=envname[:2],
-                automatically_after=Duration.days(90),
-                hosted_rotation=sm.HostedRotation.postgre_sql_single_user(),
-            )

--- a/deploy/stacks/secrets_stack.py
+++ b/deploy/stacks/secrets_stack.py
@@ -18,7 +18,6 @@ class SecretsManagerStack(pyNestedClass):
         envname='dev',
         resource_prefix='dataall',
         enable_cw_canaries=False,
-        enable_pivot_role_auto_create=False,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -40,11 +39,6 @@ class SecretsManagerStack(pyNestedClass):
             description=f'Stores dataall external id for environment {envname}',
             removal_policy=RemovalPolicy.DESTROY,
         )
-
-        if enable_pivot_role_auto_create:
-            external_id_secret.add_rotation_schedule(
-                f"ExternalIdSecretRotationSchedule{envname}", automatically_after=Duration.days(365)
-            )
 
         self.cognito_default_user = kms.Key(
             self,


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
Replaced externalId and PivotRoleName secrets in SecretsManager by SSM parameters:
- modified parameter_stack and secrets_stack to create the parameters and remove the secrets.
- the new externalId parameter uses a pre-existing secret if it exists, otherwise it generates a random sequence of numbers and letters
- modified the sts handler to retrieve the pivotRoleName and externalId from SSM

### Relates
- #443 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
