### PR TITLE
465 - Update Aurora default Parameter Group to 'default.aurora-postgresql11'.

### DIFF
--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -125,7 +125,7 @@ class AuroraServerlessStack(pyNestedClass):
             deletion_protection=True,
             cluster_identifier=f'{resource_prefix}-{envname}-db',
             parameter_group=rds.ParameterGroup.from_parameter_group_name(
-                self, 'ParameterGroup', 'default.aurora-postgresql10'
+                self, 'ParameterGroup', 'default.aurora-postgresql11'
             ),
             enable_data_api=True,
             default_database_name=f'{envname}db',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Update Aurora default Parameter Group to 'default.aurora-postgresql11'.  Fixes an issue where the Aurora nested stack deploy in the data.all backend deploy would fail and/or block indefinitely due to 'default.aurora-postgresql10' mismatch with version 11 of the Aurora database engine.

### Relates
- https://github.com/awslabs/aws-dataall/issues/465

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
