### PR TITLE
feat: Disabling profiling results from "secret" and "official" datasets

### DIFF
--- a/backend/dataall/api/Objects/DatasetProfiling/mutations.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/mutations.py
@@ -7,13 +7,3 @@ startDatasetProfilingRun = gql.MutationField(
     type=gql.Ref('DatasetProfilingRun'),
     resolver=start_profiling_run,
 )
-
-updateDatasetProfilingRunResults = gql.MutationField(
-    name='updateDatasetProfilingRunResults',
-    args=[
-        gql.Argument(name='profilingRunUri', type=gql.NonNullableType(gql.String)),
-        gql.Argument(name='results', type=gql.NonNullableType(gql.String)),
-    ],
-    type=gql.Ref('DatasetProfilingRun'),
-    resolver=update_profiling_run_results,
-)

--- a/backend/dataall/api/Objects/DatasetProfiling/queries.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/queries.py
@@ -2,24 +2,6 @@ from ... import gql
 from .resolvers import *
 
 
-getDatasetProfilingRun = gql.QueryField(
-    name='getDatasetProfilingRun',
-    args=[gql.Argument(name='profilingRunUri', type=gql.NonNullableType(gql.String))],
-    type=gql.Ref('DatasetProfilingRun'),
-    resolver=get_profiling_run,
-)
-
-
-listDatasetProfilingRuns = gql.QueryField(
-    name='listDatasetProfilingRuns',
-    args=[
-        gql.Argument(name='datasetUri', type=gql.NonNullableType(gql.String)),
-        gql.Argument(name='filter', type=gql.Ref('DatasetProfilingRunFilter')),
-    ],
-    type=gql.Ref('DatasetProfilingRunSearchResults'),
-    resolver=list_profiling_runs,
-)
-
 listDatasetTableProfilingRuns = gql.QueryField(
     name='listDatasetTableProfilingRuns',
     args=[gql.Argument(name='tableUri', type=gql.NonNullableType(gql.String))],

--- a/backend/dataall/api/Objects/DatasetProfiling/queries.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/queries.py
@@ -13,5 +13,5 @@ getDatasetTableLastProfilingRun = gql.QueryField(
     name='getDatasetTableProfilingRun',
     args=[gql.Argument(name='tableUri', type=gql.NonNullableType(gql.String))],
     type=gql.Ref('DatasetProfilingRun'),
-    resolver=get_last_table_profiling_run,
+    resolver=get_dataset_table_profiling_run,
 )

--- a/backend/dataall/api/Objects/DatasetProfiling/resolvers.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/resolvers.py
@@ -72,7 +72,7 @@ def start_profiling_run(context: Context, source, input: dict = None):
     return run
 
 
-def get_last_table_profiling_run(context: Context, source, tableUri=None):
+def get_dataset_table_profiling_run(context: Context, source, tableUri=None):
     """
     Shows the results of the last profiling job on a Table.
     For datasets "Unclassified" all users can perform this action.

--- a/backend/dataall/api/Objects/DatasetProfiling/resolvers.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/resolvers.py
@@ -20,7 +20,30 @@ def resolve_dataset(context, source: models.DatasetProfilingRun):
         )
 
 
+def resolve_profiling_run_status(context: Context, source: models.DatasetProfilingRun):
+    if not source:
+        return None
+    with context.engine.scoped_session() as session:
+        task = models.Task(
+            targetUri=source.profilingRunUri, action='glue.job.profiling_run_status'
+        )
+        session.add(task)
+    Worker.queue(engine=context.engine, task_ids=[task.taskUri])
+    return source.status
+
+
+def resolve_profiling_results(context: Context, source: models.DatasetProfilingRun):
+    if not source or source.results == {}:
+        return None
+    else:
+        return json.dumps(source.results)
+
+
 def start_profiling_run(context: Context, source, input: dict = None):
+    """
+    Triggers profiling jobs on a Table.
+    Only Dataset owners with PROFILE_DATASET_TABLE can perform this action
+    """
     with context.engine.scoped_session() as session:
 
         ResourcePolicy.check_user_resource_permission(
@@ -49,46 +72,12 @@ def start_profiling_run(context: Context, source, input: dict = None):
     return run
 
 
-def get_profiling_run_status(context: Context, source: models.DatasetProfilingRun):
-    if not source:
-        return None
-    with context.engine.scoped_session() as session:
-        task = models.Task(
-            targetUri=source.profilingRunUri, action='glue.job.profiling_run_status'
-        )
-        session.add(task)
-    Worker.queue(engine=context.engine, task_ids=[task.taskUri])
-    return source.status
-
-
-def get_profiling_results(context: Context, source: models.DatasetProfilingRun):
-    if not source or source.results == {}:
-        return None
-    else:
-        return json.dumps(source.results)
-
-
-def update_profiling_run_results(context: Context, source, profilingRunUri, results):
-    with context.engine.scoped_session() as session:
-        run = api.DatasetProfilingRun.update_run(
-            session=session, profilingRunUri=profilingRunUri, results=results
-        )
-        return run
-
-
-def list_profiling_runs(context: Context, source, datasetUri=None):
-    with context.engine.scoped_session() as session:
-        return api.DatasetProfilingRun.list_profiling_runs(session, datasetUri)
-
-
-def get_profiling_run(context: Context, source, profilingRunUri=None):
-    with context.engine.scoped_session() as session:
-        return api.DatasetProfilingRun.get_profiling_run(
-            session=session, profilingRunUri=profilingRunUri
-        )
-
-
 def get_last_table_profiling_run(context: Context, source, tableUri=None):
+    """
+    Shows the results of the last profiling job on a Table.
+    For datasets "Unclassified" all users can perform this action.
+    For datasets "Secret" or "Official", only users with PREVIEW_DATASET_TABLE permissions can perform this action.
+    """
     with context.engine.scoped_session() as session:
         table: models.DatasetTable = db.api.DatasetTable.get_dataset_table_by_uri(
             session, tableUri
@@ -118,7 +107,7 @@ def get_last_table_profiling_run(context: Context, source, tableUri=None):
                 environment = api.Environment.get_environment_by_uri(
                     session, dataset.environmentUri
                 )
-                content = get_profiling_results_from_s3(
+                content = _get_profiling_results_from_s3(
                     environment, dataset, table, run
                 )
                 if content:
@@ -137,7 +126,7 @@ def get_last_table_profiling_run(context: Context, source, tableUri=None):
         return run
 
 
-def get_profiling_results_from_s3(environment, dataset, table, run):
+def _get_profiling_results_from_s3(environment, dataset, table, run):
     s3 = SessionHelper.remote_session(environment.AwsAccountId).client(
         's3', region_name=environment.region
     )
@@ -157,7 +146,27 @@ def get_profiling_results_from_s3(environment, dataset, table, run):
 
 
 def list_table_profiling_runs(context: Context, source, tableUri=None):
+    """
+    Lists the runs of a profiling job on a Table.
+    For datasets "Unclassified" all users can perform this action.
+    For datasets "Secret" or "Official", only users with PREVIEW_DATASET_TABLE permissions can perform this action.
+    """
     with context.engine.scoped_session() as session:
+        table: models.DatasetTable = db.api.DatasetTable.get_dataset_table_by_uri(
+            session, tableUri
+        )
+        dataset = db.api.Dataset.get_dataset_by_uri(session, table.datasetUri)
+        if (
+                dataset.confidentiality
+                != models.ConfidentialityClassification.Unclassified.value
+        ):
+            ResourcePolicy.check_user_resource_permission(
+                session=session,
+                username=context.username,
+                groups=context.groups,
+                resource_uri=table.tableUri,
+                permission_name=permissions.PREVIEW_DATASET_TABLE,
+            )
         return api.DatasetProfilingRun.list_table_profiling_runs(
             session=session, tableUri=tableUri, filter={}
         )

--- a/backend/dataall/api/Objects/DatasetProfiling/schema.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/schema.py
@@ -16,11 +16,11 @@ DatasetProfilingRun = gql.ObjectType(
         gql.Field(name='GlueTriggerName', type=gql.String),
         gql.Field(name='GlueTableName', type=gql.String),
         gql.Field(name='AwsAccountId', type=gql.String),
-        gql.Field(name='results', type=gql.String, resolver=get_profiling_results),
+        gql.Field(name='results', type=gql.String, resolver=resolve_profiling_results),
         gql.Field(name='created', type=gql.String),
         gql.Field(name='updated', type=gql.String),
         gql.Field(name='owner', type=gql.String),
-        gql.Field('status', type=gql.String, resolver=get_profiling_run_status),
+        gql.Field('status', type=gql.String, resolver=resolve_profiling_run_status),
         gql.Field(name='dataset', type=gql.Ref('Dataset'), resolver=resolve_dataset),
     ],
 )

--- a/backend/dataall/api/Objects/DatasetProfiling/schema.py
+++ b/backend/dataall/api/Objects/DatasetProfiling/schema.py
@@ -1,8 +1,8 @@
 from ... import gql
 from .resolvers import (
     resolve_dataset,
-    get_profiling_run_status,
-    get_profiling_results,
+    resolve_profiling_run_status,
+    resolve_profiling_results,
 )
 
 DatasetProfilingRun = gql.ObjectType(

--- a/tests/api/test_dataset_profiling.py
+++ b/tests/api/test_dataset_profiling.py
@@ -32,17 +32,7 @@ def test_add_tables(table, dataset1, db):
     assert nb == 10
 
 
-def update_runs(db, runs):
-    with db.scoped_session() as session:
-        for run in runs:
-            run = session.query(dataall.db.models.DatasetProfilingRun).get(
-                run['profilingRunUri']
-            )
-            run.status = 'SUCCEEDED'
-            session.commit()
-
-
-def test_start_profiling(org1, env1, dataset1, client, module_mocker, db, user, group):
+def test_start_profiling_run(org1, env1, dataset1, client, module_mocker, db, user, group):
     module_mocker.patch('requests.post', return_value=True)
     module_mocker.patch(
         'dataall.aws.handlers.service_handlers.Worker.process', return_value=True
@@ -73,66 +63,15 @@ def test_start_profiling(org1, env1, dataset1, client, module_mocker, db, user, 
         session.commit()
 
 
-def test_list_runs(client, dataset1, env1, group):
-    runs = list_profiling_runs(client, dataset1, group)
-    assert len(runs) == 1
-
-
-def list_profiling_runs(client, dataset1, group):
-    response = client.query(
-        """
-        query listDatasetProfilingRuns($datasetUri:String!){
-            listDatasetProfilingRuns(datasetUri:$datasetUri){
-                count
-                nodes{
-                    profilingRunUri
-                }
-            }
-        }
-        """,
-        datasetUri=dataset1.datasetUri,
-        groups=[group.name],
-    )
-    return response.data.listDatasetProfilingRuns['nodes']
-
-
-def test_get_profiling_run(client, dataset1, env1, module_mocker, db, group):
-    runs = list_profiling_runs(client, dataset1, group)
-    module_mocker.patch(
-        'dataall.aws.handlers.service_handlers.Worker.queue',
-        return_value=update_runs(db, runs),
-    )
-    response = client.query(
-        """
-        query getDatasetProfilingRun($profilingRunUri:String!){
-            getDatasetProfilingRun(profilingRunUri:$profilingRunUri){
-                profilingRunUri
-                status
-            }
-        }
-        """,
-        profilingRunUri=runs[0]['profilingRunUri'],
-        groups=[group.name],
-    )
-    assert (
-        response.data.getDatasetProfilingRun['profilingRunUri']
-        == runs[0]['profilingRunUri']
-    )
-    assert response.data.getDatasetProfilingRun['status'] == 'SUCCEEDED'
-
 
 def test_get_table_profiling_run(
     client, dataset1, env1, module_mocker, table, db, group
 ):
     module_mocker.patch(
-        'dataall.api.Objects.DatasetProfiling.resolvers.get_profiling_results_from_s3',
+        'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
         return_value='{"results": "yes"}',
     )
-    runs = list_profiling_runs(client, dataset1, group)
-    module_mocker.patch(
-        'dataall.aws.handlers.service_handlers.Worker.queue',
-        return_value=update_runs(db, runs),
-    )
+
     table = table(dataset=dataset1, name='table1', username=dataset1.owner)
     with db.scoped_session() as session:
         table = (
@@ -153,11 +92,8 @@ def test_get_table_profiling_run(
         tableUri=table.tableUri,
         groups=[group.name],
     )
-    assert (
-        response.data.getDatasetTableProfilingRun['profilingRunUri']
-        == runs[0]['profilingRunUri']
-    )
-    assert response.data.getDatasetTableProfilingRun['status'] == 'SUCCEEDED'
+    assert response.data.getDatasetTableProfilingRun['profilingRunUri']
+    assert response.data.getDatasetTableProfilingRun['status'] == 'RUNNING'
     assert response.data.getDatasetTableProfilingRun['GlueTableName'] == 'table1'
 
 
@@ -165,11 +101,10 @@ def test_list_table_profiling_runs(
     client, dataset1, env1, module_mocker, table, db, group
 ):
     module_mocker.patch(
-        'dataall.api.Objects.DatasetProfiling.resolvers.get_profiling_results_from_s3',
+        'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
         return_value='{"results": "yes"}',
     )
     module_mocker.patch('requests.post', return_value=True)
-    runs = list_profiling_runs(client, dataset1, group)
     table1000 = table(dataset=dataset1, name='table1000', username=dataset1.owner)
     with db.scoped_session() as session:
         table = (
@@ -177,10 +112,6 @@ def test_list_table_profiling_runs(
             .filter(dataall.db.models.DatasetTable.GlueTableName == 'table1')
             .first()
         )
-    module_mocker.patch(
-        'dataall.aws.handlers.service_handlers.Worker.queue',
-        return_value=update_runs(db, runs),
-    )
     response = client.query(
         """
         query listDatasetTableProfilingRuns($tableUri:String!){
@@ -198,69 +129,12 @@ def test_list_table_profiling_runs(
         tableUri=table.tableUri,
         groups=[group.name],
     )
+    assert response.data.listDatasetTableProfilingRuns['count'] == 1
+    assert response.data.listDatasetTableProfilingRuns['nodes'][0]['profilingRunUri']
     assert (
-        response.data.listDatasetTableProfilingRuns['nodes'][0]['profilingRunUri']
-        == runs[0]['profilingRunUri']
-    )
-    assert (
-        response.data.listDatasetTableProfilingRuns['nodes'][0]['status'] == 'SUCCEEDED'
+        response.data.listDatasetTableProfilingRuns['nodes'][0]['status'] == 'RUNNING'
     )
     assert (
         response.data.listDatasetTableProfilingRuns['nodes'][0]['GlueTableName']
         == 'table1'
     )
-
-    module_mocker.patch(
-        'dataall.aws.handlers.service_handlers.Worker.queue',
-        return_value=update_runs(db, runs),
-    )
-    response = client.query(
-        """
-        query listDatasetTableProfilingRuns($tableUri:String!){
-            listDatasetTableProfilingRuns(tableUri:$tableUri){
-                count
-                nodes{
-                    profilingRunUri
-                    status
-                    GlueTableName
-                }
-
-            }
-        }
-        """,
-        tableUri=table1000.tableUri,
-        groups=[group.name],
-    )
-    assert response.data.listDatasetTableProfilingRuns['count'] == 0
-
-    response = client.query(
-        """
-        query getDatasetTableProfilingRun($tableUri:String!){
-            getDatasetTableProfilingRun(tableUri:$tableUri){
-                profilingRunUri
-                status
-                GlueTableName
-            }
-        }
-        """,
-        tableUri=table.tableUri,
-        groups=[group.name],
-    )
-    assert (
-        response.data.getDatasetTableProfilingRun['profilingRunUri']
-        == runs[0]['profilingRunUri']
-    )
-
-    response = client.query(
-        """
-        query getDatasetTableProfilingRun($tableUri:String!){
-            getDatasetTableProfilingRun(tableUri:$tableUri){
-                profilingRunUri
-                status
-                GlueTableName
-            }
-        }
-        """,
-        tableUri=table1000.tableUri,
-    )
-    assert not response.data.getDatasetTableProfilingRun

--- a/tests/api/test_dataset_profiling.py
+++ b/tests/api/test_dataset_profiling.py
@@ -15,24 +15,32 @@ def env1(env, org1, user, group, tenant):
     env1 = env(org1, 'dev', user.userName, group.name, '111111111111', 'eu-west-1')
     yield env1
 
+@pytest.fixture(scope='module', autouse=True)
+def org2(org, user2, group2, tenant):
+    org2 = org('testorg2', user2.userName, group2.name)
+    yield org2
+
+
+@pytest.fixture(scope='module', autouse=True)
+def env2(env, org2, user2, group2, tenant):
+    env2 = env(org2, 'dev2', user2.userName, group2.name, '2222222222', 'eu-west-1')
+    yield env2
+
 
 @pytest.fixture(scope='module')
 def dataset1(env1, org1, dataset, group, user) -> dataall.db.models.Dataset:
-    yield dataset(
-        org=org1, env=env1, name='dataset1', owner=user.userName, group=group.name
+    dataset1 = dataset(
+        org=org1, env=env1, name='dataset1', owner=user.userName, group=group.name,
+        confidentiality=dataall.api.constants.ConfidentialityClassification.Secret.value
     )
+    yield dataset1
+
+@pytest.fixture(scope='module')
+def table1(dataset1, table_with_permission, group, user):
+    yield table_with_permission(dataset=dataset1, name="table1", owner=user.userName, group=group.name)
 
 
-def test_add_tables(table, dataset1, db):
-    for i in range(0, 10):
-        table(dataset=dataset1, name=f'table{i+1}', username=dataset1.owner)
-
-    with db.scoped_session() as session:
-        nb = session.query(dataall.db.models.DatasetTable).count()
-    assert nb == 10
-
-
-def test_start_profiling_run(org1, env1, dataset1, client, module_mocker, db, user, group):
+def test_start_profiling_run_authorized(org1, env1, dataset1, table1, client, module_mocker, db, user, group):
     module_mocker.patch('requests.post', return_value=True)
     module_mocker.patch(
         'dataall.aws.handlers.service_handlers.Worker.process', return_value=True
@@ -50,7 +58,7 @@ def test_start_profiling_run(org1, env1, dataset1, client, module_mocker, db, us
             }
         """,
         username=user.userName,
-        input={'datasetUri': dataset1.datasetUri, 'GlueTableName': 'table1'},
+        input={'datasetUri': dataset1.datasetUri, 'GlueTableName': table1.name},
         groups=[group.name],
     )
     profiling = response.data.startDatasetProfilingRun
@@ -63,22 +71,38 @@ def test_start_profiling_run(org1, env1, dataset1, client, module_mocker, db, us
         session.commit()
 
 
+def test_start_profiling_run_unauthorized(org2, env2, dataset1, table1, client, module_mocker, db, user2, group2):
+    module_mocker.patch('requests.post', return_value=True)
+    module_mocker.patch(
+        'dataall.aws.handlers.service_handlers.Worker.process', return_value=True
+    )
+    dataset1.GlueProfilingJobName = ('profile-job',)
+    dataset1.GlueProfilingTriggerSchedule = ('cron(* 2 * * ? *)',)
+    dataset1.GlueProfilingTriggerName = ('profile-job',)
+    response = client.query(
+        """
+        mutation startDatasetProfilingRun($input:StartDatasetProfilingRunInput){
+            startDatasetProfilingRun(input:$input)
+                {
+                    profilingRunUri
+                }
+            }
+        """,
+        username=user2.userName,
+        input={'datasetUri': dataset1.datasetUri, 'GlueTableName': table1.name},
+        groups=[group2.name],
+    )
+    assert 'UnauthorizedOperation' in response.errors[0].message
 
-def test_get_table_profiling_run(
-    client, dataset1, env1, module_mocker, table, db, group
+
+def test_get_table_profiling_run_authorized(
+    client, dataset1, table1, module_mocker, db, user, group
 ):
     module_mocker.patch(
         'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
         return_value='{"results": "yes"}',
     )
 
-    table = table(dataset=dataset1, name='table1', username=dataset1.owner)
-    with db.scoped_session() as session:
-        table = (
-            session.query(dataall.db.models.DatasetTable)
-            .filter(dataall.db.models.DatasetTable.GlueTableName == 'table1')
-            .first()
-        )
     response = client.query(
         """
         query getDatasetTableProfilingRun($tableUri:String!){
@@ -89,29 +113,48 @@ def test_get_table_profiling_run(
             }
         }
         """,
-        tableUri=table.tableUri,
+        tableUri=table1.tableUri,
         groups=[group.name],
+        username=user.userName,
     )
     assert response.data.getDatasetTableProfilingRun['profilingRunUri']
     assert response.data.getDatasetTableProfilingRun['status'] == 'RUNNING'
     assert response.data.getDatasetTableProfilingRun['GlueTableName'] == 'table1'
 
+def test_get_table_profiling_run_unauthorized(
+    client, dataset1, module_mocker, table1, db, user2, group2
+):
+    module_mocker.patch(
+        'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
+        return_value='{"results": "yes"}',
+    )
 
-def test_list_table_profiling_runs(
-    client, dataset1, env1, module_mocker, table, db, group
+    response = client.query(
+        """
+        query getDatasetTableProfilingRun($tableUri:String!){
+            getDatasetTableProfilingRun(tableUri:$tableUri){
+                profilingRunUri
+                status
+                GlueTableName
+            }
+        }
+        """,
+        tableUri=table1.tableUri,
+        groups=[group2.name],
+        username=user2.userName,
+    )
+    assert 'UnauthorizedOperation' in response.errors[0].message
+
+
+def test_list_table_profiling_runs_authorized(
+    client, dataset1, module_mocker, table1, db, user, group
 ):
     module_mocker.patch(
         'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
         return_value='{"results": "yes"}',
     )
     module_mocker.patch('requests.post', return_value=True)
-    table1000 = table(dataset=dataset1, name='table1000', username=dataset1.owner)
-    with db.scoped_session() as session:
-        table = (
-            session.query(dataall.db.models.DatasetTable)
-            .filter(dataall.db.models.DatasetTable.GlueTableName == 'table1')
-            .first()
-        )
+
     response = client.query(
         """
         query listDatasetTableProfilingRuns($tableUri:String!){
@@ -126,8 +169,9 @@ def test_list_table_profiling_runs(
             }
         }
         """,
-        tableUri=table.tableUri,
+        tableUri=table1.tableUri,
         groups=[group.name],
+        username=user.userName,
     )
     assert response.data.listDatasetTableProfilingRuns['count'] == 1
     assert response.data.listDatasetTableProfilingRuns['nodes'][0]['profilingRunUri']
@@ -138,3 +182,32 @@ def test_list_table_profiling_runs(
         response.data.listDatasetTableProfilingRuns['nodes'][0]['GlueTableName']
         == 'table1'
     )
+
+def test_list_table_profiling_runs_unauthorized(
+    client, dataset1, module_mocker, table1, db, user2, group2
+):
+    module_mocker.patch(
+        'dataall.api.Objects.DatasetProfiling.resolvers._get_profiling_results_from_s3',
+        return_value='{"results": "yes"}',
+    )
+    module_mocker.patch('requests.post', return_value=True)
+
+    response = client.query(
+        """
+        query listDatasetTableProfilingRuns($tableUri:String!){
+            listDatasetTableProfilingRuns(tableUri:$tableUri){
+                count
+                nodes{
+                    profilingRunUri
+                    status
+                    GlueTableName
+                }
+
+            }
+        }
+        """,
+        tableUri=table1.tableUri,
+        groups=[group2.name],
+        username=user2.userName,
+    )
+    assert 'UnauthorizedOperation' in response.errors[0].message


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- For datasets that are classified as "Secret", data preview is disabled. In the same way, data profiling results should alse be denied.
![image](https://github.com/awslabs/aws-dataall/assets/71252798/cc860476-b8ad-429f-ab2b-76c6f09f0010)

### Relates
- #478 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
