### PR TITLE
hotfix: Remove GitHub template option from data.all Pipelines

### DIFF
--- a/backend/dataall/api/Objects/DataPipeline/input_types.py
+++ b/backend/dataall/api/Objects/DataPipeline/input_types.py
@@ -9,7 +9,6 @@ NewDataPipelineInput = gql.InputType(
         gql.Argument(name='SamlGroupName', type=gql.NonNullableType(gql.String)),
         gql.Argument(name='tags', type=gql.ArrayType(gql.String)),
         gql.Argument(name='devStrategy', type=gql.NonNullableType(gql.String)),
-        gql.Argument(name='template', type=gql.String)
     ],
 )
 

--- a/backend/dataall/api/Objects/DataPipeline/resolvers.py
+++ b/backend/dataall/api/Objects/DataPipeline/resolvers.py
@@ -7,7 +7,6 @@ from ...constants import DataPipelineRole
 from ...context import Context
 from ....aws.handlers.service_handlers import Worker
 from ....aws.handlers.sts import SessionHelper
-from ....aws.handlers.codecommit import CodeCommit
 from ....db import permissions, models, exceptions
 from ....db.api import Pipeline, Environment, ResourcePolicy, Stack, KeyValueTag
 
@@ -29,15 +28,6 @@ def create_pipeline(context: Context, source, input=None):
                 session=session,
                 environment_uri=pipeline.environmentUri,
                 target_type='cdkpipeline',
-                target_uri=pipeline.DataPipelineUri,
-                target_label=pipeline.label,
-                payload={'account': pipeline.AwsAccountId, 'region': pipeline.region},
-            )
-        elif input['devStrategy'] == 'template':
-            Stack.create_stack(
-                session=session,
-                environment_uri=pipeline.environmentUri,
-                target_type='template',
                 target_uri=pipeline.DataPipelineUri,
                 target_label=pipeline.label,
                 payload={'account': pipeline.AwsAccountId, 'region': pipeline.region},

--- a/backend/dataall/cdkproxy/cdkpipeline/cdk_pipeline.py
+++ b/backend/dataall/cdkproxy/cdkpipeline/cdk_pipeline.py
@@ -117,13 +117,13 @@ class CDKPipelineStack:
     def initialize_repo_template(self, template):
         venv_name = ".venv"
         cmd_init = [
-            f"git clone {template} {self.pipeline.repo}",
             f"cd {self.pipeline.repo}",
             "rm -rf .git",
             "git init --initial-branch main",
             f"python3 -m venv {venv_name} && source {venv_name}/bin/activate",
             "pip install -r requirements.txt",
             f"ddk create-repository {self.pipeline.repo} -t application dataall -t team {self.pipeline.SamlGroupName}"
+            f"ddk init --template {template} --generate-only"
         ]
 
         logger.info(f"Running Commands: {'; '.join(cmd_init)}")

--- a/backend/dataall/cdkproxy/cdkpipeline/cdk_pipeline.py
+++ b/backend/dataall/cdkproxy/cdkpipeline/cdk_pipeline.py
@@ -45,7 +45,6 @@ class CDKPipelineStack:
         self.env, aws = CDKPipelineStack._set_env_vars(self.pipeline_environment)
 
         self.code_dir_path = os.path.dirname(os.path.abspath(__file__))
-        template = self.pipeline.template
 
         try:
             codecommit_client = aws.client('codecommit', region_name=self.pipeline_environment.region)
@@ -82,12 +81,9 @@ class CDKPipelineStack:
             else:
                 raise Exception
         except Exception as e:
-            if len(template):
-                self.venv_name = self.initialize_repo_template(template)
-            else:
-                self.venv_name = self.initialize_repo()
-                CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments)
-                CDKPipelineStack.write_ddk_json_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="ddk.json", pipeline_environment=self.pipeline_environment, development_environments=self.development_environments)
+            self.venv_name = self.initialize_repo()
+            CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments)
+            CDKPipelineStack.write_ddk_json_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="ddk.json", pipeline_environment=self.pipeline_environment, development_environments=self.development_environments)
             self.git_push_repo()
 
     def initialize_repo(self):
@@ -97,33 +93,6 @@ class CDKPipelineStack:
             f"cd {self.pipeline.repo}",
             "git init --initial-branch main",
             f"ddk create-repository {self.pipeline.repo} -t application dataall -t team {self.pipeline.SamlGroupName}"
-        ]
-
-        logger.info(f"Running Commands: {'; '.join(cmd_init)}")
-
-        process = subprocess.run(
-            '; '.join(cmd_init),
-            text=True,
-            shell=True,  # nosec
-            encoding='utf-8',
-            cwd=self.code_dir_path,
-            env=self.env
-        )
-        if process.returncode == 0:
-            logger.info("Successfully Initialized New CDK/DDK App")
-
-            return venv_name
-
-    def initialize_repo_template(self, template):
-        venv_name = ".venv"
-        cmd_init = [
-            f"cd {self.pipeline.repo}",
-            "rm -rf .git",
-            "git init --initial-branch main",
-            f"python3 -m venv {venv_name} && source {venv_name}/bin/activate",
-            "pip install -r requirements.txt",
-            f"ddk create-repository {self.pipeline.repo} -t application dataall -t team {self.pipeline.SamlGroupName}"
-            f"ddk init --template {template} --generate-only"
         ]
 
         logger.info(f"Running Commands: {'; '.join(cmd_init)}")

--- a/backend/dataall/db/api/pipeline.py
+++ b/backend/dataall/db/api/pipeline.py
@@ -63,7 +63,7 @@ class Pipeline:
             region=environment.region,
             repo=slugify(data['label']),
             devStrategy=data['devStrategy'],
-            template=data['template'] if data['devStrategy'] == 'template' else "",
+            template="",
         )
 
         session.add(pipeline)

--- a/documentation/userguide/docs/pipelines.md
+++ b/documentation/userguide/docs/pipelines.md
@@ -42,7 +42,6 @@ data.all pipelines are created from the UI, under Pipelines. We need to fill the
     1. [**CDK Pipelines - Trunk-based**](#CDK-Pipelines-Overview) : A CICD pipeline based on [CDK Pipelines library](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.pipelines/README.html). It defines a DDK Core construct which deploys Continuous Integration and Delivery for your app. Specifically, it provisions a stack containing a self-mutating CDK code pipeline to deploy one or more copies of your CDK applications using CloudFormation with a minimal amount of effort on your part.
     2. [**CodePipeline - Trunk-based**](#CodePipeline-pipelines---Trunk-based-or-GitFlow-Overview) : A CICD pipeline similar to CDK Pipelines and with a trunk-based approach but is not self-mutating.
     3. [**CodePipeline - Gitflow**](#CodePipeline-pipelines---Trunk-based-or-GitFlow-Overview): A Gitflow branching strategy where each branch of the source repository has a corresponding CICD Pipeline that deploys resources for that branches environment.
-    4. [**GitHub Template**](#Github-Template-Pipelines-Overview) : This is a Bring-Your-Own-Template approach where users can specify they git clone path and deploy their own pipelines and IaC rather than using one of the previous 3 strategies. 
 
 Finally, we need to add **Development environments**. These are the AWS accounts and regions where the infrastructure defined in the CICD pipeline
 is deployed. 
@@ -168,17 +167,7 @@ The `dev` pipeline reads from the `dev` branch of the repository:
 
 ![created_pipeline](pictures/pipelines/pip_cp_gitflow2.png#zoom#shadow)
 
---- 
-### Github Template Pipelines Overview
-
-This pipeline strategy takes a pre-defined IaC CDK Application that exists in a github repository and deploys the pipeline to be managed by data all. An AWS CodeCommit repository with the code of the github repository is created in the CICD environment AWS account.
-
-**NOTE: You may have to specify a access token in the HTTPS Clone Path of the Github Repository if the repository is private**
-
-data.all performs the inital deployment of this pipeline by running `cdk deploy` for the code now existing in AWS CodeCommit in the CICD environment. Adding development environments here is on the responsibility of the pipeline creator to align with the deployment environments specified in the cloned repository.
-
-![created_pipeline](pictures/pipelines/github_template_create.png#zoom#shadow)
-
+---
 ## Editing a Data All Pipeline
 
 For users who would like to promote their pipeline deployments to new environments managed by data all, you can do so by first bootstrapping the new environment(s) to be deployed to (as mentioned in the [Pre-requisites](#Pre-requisites)) and then adding and/or editing the development environments.
@@ -189,7 +178,6 @@ Based on pipeline use case, editing a data all pipeline's development environmen
 - **CDK Pipelines**: On update, the `ddk.json` and `app.py` will be edited to update the new development environment information. The self-mutating, CICD Pipeline will trigger and deploy to the new environments based on the source CodeCommit repository changes.
 - **CodePipelines - Trunk-based**: On update the `ddk.json` will be edited. A new `cdk deploy` will run to update the CICD CloudFormation Stack for the AWS CodePipeline to add the new stages required for the additional environment deployment(s) (as well as manual approval steps between stages in the code pipeline). You will see these updates to the CICD stack in CloudFormaiton of the CICD environment.
 - **CodePipelines - Gitflow**: On update the `ddk.json` will be edited. A new `cdk deploy` will run to update the CICD CloudFormation Stack to add the new AWS CodePipelines required for the additional environment deployment(s). You will see these updates to the CICD stack in CloudFormaiton of the CICD environment.
-- **Github Template Pipelines**: Editing development environments **will NOT** re-deploy the application or update the CodeCommit repository. Editing of template pipeline's development environment(s) is the responsibility of the pipeline creator for proper data all pipeline management.
 
 ## Which development strategy should I choose?
 
@@ -203,11 +191,6 @@ Based on pipeline use case, editing a data all pipeline's development environmen
 1. The `aws-codepipelines` construct uses AWS CodePipelines directly. We are able to define any type of CICD architecture, such as in this case Trunk-based and GitFlow.
 2. Developers working on the pipeline cannot modify the CICD pipeline
 3. Cross-account deployments require specific definition of the environment in the code.
-
-**Github Template Pipelines**
-
-1. The aforementioned pipeline strategies do not align with your desired pipeline architecture
-2. You already have pipelines IaC written in AWS CDK and ready to be deployed rather than creating pipeline(s) and developing from scratch
 
 
 **Summary**

--- a/frontend/src/views/Pipelines/PipelineCreateForm.js
+++ b/frontend/src/views/Pipelines/PipelineCreateForm.js
@@ -44,7 +44,7 @@ const PipelineCrateForm = (props) => {
   const [loading, setLoading] = useState(true);
   const [groupOptions, setGroupOptions] = useState([]);
   const [environmentOptions, setEnvironmentOptions] = useState([]);
-  const devOptions =[{value:"cdk-trunk", label:"CDK Pipelines - Trunk-based"},{value:"trunk", label:"CodePipeline - Trunk-based"},{value:"gitflow", label:"CodePipeline - Gitflow"},{value:"template", label:"GitHub Template"}];/*DBT Pipelines*/
+  const devOptions =[{value:"cdk-trunk", label:"CDK Pipelines - Trunk-based"},{value:"trunk", label:"CodePipeline - Trunk-based"},{value:"gitflow", label:"CodePipeline - Gitflow"}];/*DBT Pipelines*/
   const [triggerEnvSubmit, setTriggerEnvSubmit] = useState(false);
   const [countEnvironmentsValid, setCountEnvironmentsValid] = useState(false);
   const [pipelineUri, setPipelineUri] = useState('');
@@ -116,8 +116,7 @@ const PipelineCrateForm = (props) => {
                 description: values.description,
                 SamlGroupName: values.SamlGroupName,
                 tags: values.tags,
-                devStrategy: values.devStrategy,
-                template: values.template
+                devStrategy: values.devStrategy
               }
             })
           );
@@ -226,7 +225,6 @@ const PipelineCrateForm = (props) => {
                 environment: '',
                 tags: [],
                 devStrategy: 'cdk-trunk',
-                template: '',
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -238,7 +236,6 @@ const PipelineCrateForm = (props) => {
                 environment: Yup.object(),
                 devStrategy: Yup.string().required('*A CICD strategy is required'),
                 tags: Yup.array().nullable(),
-                template: Yup.string().nullable(),
               })}
               onSubmit={async (
                 values,
@@ -433,21 +430,6 @@ const PipelineCrateForm = (props) => {
                               </MenuItem>
                             ))}
                           </TextField>
-                        </CardContent>
-                        <CardContent>
-                          {values.devStrategy === "template" && (
-                            <TextField
-                              error={Boolean(touched.template && errors.template)}
-                              fullWidth
-                              helperText={touched.template && errors.template}
-                              label="GitHub Template Clone Path"
-                              name="template"
-                              onBlur={handleBlur}
-                              onChange={handleChange}
-                              value={values.template}
-                              variant="outlined"
-                            />
-                          )}
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/views/Pipelines/PipelineList.js
+++ b/frontend/src/views/Pipelines/PipelineList.js
@@ -86,7 +86,7 @@ const PipelineList = () => {
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(true);
   const client = useClient();
-  const devOptions =[{value:"cdk-trunk", label:"CDK Pipelines - Trunk-based"},{value:"trunk", label:"CodePipeline - Trunk-based"},{value:"gitflow", label:"CodePipeline - Gitflow"},{value:"template", label:"GitHub Template"}];/*DBT Pipelines*/
+  const devOptions =[{value:"cdk-trunk", label:"CDK Pipelines - Trunk-based"},{value:"trunk", label:"CodePipeline - Trunk-based"},{value:"gitflow", label:"CodePipeline - Gitflow"}];/*DBT Pipelines*/
   const [filterItems] = useState([{title:'DevStrategy', options: devOptions},{title:'Tags'},{title: 'Region', options: AwsRegions}]);
 
   const fetchItems = useCallback(async () => {

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -740,7 +740,6 @@ def pipeline(client, tenant, group, env_fixture) -> models.DataPipeline:
             'tags': [group.name],
             'environmentUri': env_fixture.environmentUri,
             'devStrategy': 'trunk',
-            'template': '',
         },
         username='alice',
         groups=[group.name],

--- a/tests/api/test_datapipelines.py
+++ b/tests/api/test_datapipelines.py
@@ -40,7 +40,6 @@ def pipeline(client, tenant, group, env1):
             'tags': [group.name],
             'environmentUri': env1.environmentUri,
             'devStrategy': 'trunk',
-            'template': ''
         },
         username='alice',
         groups=[group.name],


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Remove the GitHub template development strategy from the possible types of data.all pipelines.

The initial idea was to use the parameter `--template` from the [AWS DDK CLI](https://awslabs.github.io/aws-ddk/release/stable/api/cli/aws_ddk.html#ddk-init) which has been deprecated after its last major release (1.0.0). Using templates would enable customers to use any cookiecutter template directly in data.all. 

However, from the way that it was implemented it exposed a **vulnerability** in which customers could enter code instead of a template and perform cmd code injections in data.all ECS deployment task.

Given that this is a high-risk issue + AWS DDK 1.0.0 does not use CLI + `templates` are not critical for any known customer we will remove it for the moment to ensure security. In the future we will revisit other ways of providing templates and accelerating data pipeline building in a secure manner.


### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
