### PR TITLE
Fixes issue with existing cognito callbacks

### DIFF
--- a/deploy/configs/cognito_urls_config.py
+++ b/deploy/configs/cognito_urls_config.py
@@ -58,8 +58,8 @@ def setup_cognito(
             f'https://{user_guide_link}/parseauth',
         ]
         existing_callbacks = user_pool['UserPoolClient'].get('CallbackURLs', [])
-        if 'example.com' in existing_callbacks:
-            existing_callbacks.remove('example.com')
+        if 'https://example.com' in existing_callbacks:
+            existing_callbacks.remove('https://example.com')
         updated_callbacks = existing_callbacks + list(
             set(config_callbacks) - set(existing_callbacks)
         )


### PR DESCRIPTION
### Feature or Bugfix
- BugFix

### Detail
- In line (https://github.com/awslabs/aws-dataall/blob/13a2fc082694600a0dacaa7e88d0d61ec950d753/deploy/configs/cognito_urls_config.py#L61)

It checks for example.com where instead the right callback to check is ```https://example.com``` and that's why it doesn't get replaced during the configuration phase.

### Relates
- https://github.com/awslabs/aws-dataall/issues/454

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
