### PR TITLE
modularization: Disable and skip module test directories for modules that are inactive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,27 @@
 import os
 import pytest
 import dataall
+from dataall.core.config import config
 from dataall.modules.loader import load_modules, ImportMode
 
 load_modules(modes=[ImportMode.HANDLERS, ImportMode.API, ImportMode.CDK])
 ENVNAME = os.environ.get('envname', 'pytest')
+
+collect_ignore_glob = []
+
+
+def ignore_module_tests_if_not_active():
+    """
+    Ignores tests of the modules that are turned off.
+    It uses the collect_ignore_glob hook
+    """
+    modules = config.get_property('modules', {})
+    for name, props in modules.items():
+        if not props["active"]:
+            collect_ignore_glob.append(os.path.join('modules', f'{name}*'))
+
+
+ignore_module_tests_if_not_active()
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def ignore_module_tests_if_not_active():
     modules = config.get_property('modules', {})
     for name, props in modules.items():
         if not props["active"]:
-            collect_ignore_glob.append(os.path.join('modules', f'{name}*'))
+            collect_ignore_glob.append(os.path.join('modules', f'{name}', '*'))
 
 
 ignore_module_tests_if_not_active()


### PR DESCRIPTION
Enabled the feature to turn off tests whenever a module if inactive. 
More info: https://docs.pytest.org/en/7.3.x/example/pythoncollection.html#customizing-test-collection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
