### PR TITLE
Fix lambda/ECS IAM permissions for AOSS

### DIFF
--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -431,7 +431,7 @@ class ContainerStack(pyNestedClass):
                         'aoss:APIAccessAll',
                     ],
                     resources=[
-                        f'arn:aws:aoss:{self.region}:{self.account}:collection/{resource_prefix}-{envname}-collection',
+                        f'arn:aws:aoss:{self.region}:{self.account}:collection/*',
                     ],
                 ),
             ],

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -426,6 +426,14 @@ class ContainerStack(pyNestedClass):
                     ],
                     resources=['*'],
                 ),
+                iam.PolicyStatement(
+                    actions=[
+                        'aoss:APIAccessAll',
+                    ],
+                    resources=[
+                        f'arn:aws:aoss:{self.region}:{self.account}:collection/{resource_prefix}-{envname}-collection',
+                    ],
+                ),
             ],
         )
         task_role = iam.Role(

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -248,7 +248,7 @@ class LambdaApiStack(pyNestedClass):
                         'aoss:APIAccessAll',
                     ],
                     resources=[
-                        f'arn:aws:aoss:{self.region}:{self.account}:collection/{resource_prefix}-{envname}-collection',
+                        f'arn:aws:aoss:{self.region}:{self.account}:collection/*',
                     ],
                 ),
             ],

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -243,6 +243,14 @@ class LambdaApiStack(pyNestedClass):
                     ],
                     resources=['*'],
                 ),
+                iam.PolicyStatement(
+                    actions=[
+                        'aoss:APIAccessAll',
+                    ],
+                    resources=[
+                        f'arn:aws:aoss:{self.region}:{self.account}:collection/{resource_prefix}-{envname}-collection',
+                    ],
+                ),
             ],
         )
         role = iam.Role(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add "aoss:APIAccessAll" to lambda/ECS task IAM roles required since May 10th (see message below). Fixes 403 errors from APIs.

```
[Action required] Amazon OpenSearch Serverless requires mandatory IAM permission for access to resources
Starting May 10th, 2023, OpenSearch Serverless is mandating two new IAM permissions for collection resources. The two IAM permissions are "aoss:APIAccessAll" for Data Plane API access, and "aoss:DashboardsAccessAll" for Dashboards access from the browser.
You are required to add these two IAM permissions for your OpenSearch Serverless "aoss:APIAccessAll" for Data Plane API access, and "aoss:DashboardsAccessAll" for Dashboards access. You must complete this action by May 9th, 2023. Failure to add the two new IAM permissions will result in 403 errors starting on May 10th, 2023
For a sample data-plane policy [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/security-iam-serverless.html#security_iam_id-based-policy-examples-data-plane.html)
If you have any questions or concerns, please contact [AWS Support](https://aws.amazon.com/support)
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
