### PR TITLE
Update CDK Version to v2.77.0 to fix issue with CDK Pipeline role

### DIFF
--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.61.1
+aws-cdk-lib==2.77.0
 aws_cdk.aws_redshift_alpha==2.14.0a0
 boto3==1.24.85
 boto3-stubs==1.24.85

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.61.1
+aws-cdk-lib==2.77.0
 boto3-stubs==1.20.20
 boto3==1.24.85
 botocore==1.27.85


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Detail
- The AWS Cloud Development Kit (CDK) Team recently identified an issue with the CDK Pipelines construct library that may result in unintended permissions being granted to authenticated users within your account. As of April 4, 2023, we have fixed the issue in version 1.200.0 [1] for CDK v1, and version 2.77.0 [2] for CDK v2. We strongly recommend you upgrade to one of these versions as soon as possible. Please refer to the Managing Dependencies documentation [3] in the CDK Developer Guide for instructions on how to perform the upgrade.
Starting with versions 1.158.0 and 2.26.0, released May 30, 2022, the library creates a role that allows every identity in the same account with sts:AssumeRole permissions on Resource: * to assume it. This may result in granting privileges to authenticated users in your account allowing them to take pipeline actions beyond what was intended.

### Relates
- N.A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
