### PR TITLE
Added ec2:DescribePrefix permissions to CDKSynth

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -95,6 +95,8 @@ class PipelineStack(Stack):
             iam.PolicyStatement(
                 actions=[
                     'ecr:GetAuthorizationToken',
+                    'ec2:DescribePrefixLists',
+                    'ec2:DescribeManagedPrefixLists'
                 ],
                 resources=['*'],
             ),


### PR DESCRIPTION
### Feature or Bugfix
- BugFix

### Detail
For the release of v1.6 one permission is needed in CDK Synth CodeBuild stage. Since this permission will be added in the next CodeBuild stage of the deployment pipeline (UpdatePipeline and SelfMutate) the pipeline execution will fail when upgrading to V1.6. 
This PR adds the permission so if customers want to avoid manually adding the permission they can upgrade to v1.5.X and then to V1.6.0 in a 2 steps upgrade

### Relates
Release v1.6.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
