### PR TITLE
feat: limit dataset role permissions

### DIFF
--- a/backend/dataall/aws/handlers/glue.py
+++ b/backend/dataall/aws/handlers/glue.py
@@ -473,7 +473,7 @@ class Glue:
             glue = session.client('glue', region_name=data.get('region', 'eu-west-1'))
             if data.get('location'):
                 Glue._update_existing_crawler(
-                    glue, accountid, crawler_name, targets, database
+                    glue, crawler_name, targets, database
                 )
             crawler = Glue._get_crawler(glue, crawler_name)
             glue.start_crawler(Name=crawler_name)
@@ -496,7 +496,7 @@ class Glue:
         return crawler.get('Crawler') if crawler else None
 
     @staticmethod
-    def _update_existing_crawler(glue, accountid, crawler_name, targets, database):
+    def _update_existing_crawler(glue, crawler_name, targets, database):
         try:
             glue.stop_crawler(Name=crawler_name)
         except ClientError as e:
@@ -508,7 +508,6 @@ class Glue:
         try:
             glue.update_crawler(
                 Name=crawler_name,
-                Role=SessionHelper.get_delegation_role_arn(accountid=accountid),
                 DatabaseName=database,
                 Targets=targets,
             )

--- a/backend/dataall/aws/handlers/lakeformation.py
+++ b/backend/dataall/aws/handlers/lakeformation.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from .sts import SessionHelper
 
 log = logging.getLogger('aws:lakeformation')
-PIVOT_ROLE_NAME_PREFIX = "datallPivotRole"
+PIVOT_ROLE_NAME_PREFIX = "dataallPivotRole"
 
 
 class LakeFormation:

--- a/backend/dataall/cdkproxy/requirements.txt
+++ b/backend/dataall/cdkproxy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.61.1
+aws-cdk-lib==2.77.0
 aws_cdk.aws_redshift_alpha==2.14.0a0
 boto3==1.24.85
 boto3-stubs==1.24.85

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -247,6 +247,36 @@ class Dataset(Stack):
                     ],
                 ),
                 iam.PolicyStatement(
+                    sid="GlueAccessCrawler",
+                    actions=[
+                        "glue:GetDatabase",
+                        "glue:GetTableVersion",
+                        "glue:CreateTable",
+                        "glue:GetTables",
+                        "glue:GetTableVersions",
+                        "glue:UpdateTable",
+                        "glue:DeleteTableVersion",
+                        "glue:DeleteTable",
+                        "glue:GetTable"
+                    ],
+                    effect=iam.Effect.ALLOW,
+                    resources=[
+                        f"arn:aws:glue:*:{dataset.AwsAccountId}:catalog",
+                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/{dataset.S3BucketName}",
+                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:table/{dataset.S3BucketName}/*"
+                    ]
+                ),
+                iam.PolicyStatement(
+                    sid="LoggingGlueCrawler",
+                    actions=[
+                        'logs:PutLogEvents',
+                    ],
+                    effect=iam.Effect.ALLOW,
+                    resources=[
+                        f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/crawlers:log-stream:{dataset.GlueCrawlerName}',
+                    ],
+                ),
+                iam.PolicyStatement(
                     actions=['s3:ListEnvironmentBucket'],
                     resources=[f'arn:aws:s3:::{env.EnvironmentDefaultBucketName}'],
                     effect=iam.Effect.ALLOW,

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -220,7 +220,7 @@ class Dataset(Stack):
                         "s3:GetObjectAcl",
                         "s3:GetObjectVersion",
                         "s3:DeleteObject"
-                     ],
+                    ],
                     effect=iam.Effect.ALLOW,
                     resources=[dataset_bucket.bucket_arn + '/*'],
                 ),

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -197,12 +197,6 @@ class Dataset(Stack):
                     actions=['s3:List*'], resources=['*'], effect=iam.Effect.ALLOW
                 ),
                 iam.PolicyStatement(
-                    actions=['logs:*'], resources=['*'], effect=iam.Effect.ALLOW
-                ),
-                iam.PolicyStatement(
-                    actions=['tag:*'], resources=['*'], effect=iam.Effect.ALLOW
-                ),
-                iam.PolicyStatement(
                     actions=['s3:List*', 's3:Get*'],
                     resources=[dataset_bucket.bucket_arn],
                     effect=iam.Effect.ALLOW,
@@ -217,68 +211,21 @@ class Dataset(Stack):
                         's3:GetAccessPoint',
                         's3:GetAccessPointPolicy',
                         's3:ListAccessPoints',
-                        's3:CreateAccessPoint',
-                        's3:DeleteAccessPoint',
                         's3:GetAccessPointPolicyStatus',
-                        's3:DeleteAccessPointPolicy',
-                        's3:PutAccessPointPolicy',
                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[
-                        f'arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/*',
+                        f'arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{dataset.datasetUri}*',
                     ],
                 ),
                 iam.PolicyStatement(
-                    actions=['s3:List*', 's3:Get*'],
+                    actions=['s3:List*'],
                     resources=[f'arn:aws:s3:::{env.EnvironmentDefaultBucketName}'],
                     effect=iam.Effect.ALLOW,
                 ),
                 iam.PolicyStatement(
-                    actions=['s3:*'],
-                    effect=iam.Effect.ALLOW,
-                    resources=[f'arn:aws:s3:::{env.EnvironmentDefaultBucketName}/*'],
-                ),
-                iam.PolicyStatement(
-                    effect=iam.Effect.ALLOW,
-                    resources=['arn:aws:s3:::aws-glue-*'],
-                    actions=['s3:CreateBucket'],
-                ),
-                iam.PolicyStatement(
-                    actions=['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-                    effect=iam.Effect.ALLOW,
-                    resources=[
-                        'arn:aws:s3:::aws-glue-*/*',
-                        'arn:aws:s3:::*/*aws-glue-*/*',
-                    ],
-                ),
-                iam.PolicyStatement(
-                    actions=['s3:GetObject'],
-                    effect=iam.Effect.ALLOW,
-                    resources=[
-                        'arn:aws:s3:::crawler-public*',
-                        'arn:aws:s3:::aws-glue-*',
-                    ],
-                ),
-                iam.PolicyStatement(
-                    actions=[
-                        'logs:CreateLogGroup',
-                        'logs:CreateLogStream',
-                        'logs:PutLogEvents',
-                    ],
-                    effect=iam.Effect.ALLOW,
-                    resources=['arn:aws:logs:*:*:/aws-glue/*'],
-                ),
-                iam.PolicyStatement(
-                    actions=['kms:*'], effect=iam.Effect.ALLOW, resources=['*']
-                ),
-                iam.PolicyStatement(
-                    actions=['glue:*', 'athena:*', 'lakeformation:*'],
-                    resources=['*'],
-                    effect=iam.Effect.ALLOW,
-                ),
-                iam.PolicyStatement(
-                    actions=['cloudformation:*'],
-                    resources=['*'],
+                    actions=['s3:List*', 's3:Get*'],
+                    resources=[f'arn:aws:s3:::{env.EnvironmentDefaultBucketName}/profiling*'],
                     effect=iam.Effect.ALLOW,
                 ),
             ],
@@ -290,14 +237,6 @@ class Dataset(Stack):
             'DatasetAdminRole',
             role_name=dataset.IAMDatasetAdminRoleArn.split('/')[-1],
             assumed_by=iam.CompositePrincipal(
-                iam.ServicePrincipal('glue.amazonaws.com'),
-                iam.ServicePrincipal('lakeformation.amazonaws.com'),
-                iam.ServicePrincipal('athena.amazonaws.com'),
-                iam.ServicePrincipal('sagemaker.amazonaws.com'),
-                iam.ServicePrincipal('lambda.amazonaws.com'),
-                iam.ServicePrincipal('ec2.amazonaws.com'),
-                iam.AccountPrincipal(str(os.environ.get('CURRENT_AWS_ACCOUNT'))),
-                iam.AccountPrincipal(dataset.AwsAccountId),
                 iam.ArnPrincipal(
                     f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'
                 ),

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -267,6 +267,17 @@ class Dataset(Stack):
                     ]
                 ),
                 iam.PolicyStatement(
+                    sid="CreateLoggingGlueCrawler",
+                    actions=[
+                        'logs:CreateLogGroup',
+                        'logs:CreateLogStream',
+                    ],
+                    effect=iam.Effect.ALLOW,
+                    resources=[
+                        f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/crawlers*',
+                    ],
+                ),
+                iam.PolicyStatement(
                     sid="LoggingGlueCrawler",
                     actions=[
                         'logs:PutLogEvents',

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -194,15 +194,29 @@ class Dataset(Stack):
             policy_name=dataset.S3BucketName,
             statements=[
                 iam.PolicyStatement(
-                    actions=['s3:List*'], resources=['*'], effect=iam.Effect.ALLOW
+                    actions=[
+                        "s3:ListAllMyBuckets",
+                        "s3:ListAccessPoints",
+                    ],
+                    resources=["*"],
+                    effect=iam.Effect.ALLOW
                 ),
                 iam.PolicyStatement(
-                    actions=['s3:List*', 's3:Get*'],
+                    actions=[
+                        "s3:ListBucket",
+                        "s3:GetBucketLocation"
+                    ],
                     resources=[dataset_bucket.bucket_arn],
                     effect=iam.Effect.ALLOW,
                 ),
                 iam.PolicyStatement(
-                    actions=['s3:*'],
+                    actions=[
+                        "s3:PutObject",
+                        "s3:PutObjectAcl",
+                        "s3:GetObject",
+                        "s3:GetObjectAcl",
+                        "s3:DeleteObject"
+                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[dataset_bucket.bucket_arn + '/*'],
                 ),
@@ -210,7 +224,6 @@ class Dataset(Stack):
                     actions=[
                         's3:GetAccessPoint',
                         's3:GetAccessPointPolicy',
-                        's3:ListAccessPoints',
                         's3:GetAccessPointPolicyStatus',
                     ],
                     effect=iam.Effect.ALLOW,
@@ -219,7 +232,7 @@ class Dataset(Stack):
                     ],
                 ),
                 iam.PolicyStatement(
-                    actions=['s3:List*'],
+                    actions=['s3:ListBucket'],
                     resources=[f'arn:aws:s3:::{env.EnvironmentDefaultBucketName}'],
                     effect=iam.Effect.ALLOW,
                 ),
@@ -240,6 +253,7 @@ class Dataset(Stack):
                 iam.ArnPrincipal(
                     f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'
                 ),
+                iam.ServicePrincipal('glue.amazonaws.com'),
             ),
         )
         dataset_admin_policy.attach_to_role(dataset_admin_role)

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -262,8 +262,8 @@ class Dataset(Stack):
                     effect=iam.Effect.ALLOW,
                     resources=[
                         f"arn:aws:glue:*:{dataset.AwsAccountId}:catalog",
-                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/{dataset.S3BucketName}",
-                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:table/{dataset.S3BucketName}/*"
+                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/{dataset.GlueDatabaseName}",
+                        f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:table/{dataset.GlueDatabaseName}/*"
                     ]
                 ),
                 iam.PolicyStatement(

--- a/backend/dataall/db/api/environment.py
+++ b/backend/dataall/db/api/environment.py
@@ -392,6 +392,23 @@ class Environment:
                 message=f'Team: {group} has created {group_env_objects_count} resources on this environment.',
             )
 
+        shares_count = (
+            session.query(models.ShareObject)
+            .filter(
+                and_(
+                    models.ShareObject.principalId == group,
+                    models.ShareObject.principalType == PrincipalType.Group.value
+                )
+            )
+            .count()
+        )
+
+        if shares_count > 0:
+            raise exceptions.EnvironmentResourcesFound(
+                action='Remove Team',
+                message=f'Team: {group} has created {shares_count} share requests on this environment.',
+            )
+
         group_membership = Environment.find_environment_group(
             session, group, environment.environmentUri
         )
@@ -528,6 +545,23 @@ class Environment:
             raise exceptions.RequiredParameter('consumptionRoleUri')
 
         consumption_role = Environment.get_environment_consumption_role(session, uri, data.get('environmentUri'))
+
+        shares_count = (
+            session.query(models.ShareObject)
+            .filter(
+                and_(
+                    models.ShareObject.principalId == uri,
+                    models.ShareObject.principalType == PrincipalType.ConsumptionRole.value
+                )
+            )
+            .count()
+        )
+
+        if shares_count > 0:
+            raise exceptions.EnvironmentResourcesFound(
+                action='Remove Consumption Role',
+                message=f'Consumption role: {consumption_role.consumptionRoleName} has created {shares_count} share requests on this environment.',
+            )
 
         if consumption_role:
             session.delete(consumption_role)

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.61.1
+aws-cdk-lib==2.77.0
 boto3-stubs==1.20.20
 boto3==1.24.85
 botocore==1.27.85


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
The resulting IAM policy can:
- list all buckets
- read and write objects to the dataset Bucket which is encrypted
- read S3 access points in the dataset Bucket
- putLogs in dataset Glue crawler log group
- read dataset Glue database, read and write tables in the dataset Glue database. This is not strictly necessary as in data.all permission to data is handled using Lake Formation. But restricting the IAM-based data permissions we ensure that any Glue resource that is not protected using Lake Formation is not accessible by this role
- WIP - read objects to the `/profiling/code` prefix in the environment bucket
- WIP - read and write objects to the `/profiling/code/results/datasetUri/` prefix in the environment bucket

IMPORTANT: I found a bug related to profiling jobs that prevented me to test the profiling jobs. A separate [issue](https://github.com/awslabs/aws-dataall/issues/506) has been opened for it. For this reason the profiling permissions are a work in progress and might require changes. e.g. additional KMS permissions.

It cannot:
- read or write to any other S3 Bucket
- use any KMS key different from the dataset KMS key
- read or write any other Glue database/tables

In addition, the Glue crawler and the profiling Job of the dataset have been modified to always use the dataset role and not the PivotRole to break down the "super permissions" of the pivot role and distribute responsibilities. As a result, the dataset role can be assumed:
- by the pivotRole -> used whenever users are assuming the role from data.all UI
- by Glue -> to run Glue profiling jobs and Glue crawler

### Relates
- #461 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
