### PR TITLE
fix: Upgrade aurora engine version to 11.16

### DIFF
--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -120,7 +120,7 @@ class AuroraServerlessStack(pyNestedClass):
             self,
             f'AuroraDatabase{envname}',
             engine=rds.DatabaseClusterEngine.aurora_postgres(
-                version=rds.AuroraPostgresEngineVersion.VER_10_18
+                version=rds.AuroraPostgresEngineVersion.VER_11_15
             ),
             deletion_protection=True,
             cluster_identifier=f'{resource_prefix}-{envname}-db',

--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -120,7 +120,7 @@ class AuroraServerlessStack(pyNestedClass):
             self,
             f'AuroraDatabase{envname}',
             engine=rds.DatabaseClusterEngine.aurora_postgres(
-                version=rds.AuroraPostgresEngineVersion.VER_11_15
+                version=rds.AuroraPostgresEngineVersion.VER_11_16
             ),
             deletion_protection=True,
             cluster_identifier=f'{resource_prefix}-{envname}-db',


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix


### Detail
Update Aurora engine version to 11.16. Fixes an issue where the Aurora nested stack deployment in the data.all backend which goes  to deployment account would fail  as AuroraPostgresEngineVersion.VER_10_18  is not compatible with parameter group default.aurora-postgresql11
### Relates
- https://github.com/awslabs/aws-dataall/pull/466

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
