### PR TITLE
fix: urllib3 dependencies for glue profiling job

### DIFF
--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -445,7 +445,7 @@ class Dataset(Stack):
         crawler.node.add_dependency(dataset_bucket)
 
         job_args = {
-            '--additional-python-modules': 'pydeequ,great_expectations,requests',
+            '--additional-python-modules': 'urllib3<2,pydeequ',
             '--datasetUri': dataset.datasetUri,
             '--database': dataset.GlueDatabaseName,
             '--datasetRegion': dataset.region,


### PR DESCRIPTION

### Feature or Bugfix
- Bugfix

### Detail
- Add urllib3 supported version for Glue Profiling Job

### Relates
- [#506 ]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
