### PR TITLE
Three documentation updates

### DIFF
--- a/pages/architecture.md
+++ b/pages/architecture.md
@@ -73,14 +73,14 @@ from the AWS logic and processing. To achieve this decoupling, the web applicati
 5. Short Running Asynchronous Tasks Processor (AWS Lambda)
 
 data.all infrastructure runs <span style="color:#2074d5">**90% on serverless**</span> services in a private VPC, 
-the remaining 10% are for the OpenSearch cluster that is not serverless... yet!
+the remaining 10% is for the OpenSearch cluster. Since data.all release v1.5.0 you have the ability to deploy an OpenSearch Serverless cluster instead by specifying the `enable_opensearch_serverless` parameter of the configuration cdk.json file. Check the [Deploy to AWS](./deploy-aws/) section.
 
 ![archi](img/architecture_infrastructure.drawio.png#zoom#shadow)
 
 ## Frontend Components <a name="frontend"></a>
 
 To fit the requirements of enterprise grade customers, data.all architecture has two variants. Both 
-architectures are part of data.all code base and can be configured with in the deployment with the 
+architectures are part of data.all code base and can be configured in the deployment with the 
 `internet_facing` parameter of the configuration cdk.json file. Check the [Deploy to AWS](./deploy-aws/) section.
 
 - Internet facing architecture

--- a/pages/deploy/deploy_aws.md
+++ b/pages/deploy/deploy_aws.md
@@ -321,7 +321,7 @@ cdk bootstrap --trust <tooling-account-id> --trust-for-lookup <tooling-account-i
 ```
 North Virginia region (needed for Cloudfront integration with ACM on us-east-1)
 ```bash
-cdk bootstrap --trust <tooling-account-id> --trust-for-lookup <tooling-account-id> -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://<deployment-account-id>/us-east
+cdk bootstrap --trust <tooling-account-id> --trust-for-lookup <tooling-account-id> -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://<deployment-account-id>/us-east-1
 ```
 
 
@@ -393,6 +393,7 @@ Some AWS resources have deletion particularities:
 in AWS CloudFormation. Enable deletion in RDS before deleting `<resource_prefix>-<git_branch>-cicd-stack`. 
 - KMS keys are marked as `pending deletion` and once the waiting period is over they are effectively deleted. This is
 their default behavior explained in the [documentation](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html).
+- The S3 buckets created by the deployment will not get deleted by AWS CloudFormation automatically, given these contain objects. Before running a new deployment, remove the S3 buckets matching the naming convention `<resource_prefix>-<git_branch>-cicd-stack-xxxxxxxxx` first to prevent a CloudFormation error reporting on already existing buckets.
 
 ### Troubleshooting - The CodePipeline Pipeline fails with CodeBuild Error Code "AccountLimitExceededException"
 Sometimes, we run into the following error *"Error calling startBuild: Cannot have more than 1 builds in queue for the account"*.


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Added information about OpenSearch serverless to architecture.md
- Fixed typo in architecture.md
- Fixed region typo in deploy_aws.md
- Added information about how to undeploy data.all and trigger a re-deploy, which requires S3 bucket deletion first.

### Relates
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
