### PR TITLE
Change the pipeline for the modularization

### DIFF
--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -32,11 +32,15 @@ class ContainerStack(pyNestedClass):
     ):
         super().__init__(scope, id, **kwargs)
         self._envname = envname
+        self._resource_prefix = resource_prefix
 
         if self.node.try_get_context('image_tag'):
             image_tag = self.node.try_get_context('image_tag')
 
-        cdkproxy_image_tag = f'cdkproxy-{image_tag}'
+        self._cdkproxy_image_tag = f'cdkproxy-{image_tag}'
+        self._ecr_repository = ecr_repository
+        self._vpc = vpc
+        self._prod_sizing = prod_sizing
 
         self.ecs_security_groups: [aws_ec2.SecurityGroup] = []
 
@@ -65,7 +69,7 @@ class ContainerStack(pyNestedClass):
             f'ShareManagementTaskContainer{envname}',
             container_name=f'container',
             image=ecs.ContainerImage.from_ecr_repository(
-                repository=ecr_repository, tag=cdkproxy_image_tag
+                repository=ecr_repository, tag=self._cdkproxy_image_tag
             ),
             environment=self._create_env('DEBUG'),
             command=['python3.8', '-m', 'dataall.tasks.cdkproxy'],
@@ -91,30 +95,9 @@ class ContainerStack(pyNestedClass):
             string_value=cdkproxy_container.container_name,
         )
 
-        scheduled_tasks_sg = self.create_task_sg(
+        self._scheduled_tasks_sg = self.create_task_sg(
             envname, resource_prefix, vpc, vpc_endpoints_sg
         )
-
-        # TODO introduce the ability to change the deployment depending on config.json file
-        sync_tables_task, sync_tables_task_def = self.set_scheduled_task(
-            cluster=cluster,
-            command=['python3.8', '-m', 'dataall.modules.datasets.tasks.tables_syncer'],
-            container_id=f'container',
-            ecr_repository=ecr_repository,
-            environment=self._create_env('INFO'),
-            image_tag=cdkproxy_image_tag,
-            log_group=self.create_log_group(
-                envname, resource_prefix, log_group_name='tables-syncer'
-            ),
-            schedule_expression=Schedule.expression('rate(15 minutes)'),
-            scheduled_task_id=f'{resource_prefix}-{envname}-tables-syncer-schedule',
-            task_id=f'{resource_prefix}-{envname}-tables-syncer',
-            task_role=self.task_role,
-            vpc=vpc,
-            security_group=scheduled_tasks_sg,
-            prod_sizing=prod_sizing,
-        )
-        self.ecs_security_groups.extend(sync_tables_task.task.security_groups)
 
         catalog_indexer_task, catalog_indexer_task_def = self.set_scheduled_task(
             cluster=cluster,
@@ -122,7 +105,7 @@ class ContainerStack(pyNestedClass):
             container_id=f'container',
             ecr_repository=ecr_repository,
             environment=self._create_env('INFO'),
-            image_tag=cdkproxy_image_tag,
+            image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(
                 envname, resource_prefix, log_group_name='catalog-indexer'
             ),
@@ -131,7 +114,7 @@ class ContainerStack(pyNestedClass):
             task_id=f'{resource_prefix}-{envname}-catalog-indexer',
             task_role=self.task_role,
             vpc=vpc,
-            security_group=scheduled_tasks_sg,
+            security_group=self._scheduled_tasks_sg,
             prod_sizing=prod_sizing,
         )
         self.ecs_security_groups.extend(catalog_indexer_task.task.security_groups)
@@ -142,7 +125,7 @@ class ContainerStack(pyNestedClass):
             container_id=f'container',
             ecr_repository=ecr_repository,
             environment=self._create_env('INFO'),
-            image_tag=cdkproxy_image_tag,
+            image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(
                 envname, resource_prefix, log_group_name='stacks-updater'
             ),
@@ -151,7 +134,7 @@ class ContainerStack(pyNestedClass):
             task_id=f'{resource_prefix}-{envname}-stacks-updater',
             task_role=self.task_role,
             vpc=vpc,
-            security_group=scheduled_tasks_sg,
+            security_group=self._scheduled_tasks_sg,
             prod_sizing=prod_sizing,
         )
         self.ecs_security_groups.extend(stacks_updater.task.security_groups)
@@ -161,95 +144,6 @@ class ContainerStack(pyNestedClass):
             f'StacksUpdaterTaskDefParam{envname}',
             parameter_name=f'/dataall/{envname}/ecs/task_def_arn/stacks_updater',
             string_value=stacks_updater_task_def.task_definition_arn,
-        )
-
-        # TODO introduce the ability to change the deployment depending on config.json file
-        update_bucket_policies_task, update_bucket_task_def = self.set_scheduled_task(
-            cluster=cluster,
-            command=['python3.8', '-m', 'dataall.modules.datasets.tasks.bucket_policy_updater'],
-            container_id=f'container',
-            ecr_repository=ecr_repository,
-            environment=self._create_env('DEBUG'),
-            image_tag=cdkproxy_image_tag,
-            log_group=self.create_log_group(
-                envname, resource_prefix, log_group_name='policies-updater'
-            ),
-            schedule_expression=Schedule.expression('rate(15 minutes)'),
-            scheduled_task_id=f'{resource_prefix}-{envname}-policies-updater-schedule',
-            task_id=f'{resource_prefix}-{envname}-policies-updater',
-            task_role=self.task_role,
-            vpc=vpc,
-            security_group=scheduled_tasks_sg,
-            prod_sizing=prod_sizing,
-        )
-        self.ecs_security_groups.extend(
-            update_bucket_policies_task.task.security_groups
-        )
-
-        # TODO introduce the ability to change the deployment depending on config.json file
-        subscriptions_task, subscription_task_def = self.set_scheduled_task(
-            cluster=cluster,
-            command=[
-                'python3.8',
-                '-m',
-                'dataall.modules.datasets.tasks.dataset_subscription_task',
-            ],
-            container_id=f'container',
-            ecr_repository=ecr_repository,
-            environment=self._create_env('INFO'),
-            image_tag=cdkproxy_image_tag,
-            log_group=self.create_log_group(
-                envname, resource_prefix, log_group_name='subscriptions'
-            ),
-            schedule_expression=Schedule.expression('rate(15 minutes)'),
-            scheduled_task_id=f'{resource_prefix}-{envname}-subscriptions-schedule',
-            task_id=f'{resource_prefix}-{envname}-subscriptions',
-            task_role=self.task_role,
-            vpc=vpc,
-            security_group=scheduled_tasks_sg,
-            prod_sizing=prod_sizing,
-        )
-        self.ecs_security_groups.extend(subscriptions_task.task.security_groups)
-
-        share_management_task_definition = ecs.FargateTaskDefinition(
-            self,
-            f'{resource_prefix}-{envname}-share-manager',
-            cpu=1024,
-            memory_limit_mib=2048,
-            task_role=self.task_role,
-            execution_role=self.task_role,
-            family=f'{resource_prefix}-{envname}-share-manager',
-        )
-
-        # TODO introduce the ability to change the deployment depending on config.json file
-        share_management_container = share_management_task_definition.add_container(
-            f'ShareManagementTaskContainer{envname}',
-            container_name=f'container',
-            image=ecs.ContainerImage.from_ecr_repository(
-                repository=ecr_repository, tag=cdkproxy_image_tag
-            ),
-            environment=self._create_env('DEBUG'),
-            command=['python3.8', '-m', 'dataall.modules.dataset_sharing.tasks.share_manager_task'],
-            logging=ecs.LogDriver.aws_logs(
-                stream_prefix='task',
-                log_group=self.create_log_group(
-                    envname, resource_prefix, log_group_name='share-manager'
-                ),
-            ),
-        )
-
-        ssm.StringParameter(
-            self,
-            f'ShareManagementTaskDef{envname}',
-            parameter_name=f'/dataall/{envname}/ecs/task_def_arn/share_management',
-            string_value=share_management_task_definition.task_definition_arn,
-        )
-
-        ssm.StringParameter(
-            self,
-            f'ShareManagementContainerParam{envname}',
-            parameter_name=f'/dataall/{envname}/ecs/container/share_management',
-            string_value=share_management_container.container_name,
         )
 
         ssm.StringParameter(
@@ -270,22 +164,139 @@ class ContainerStack(pyNestedClass):
             ),
         )
 
-        ssm.StringParameter(
-            self,
-            f'SecurityGroup{envname}',
-            parameter_name=f'/dataall/{envname}/ecs/security_groups',
-            string_value=','.join([s.security_group_id for s in sync_tables_task.task.security_groups]),
-        )
-
         self.ecs_cluster = cluster
+
+        self.add_sync_dataset_table_task()
+        self.add_bucket_policy_updater_task()
+        self.add_subscription_task()
+        self.add_share_management_task()
+
         self.ecs_task_definitions = [
             cdkproxy_task_definition,
-            sync_tables_task.task_definition,
-            update_bucket_policies_task.task_definition,
             catalog_indexer_task.task_definition,
-            share_management_task_definition,
-            subscriptions_task.task_definition,
         ]
+
+    def add_share_management_task(self):
+        share_management_task_definition = ecs.FargateTaskDefinition(
+            self,
+            f'{self._resource_prefix}-{self._envname}-share-manager',
+            cpu=1024,
+            memory_limit_mib=2048,
+            task_role=self.task_role,
+            execution_role=self.task_role,
+            family=f'{self._resource_prefix}-{self._envname}-share-manager',
+        )
+
+        share_management_container = share_management_task_definition.add_container(
+            f'ShareManagementTaskContainer{self._envname}',
+            container_name=f'container',
+            image=ecs.ContainerImage.from_ecr_repository(
+                repository=self._ecr_repository, tag=self._cdkproxy_image_tag
+            ),
+            environment=self._create_env('DEBUG'),
+            command=['python3.8', '-m', 'dataall.modules.dataset_sharing.tasks.share_manager_task'],
+            logging=ecs.LogDriver.aws_logs(
+                stream_prefix='task',
+                log_group=self.create_log_group(
+                    self._envname, self._resource_prefix, log_group_name='share-manager'
+                ),
+            ),
+        )
+
+        ssm.StringParameter(
+            self,
+            f'ShareManagementTaskDef{self._envname}',
+            parameter_name=f'/dataall/{self._envname}/ecs/task_def_arn/share_management',
+            string_value=share_management_task_definition.task_definition_arn,
+        )
+
+        ssm.StringParameter(
+            self,
+            f'ShareManagementContainerParam{self._envname}',
+            parameter_name=f'/dataall/{self._envname}/ecs/container/share_management',
+            string_value=share_management_container.container_name,
+        )
+        self.ecs_task_definitions.append(share_management_task_definition)
+
+    def add_subscription_task(self):
+        subscriptions_task, subscription_task_def = self.set_scheduled_task(
+            cluster=self.ecs_cluster,
+            command=[
+                'python3.8',
+                '-m',
+                'dataall.modules.datasets.tasks.dataset_subscription_task',
+            ],
+            container_id=f'container',
+            ecr_repository=self._ecr_repository,
+            environment=self._create_env('INFO'),
+            image_tag=self._cdkproxy_image_tag,
+            log_group=self.create_log_group(
+                self._envname, self._resource_prefix, log_group_name='subscriptions'
+            ),
+            schedule_expression=Schedule.expression('rate(15 minutes)'),
+            scheduled_task_id=f'{self._resource_prefix}-{self._envname}-subscriptions-schedule',
+            task_id=f'{self._resource_prefix}-{self._envname}-subscriptions',
+            task_role=self.task_role,
+            vpc=self._vpc,
+            security_group=self._scheduled_tasks_sg,
+            prod_sizing=self._prod_sizing,
+        )
+        self.ecs_security_groups.extend(subscriptions_task.task.security_groups)
+        self.ecs_task_definitions.append(subscriptions_task.task_definition)
+
+    def add_bucket_policy_updater_task(self):
+        update_bucket_policies_task, update_bucket_task_def = self.set_scheduled_task(
+            cluster=self.ecs_cluster,
+            command=['python3.8', '-m', 'dataall.modules.datasets.tasks.bucket_policy_updater'],
+            container_id=f'container',
+            ecr_repository=self._ecr_repository,
+            environment=self._create_env('DEBUG'),
+            image_tag=self._cdkproxy_image_tag,
+            log_group=self.create_log_group(
+                self._envname, self._resource_prefix, log_group_name='policies-updater'
+            ),
+            schedule_expression=Schedule.expression('rate(15 minutes)'),
+            scheduled_task_id=f'{self._resource_prefix}-{self._envname}-policies-updater-schedule',
+            task_id=f'{self._resource_prefix}-{self._envname}-policies-updater',
+            task_role=self.task_role,
+            vpc=self._vpc,
+            security_group=self._scheduled_tasks_sg,
+            prod_sizing=self._prod_sizing,
+        )
+        self.ecs_security_groups.extend(
+            update_bucket_policies_task.task.security_groups
+        )
+
+        self.ecs_task_definitions.append(update_bucket_policies_task.task_definition)
+
+    def add_sync_dataset_table_task(self):
+        sync_tables_task, sync_tables_task_def = self.set_scheduled_task(
+            cluster=self.ecs_cluster,
+            command=['python3.8', '-m', 'dataall.modules.datasets.tasks.tables_syncer'],
+            container_id=f'container',
+            ecr_repository=self._ecr_repository,
+            environment=self._create_env('INFO'),
+            image_tag=self._cdkproxy_image_tag,
+            log_group=self.create_log_group(
+                self._envname, self._resource_prefix, log_group_name='tables-syncer'
+            ),
+            schedule_expression=Schedule.expression('rate(15 minutes)'),
+            scheduled_task_id=f'{self._resource_prefix}-{self._envname}-tables-syncer-schedule',
+            task_id=f'{self._resource_prefix}-{self._envname}-tables-syncer',
+            task_role=self.task_role,
+            vpc=self._vpc,
+            security_group=self._scheduled_tasks_sg,
+            prod_sizing=self._prod_sizing,
+        )
+        self.ecs_security_groups.extend(sync_tables_task.task.security_groups)
+
+        ssm.StringParameter(
+            self,
+            f'SecurityGroup{self._envname}',
+            parameter_name=f'/dataall/{self._envname}/ecs/security_groups',
+            string_value=','.join([s.security_group_id for s in sync_tables_task.task.security_groups]),
+        )
+        self.ecs_task_definitions.append(sync_tables_task.task_definition)
 
     def create_cicd_stacks_updater_role(self, envname, resource_prefix, tooling_account_id):
         cicd_stacks_updater_role = iam.Role(
@@ -503,7 +514,7 @@ class ContainerStack(pyNestedClass):
         vpc,
         security_group,
         prod_sizing,
-    ) -> ecs_patterns.ScheduledFargateTask:
+    ) -> (ecs.FargateTaskDefinition, ecs_patterns.ScheduledFargateTask):
         task = ecs.FargateTaskDefinition(
             self,
             task_id,

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -12,6 +12,7 @@ from aws_cdk import (
 from aws_cdk.aws_applicationautoscaling import Schedule
 
 from .pyNestedStack import pyNestedClass
+from .run_if import run_if
 
 
 class ContainerStack(pyNestedClass):
@@ -176,6 +177,7 @@ class ContainerStack(pyNestedClass):
             catalog_indexer_task.task_definition,
         ]
 
+    @run_if("modules.datasets.active")
     def add_share_management_task(self):
         share_management_task_definition = ecs.FargateTaskDefinition(
             self,
@@ -218,6 +220,7 @@ class ContainerStack(pyNestedClass):
         )
         self.ecs_task_definitions.append(share_management_task_definition)
 
+    @run_if("modules.datasets.active")
     def add_subscription_task(self):
         subscriptions_task, subscription_task_def = self.set_scheduled_task(
             cluster=self.ecs_cluster,
@@ -244,6 +247,7 @@ class ContainerStack(pyNestedClass):
         self.ecs_security_groups.extend(subscriptions_task.task.security_groups)
         self.ecs_task_definitions.append(subscriptions_task.task_definition)
 
+    @run_if("modules.datasets.active")
     def add_bucket_policy_updater_task(self):
         update_bucket_policies_task, update_bucket_task_def = self.set_scheduled_task(
             cluster=self.ecs_cluster,
@@ -269,6 +273,7 @@ class ContainerStack(pyNestedClass):
 
         self.ecs_task_definitions.append(update_bucket_policies_task.task_definition)
 
+    @run_if("modules.datasets.active")
     def add_sync_dataset_table_task(self):
         sync_tables_task, sync_tables_task_def = self.set_scheduled_task(
             cluster=self.ecs_cluster,

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -167,15 +167,15 @@ class ContainerStack(pyNestedClass):
 
         self.ecs_cluster = cluster
 
-        self.add_sync_dataset_table_task()
-        self.add_bucket_policy_updater_task()
-        self.add_subscription_task()
-        self.add_share_management_task()
-
         self.ecs_task_definitions = [
             cdkproxy_task_definition,
             catalog_indexer_task.task_definition,
         ]
+
+        self.add_sync_dataset_table_task()
+        self.add_bucket_policy_updater_task()
+        self.add_subscription_task()
+        self.add_share_management_task()
 
     @run_if("modules.datasets.active")
     def add_share_management_task(self):

--- a/deploy/stacks/deploy_config.py
+++ b/deploy/stacks/deploy_config.py
@@ -1,0 +1,71 @@
+"""Reads and encapsulates the configuration provided in config.json"""
+import json
+import copy
+from typing import Any, Dict
+import os
+from pathlib import Path
+
+
+class _DeployConfig:
+    """A container of properties in the configuration file
+     and any other that can be specified/overwritten later in the application"""
+
+    def __init__(self):
+        self._config = self._read_config_file()
+
+    def get_property(self, key: str, default=None) -> Any:
+        """
+        Retrieves a copy of the property
+        Config uses dot as a separator to navigate easy to the needed property e.g.
+        some.needed.parameter is equivalent of config["some"]["needed"]["parameter"]
+        It enables fast navigation for any nested parameter
+        """
+        res = self._config
+
+        props = key.split(".")
+
+        # going through the hierarchy of json
+        for prop in props:
+            if prop not in res:
+                if default is not None:
+                    return default
+
+                raise KeyError(f"Couldn't find a property {key} in the config")
+
+            res = res[prop]
+        return copy.deepcopy(res)
+
+    def set_property(self, key: str, value: Any) -> None:
+        """
+        Sets a property into the config
+        If the property has dot it will be split to nested levels
+        """
+        conf = self._config
+        props = key.split(".")
+
+        for i, prop in enumerate(props):
+            if i == len(props) - 1:
+                conf[prop] = value
+            else:
+                conf[prop] = conf[prop] if prop in conf is not None else {}
+                conf = conf[prop]
+
+    @classmethod
+    def _read_config_file(cls) -> Dict[str, Any]:
+        with open(cls._path_to_file()) as config_file:
+            return json.load(config_file)
+
+    @staticmethod
+    def _path_to_file() -> str:
+        """Tries to get a property. If not defined it tries to resolve the config from the current file's directory"""
+        path = os.getenv("config_location")
+        if path:
+            return path
+        return os.path.join(Path(__file__).parents[2], "config.json")
+
+    def __repr__(self):
+        return str(self._config)
+
+
+deploy_config = _DeployConfig()
+

--- a/deploy/stacks/run_if.py
+++ b/deploy/stacks/run_if.py
@@ -1,0 +1,37 @@
+from .deploy_config import deploy_config
+
+
+def _process_func(func):
+    """Helper function that helps decorate methods/functions"""
+    def no_decorated(f):
+        return f
+
+    static_func = False
+    try:
+        fn = func.__func__
+        static_func = True
+    except AttributeError:
+        fn = func
+
+    # returns a function to call and static decorator if applied
+    return fn, staticmethod if static_func else no_decorated
+
+
+def run_if(active_property: str):
+    """
+    Decorator that check whether a method should be active or not.
+    The active_property must be a boolean value in the config file
+    """
+    def decorator(f):
+        fn, fn_decorator = _process_func(f)
+
+        def decorated(*args, **kwargs):
+            is_active = deploy_config.get_property(active_property, False)
+            if not is_active:
+                return None
+
+            return fn(*args, **kwargs)
+
+        return fn_decorator(decorated)
+
+    return decorator


### PR DESCRIPTION
A way to change the deployment pipeline based on the configuration file has been created in this PR.
Used the same approach with the feature flags as in #538 ( all kudos to @blitzmohit ) since it doesn't require a dedicated module loader (would be too much at least at the current stage for just toggling 4 tasks). Decided to use a bit different naming as it's not about futures/API, though the idea is completely the same. 

The config and decorator `run_if` can be used in many places, not only related to modularization 

I had to copy the config file from the backend since the file is not reachable from the deployment code base (except changing `PYTHONPATH` on the fly, but it'd bring other complications with backend loading)

The open question that's out of this PR scope: should all / some / none properties be migrated from `cdk.json` -> `config.json to` keep them centralize?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
