### PR TITLE
Updated CDK Version to fix issue with cdkproxy/ dataset stack creations

### DIFF
--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.20.0
+aws-cdk-lib==2.61.1
 aws_cdk.aws_redshift_alpha==2.14.0a0
 boto3==1.24.85
 boto3-stubs==1.24.85

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -296,7 +296,7 @@ class Dataset(Stack):
                 iam.ServicePrincipal('sagemaker.amazonaws.com'),
                 iam.ServicePrincipal('lambda.amazonaws.com'),
                 iam.ServicePrincipal('ec2.amazonaws.com'),
-                iam.AccountPrincipal(os.environ.get('CURRENT_AWS_ACCOUNT')),
+                iam.AccountPrincipal(str(os.environ.get('CURRENT_AWS_ACCOUNT'))),
                 iam.AccountPrincipal(dataset.AwsAccountId),
                 iam.ArnPrincipal(
                     f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'


### PR DESCRIPTION
### Feature or Bugfix
- BugFix

### Detail
- cdkproxy was using an outdated version of aws-cdk-lib which uses NODEJS_12_X for the AWS Custom Resources Lambda Functions, which are now not anymore supported in the AWS Accounts and causes failure of the creation of CloudFormation stacks in the case when you create a new DataSet Stack
- The version change also triggered a minor type enforcement for the AccountPrincipal AccountId to be explicitly ```string```

### Relates
- https://github.com/awslabs/aws-dataall/issues/475

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
