### PR TITLE
Make OpenSearch Compliant Names

### DIFF
--- a/deploy/stacks/opensearch.py
+++ b/deploy/stacks/opensearch.py
@@ -1,3 +1,5 @@
+import re
+
 from aws_cdk import (
     aws_ec2 as ec2,
     aws_iam as iam,
@@ -77,7 +79,7 @@ class OpenSearchStack(pyNestedClass):
         self.domain = opensearch.Domain(
             self,
             f'OpenSearchDomain{envname}',
-            domain_name=f'{resource_prefix}-{envname}-domain',
+            domain_name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-domain')[:28].lower(),
             version=opensearch.EngineVersion.OPENSEARCH_1_1,
             capacity=opensearch.CapacityConfig(
                 data_nodes=2, master_nodes=3 if prod_sizing else 0

--- a/deploy/stacks/opensearch_serverless.py
+++ b/deploy/stacks/opensearch_serverless.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any, Dict, List, Optional
 from aws_cdk import (
     aws_ec2 as ec2,
@@ -32,7 +33,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         self.cfn_collection = opensearchserverless.CfnCollection(
             self,
             f'OpenSearchCollection{envname}',
-            name=f'{resource_prefix}-{envname}-collection',
+            name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-collection')[:28].lower(),
             type="SEARCH",
         )
 
@@ -49,7 +50,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_encryption_policy = opensearchserverless.CfnSecurityPolicy(
             self,
             f'OpenSearchCollectionEncryptionPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-encryption-policy',
+            name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-encryption-policy')[:28].lower(),
             type='encryption',
             policy=self._get_encryption_policy(
                 collection_name=self.cfn_collection.name,
@@ -60,7 +61,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_vpc_endpoint = opensearchserverless.CfnVpcEndpoint(
             self,
             f'OpenSearchCollectionVpcEndpoint{envname}',
-            name=f'{resource_prefix}-{envname}-vpc-endpoint',
+            name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-vpc-endpoint')[:28].lower(),
             vpc_id=vpc.vpc_id,
             security_group_ids=[vpc_endpoints_sg.security_group_id],
             subnet_ids=[subnet.subnet_id for subnet in vpc.private_subnets],
@@ -69,7 +70,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_network_policy = opensearchserverless.CfnSecurityPolicy(
             self,
             f'OpenSearchCollectionNetworkPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-network-policy',
+            name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-network-policy')[:28].lower(),
             type='network',
             policy=self._get_network_policy(
                 collection_name=self.cfn_collection.name,
@@ -87,7 +88,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         opensearchserverless.CfnAccessPolicy(
             self,
             f'OpenSearchCollectionAccessPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-access-policy',
+            name=re.sub(r"[^a-z0-9-]","",f'{resource_prefix}-{envname}-access-policy')[:28].lower(),
             type='data',
             policy=self._get_access_policy(
                 collection_name=self.cfn_collection.name,


### PR DESCRIPTION
### Feature or Bugfix
- Feature Enhancement

### Detail
- Ensure the names passed for OpenSearch Domain and OpenSearch Serverless Collection, Access Policy, Security Policy, and VPC Endpoint all follow naming conventions required by the service, meaning
  - The name must start with a lowercase letter
  - Must be between 3 and 28 characters
  - Valid characters are a-z (lowercase only), 0-9, and - (hyphen).

### Relates
- #540 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
