### PR TITLE
Bump starlette from 0.25.0 to 0.27.0 and upgrade fastapi

### DIFF
--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -5,8 +5,8 @@ boto3-stubs==1.24.85
 botocore==1.27.85
 cdk-nag==2.7.2
 constructs==10.0.73
-starlette==0.25.0
-fastapi == 0.92.0
+starlette==0.27.0
+fastapi == 0.95.2
 Flask==2.3.2
 PyYAML==6.0
 requests==2.27.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ ariadne==0.17.0
 aws-xray-sdk==2.4.3
 boto3==1.26.95
 botocore==1.29.95
-fastapi == 0.92.0
+fastapi == 0.95.2
 Flask==2.3.2
 flask-cors==3.0.10
 nanoid==2.0.0
@@ -14,4 +14,4 @@ PyYAML==6.0
 requests==2.27.1
 requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
-starlette==0.25.0
+starlette==0.27.0


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Solve vulnerabilities found in starlette 0.25.0

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
