### PR TITLE
feat: Limiting read-only access to root file systems in ECS

### DIFF
--- a/backend/docker/prod/ecs/Dockerfile
+++ b/backend/docker/prod/ecs/Dockerfile
@@ -49,12 +49,13 @@ RUN /bin/bash -c "pip3.8 install -r /dh.requirements.txt"
 RUN /bin/bash -c "pip3.8 install -r /cdk.requirements.txt"
 
 ADD backend/dataall /dataall
+VOLUME ["/dataall"]
 ADD backend/blueprints /blueprints
 ADD backend/cdkproxymain.py /cdkproxymain.py
 
 RUN mkdir -p dataall/cdkproxy/assets/glueprofilingjob/jars
 RUN mkdir -p blueprints/ml_data_pipeline/engine/glue/jars
-RUN curl https://repo1.maven.org/maven2/com/amazon/deequ/deequ/$DEEQU_VERSION/deequ-$DEEQU_VERSION.jar --output dataall/cdkproxy/assets/glueprofilingjob/jars/deequ-$DEEQU_VERSION.jar
+ADD https://repo1.maven.org/maven2/com/amazon/deequ/deequ/$DEEQU_VERSION/deequ-$DEEQU_VERSION.jar /dataall/cdkproxy/assets/glueprofilingjob/jars/
 RUN cp -f dataall/cdkproxy/assets/glueprofilingjob/jars/deequ-$DEEQU_VERSION.jar blueprints/ml_data_pipeline/engine/glue/jars/deequ-$DEEQU_VERSION.jar
 
 WORKDIR /

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -277,7 +277,7 @@ class BackendStack(Stack):
             ],
             database=aurora_stack.cluster.cluster_identifier,
             ecs_cluster=self.ecs_stack.ecs_cluster,
-            ecs_task_definitions=self.ecs_stack.ecs_task_definitions,
+            ecs_task_definitions_families=self.ecs_stack.ecs_task_definitions_families,
             backend_api=self.lambda_api_stack.backend_api_name,
             queue_name=sqs_stack.queue.queue_name,
             **kwargs,

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -77,6 +77,7 @@ class ContainerStack(pyNestedClass):
                     envname, resource_prefix, log_group_name='cdkproxy'
                 ),
             ),
+            readonly_root_filesystem=True,
         )
 
         ssm.StringParameter(
@@ -258,6 +259,7 @@ class ContainerStack(pyNestedClass):
                     envname, resource_prefix, log_group_name='share-manager'
                 ),
             ),
+            readonly_root_filesystem=True,
         )
 
         ssm.StringParameter(
@@ -544,6 +546,7 @@ class ContainerStack(pyNestedClass):
             environment=environment,
             command=command,
             logging=ecs.LogDriver.aws_logs(stream_prefix='task', log_group=log_group),
+            readonly_root_filesystem=True,
         )
         scheduled_task = ecs_patterns.ScheduledFargateTask(
             self,

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -83,7 +83,7 @@ class ContainerStack(pyNestedClass):
                 log_configuration=ecs.CfnTaskDefinition.LogConfigurationProperty(
                     log_driver="awslogs",
                     options={
-                        "awslogs-group": f'/{resource_prefix}/{envname}/ecs/cdkproxy',
+                        "awslogs-group": cdkproxy_log_group.log_group_name,
                         "awslogs-region": self.region,
                         "awslogs-stream-prefix": "task"
                     },

--- a/deploy/stacks/monitoring.py
+++ b/deploy/stacks/monitoring.py
@@ -27,7 +27,7 @@ class MonitoringStack(pyNestedClass):
         lambdas: [_lambda.Function] = None,
         database='dataalldevdb',
         ecs_cluster: ecs.Cluster = None,
-        ecs_task_definitions: [ecs.FargateTaskDefinition] = None,
+        ecs_task_definitions_families = None,
         backend_api=None,
         queue_name: str = None,
         **kwargs,
@@ -51,7 +51,7 @@ class MonitoringStack(pyNestedClass):
             backend_api,
             database,
             ecs_cluster,
-            ecs_task_definitions,
+            ecs_task_definitions_families,
             envname,
             lambdas,
             resource_prefix,
@@ -136,7 +136,7 @@ class MonitoringStack(pyNestedClass):
         backend_api,
         database,
         ecs_cluster,
-        ecs_task_definitions,
+        ecs_task_definitions_families,
         envname,
         lambdas,
         resource_prefix,
@@ -173,19 +173,18 @@ class MonitoringStack(pyNestedClass):
                 cf_ecs.build_ecs_cluster_task_count_widget(cluster_name),
             )
 
-            if ecs_task_definitions:
+            if ecs_task_definitions_families:
                 dashboard.add_widgets(cw.TextWidget(width=24, markdown='# ECS Tasks'))
-                task: ecs.FargateTaskDefinition
-                for task in ecs_task_definitions:
+                for task_family in ecs_task_definitions_families:
                     dashboard.add_widgets(
                         cf_ecs.build_ecs_task_container_insight_cpu_widget(
-                            cluster_name, task.family
+                            cluster_name, task_family
                         ),
                         cf_ecs.build_ecs_task_container_insight_memory_widget(
-                            cluster_name, task.family
+                            cluster_name, task_family
                         ),
                         cf_ecs.build_ecs_task_container_insight_storage_widget(
-                            cluster_name, task.family
+                            cluster_name, task_family
                         ),
                     )
         if database:


### PR DESCRIPTION
Limiting read-only access for ECS tasks deployed by data.all, reasoning detailed in: https://github.com/awslabs/aws-dataall/issues/426

Out of the 7 ECS tasks that gets deployed, only CDKProxy performs multiple write operations to the root filesystem.
The workaround is to mount [bind volumes](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html) to the proper paths in the filesystem:

- **/dataall:** required for cdk deploy write operations (cdk.out, cdk.context.json) and further file write operations invoked through dataa.all business logic like archiving objects for the Glue profiling job
- **/tmp:** required since by upon importing aws_cdk libraries a write operation happens to the /tmp folder


Since the [currently used CDK class](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ecs/FargateTaskDefinition.html) for the Fargate task definition doesn't allow the definition of mount points, I had to replace the it with the [CFN-style class.](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ecs/CfnTaskDefinition.html)


**[Testing]**
I've created 2 environments and a dataset, and performed the sharing of the dataset between the 2 environments.
I've verified, that:

- the newly created CDKProxy task definition has the same attributes as the old one (with the further addition of the ReadOnlyRootFileSystem=True flag and the 2 new bind volumes)
- the other 6 task definitions have ReadOnlyRootFileSystem=True enabled
- all 7 tasks were executed without failure with the new setting
- the security alert in security hub got archived



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
