### PR TITLE
Fix/safe removal of consumption roles with open share requests

### DIFF
--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -392,6 +392,23 @@ class Environment:
                 message=f'Team: {group} has created {group_env_objects_count} resources on this environment.',
             )
 
+        shares_count = (
+            session.query(models.ShareObject)
+            .filter(
+                and_(
+                    models.ShareObject.principalId == group,
+                    models.ShareObject.principalType == PrincipalType.Group.value
+                )
+            )
+            .count()
+        )
+
+        if shares_count > 0:
+            raise exceptions.EnvironmentResourcesFound(
+                action='Remove Team',
+                message=f'Consumption role: {group} has created {shares_count} share requests on this environment.',
+            )
+
         group_membership = Environment.find_environment_group(
             session, group, environment.environmentUri
         )

--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -529,6 +529,23 @@ class Environment:
 
         consumption_role = Environment.get_environment_consumption_role(session, uri, data.get('environmentUri'))
 
+        shares_count = (
+            session.query(models.ShareObject)
+            .filter(
+                and_(
+                    models.ShareObject.principalId == uri,
+                    models.ShareObject.principalType == PrincipalType.ConsumptionRole.value
+                )
+            )
+            .count()
+        )
+
+        if shares_count > 0:
+            raise exceptions.EnvironmentResourcesFound(
+                action='Remove Consumption Role',
+                message=f'Consumption role: {consumption_role} has created {shares_count} share requests on this environment.',
+            )
+
         if consumption_role:
             session.delete(consumption_role)
             session.commit()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Added check and exception if there are open share requests on a consumption role or on a group that we are removing from an environment

### Relates
- #450 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
