### PR TITLE
feat:increase memory limit for local frontend container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1024M
+          memory: 4096M
         reservations:
           memory: 128M
     ports:


### PR DESCRIPTION
Due to the [Dockerfile change for the local frontend container](https://github.com/awslabs/aws-dataall/pull/396), now it requires more memory, and during docker-compose up the deployment gets SIGKILL'd.
Increasing the resource limit in the docker-compose.yaml settings fixes the issue.

<img width="1010" alt="Screenshot 2023-07-12 at 12 35 17" src="https://github.com/awslabs/aws-dataall/assets/132444646/e47f9ffa-6692-4ae2-b81b-babaea642ebb">


### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
