### PR TITLE
fix: Fix typo that destroys storage locations

### DIFF
--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from .sts import SessionHelper
 
 log = logging.getLogger('aws:lakeformation')
-PIVOT_ROLE_NAME_PREFIX = "datallPivotRole"
+PIVOT_ROLE_NAME_PREFIX = "dataallPivotRole"
 
 
 class LakeFormation:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
The constant to define the dataallPivotRole missed an "a" and as a consequence the storage location for the Dataset was not registered

### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
