### PR TITLE
Resolve dataset share checks when deleting dataset

### DIFF
--- a/backend/dataall/db/api/dataset.py
+++ b/backend/dataall/db/api/dataset.py
@@ -520,11 +520,19 @@ class Dataset:
 
     @staticmethod
     def list_dataset_shares_with_existing_shared_items(session, dataset_uri) -> [models.ShareObject]:
-        query = session.query(models.ShareObject).filter(
-            and_(
-                models.ShareObject.datasetUri == dataset_uri,
-                models.ShareObject.deleted.is_(None),
-                models.ShareObject.existingSharedItems.is_(True),
+        share_item_shared_states = api.ShareItemSM.get_share_item_shared_states()
+        query = (
+            session.query(models.ShareObject)
+            .outerjoin(
+                models.ShareObjectItem,
+                models.ShareObjectItem.shareUri == models.ShareObject.shareUri
+            )
+            .filter(
+                and_(
+                    models.ShareObject.datasetUri == dataset_uri,
+                    models.ShareObject.deleted.is_(None),
+                    models.ShareObjectItem.status.in_(share_item_shared_states),
+                )
             )
         )
         return query.all()
@@ -568,23 +576,36 @@ class Dataset:
 
     @staticmethod
     def _delete_dataset_shares_with_no_shared_items(session, dataset_uri):
-        share_objects = (
+        share_item_shared_states = api.ShareItemSM.get_share_item_shared_states()
+        shares = (
             session.query(models.ShareObject)
+            .outerjoin(
+                models.ShareObjectItem,
+                models.ShareObjectItem.shareUri == models.ShareObject.shareUri
+            )
             .filter(
                 and_(
                     models.ShareObject.datasetUri == dataset_uri,
-                    models.ShareObject.existingSharedItems.is_(False),
+                    models.ShareObjectItem.status.notin_(share_item_shared_states),
                 )
             )
             .all()
         )
-        for share in share_objects:
-            (
+        for share in shares:
+            share_items = (
                 session.query(models.ShareObjectItem)
                 .filter(models.ShareObjectItem.shareUri == share.shareUri)
-                .delete()
+                .all()
             )
-            session.delete(share)
+            for item in share_items:
+                session.delete(item)
+
+            share_obj = (
+                session.query(models.ShareObject)
+                .filter(models.ShareObject.shareUri == share.shareUri)
+                .first()
+            )
+            session.delete(share_obj)
 
     @staticmethod
     def _delete_dataset_term_links(session, uri):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
- Fix query to check dataset shares before deleting a dataset

The `existingSharedItems` property of `ShareObject` was not resolving correctly to a `True` or `False` value but rather to `None`.  The impact is:

1. When checking a dataset's shares before deleting the dataset  - we would not raise an exception for datasets that did in fact have existing shared items.

2. Additionally, when deleting a dataset with associated shared objects created - we would not successfully delete the associated share object and share object items and not clean up rows in the DB appropriately. This caused issues when viewing the Share Tab as the dataset does not exist but is still referenced in the outdated ShareObject and throws an error.


### Relates
- #544 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
