### PR TITLE
v1.6.0 backwards compatibility changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-tests:
 
 lint:
 	pip install flake8
-	flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
+	python -m flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
 
 bandit:
 	pip install bandit

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-tests:
 
 lint:
 	pip install flake8
-	python -m flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
+	flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
 
 bandit:
 	pip install bandit

--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
@@ -121,8 +121,8 @@ def on_delete(event):
     physical_id = event['PhysicalResourceId']
     if physical_id.startswith('IMPORTED'):
         log.info(f'Imported database {physical_id} will not be deleted (it was not created by dataa.all)')
-    else:
-        database_name = physical_id.replace('IMPORTED-', '')
+    elif physical_id.startswith('CREATED'):
+        database_name = physical_id.replace('CREATED-', '')
         log.info('delete resource %s' % database_name)
         try:
             glue_client.get_database(Name=database_name)
@@ -134,5 +134,7 @@ def on_delete(event):
             response = glue_client.delete_database(CatalogId=AWS_ACCOUNT, Name=database_name)
             log.info(f'Successfully deleted database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
         except ClientError as e:
-            log.exception(f'Could not delete databse {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
-            raise Exception(f'Could not delete databse {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+            log.exception(f'Could not delete database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+            raise Exception(f'Could not delete database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+    else:
+        log.info('Old PhysicalID, do not delete anything')

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -441,7 +441,7 @@ class Dataset(Stack):
                     'LocationUri': f's3://{dataset.S3BucketName}/',
                     'Name': f'{dataset.GlueDatabaseName}',
                     'CreateTableDefaultPermissions': [],
-                    'Imported': 'IMPORTED-' if dataset.imported else ''
+                    'Imported': 'IMPORTED-' if dataset.imported else 'CREATED-'
                 },
                 'DatabaseAdministrators': dataset_admins
             },


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- When updating the dataset database handler custom resource to use a different PhysicalId to distinguish imported datasets CloudFormation forces a replacement of the resource which results in the deletion of the glue database. With this PR we add a condition to only delete databases when the custom resource physical id is prefixed by "CREATED-".
- Force that Glue crawlers ccreated by data.all use the dataset IAM role as execution role. Previously a boto3 call updated this to use the pivotRole (contrary to what it was defined in CloudFormation). With this PR we make sure that the correct role is used in any existing crawler.

I tested in a real AWS deployment that had previously created environments and datasets, with a crawler with the pivotRole assigned:

- [X] Crawler execution role gets updated to dataset role
- [X] Imported glue databases do not get deleted when the custom resource updates the physicalID

### Relates
- #531 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
