### PR TITLE
SSE-S3 for imported datasets + rename imported dataset resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-tests:
 
 lint:
 	pip install flake8
-	flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
+	python -m flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
 
 bandit:
 	pip install bandit

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-tests:
 
 lint:
 	pip install flake8
-	python -m flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
+	flake8 --exclude cdk.out,blueprints --ignore E402,E501,F841,W503,F405,F403,F401,E712,E203 backend/
 
 bandit:
 	pip install bandit

--- a/backend/dataall/api/Objects/Dataset/resolvers.py
+++ b/backend/dataall/api/Objects/Dataset/resolvers.py
@@ -85,7 +85,7 @@ def import_dataset(context: Context, source, input=None):
         dataset.importedGlueDatabase = True if input.get('glueDatabaseName') else False
         dataset.importedKmsKey = True if input.get('KmsKeyAlias') else False
         dataset.importedAdminRole = True if input.get('adminRoleName') else False
-
+        dataset.KmsAlias = "SSE-S3" if input.get('KmsKeyAlias') == "" else input.get('KmsKeyAlias')
         Dataset.create_dataset_stack(session, dataset)
 
         indexers.upsert_dataset(

--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
@@ -121,8 +121,8 @@ def on_delete(event):
     physical_id = event['PhysicalResourceId']
     if physical_id.startswith('IMPORTED'):
         log.info(f'Imported database {physical_id} will not be deleted (it was not created by dataa.all)')
-    else:
-        database_name = physical_id.replace('IMPORTED-', '')
+    elif physical_id.startswith('CREATED'):
+        database_name = physical_id.replace('CREATED-', '')
         log.info('delete resource %s' % database_name)
         try:
             glue_client.get_database(Name=database_name)
@@ -134,5 +134,7 @@ def on_delete(event):
             response = glue_client.delete_database(CatalogId=AWS_ACCOUNT, Name=database_name)
             log.info(f'Successfully deleted database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
         except ClientError as e:
-            log.exception(f'Could not delete databse {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
-            raise Exception(f'Could not delete databse {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+            log.exception(f'Could not delete database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+            raise Exception(f'Could not delete database {database_name} in aws://{AWS_ACCOUNT}/{AWS_REGION}')
+    else:
+        log.info('Old PhysicalID, do not delete anything')

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -451,7 +451,7 @@ class Dataset(Stack):
         crawler = glue.CfnCrawler(
             self,
             dataset.GlueCrawlerName,
-            description=f'datall Glue Crawler for bucket {dataset.S3BucketName}',
+            description=f'datall Glue Crawler for S3 Bucket {dataset.S3BucketName}',
             name=dataset.GlueCrawlerName,
             database_name=dataset.GlueDatabaseName,
             schedule={'scheduleExpression': f'{dataset.GlueCrawlerSchedule}'}
@@ -490,6 +490,7 @@ class Dataset(Stack):
             self,
             'DatasetGlueProfilingJob',
             name=dataset.GlueProfilingJobName,
+            description=f'datall Glue Profiling job for dataset {dataset.label}',
             role=dataset_admin_role.role_arn,
             allocated_capacity=10,
             execution_property=glue.CfnJob.ExecutionPropertyProperty(
@@ -512,6 +513,7 @@ class Dataset(Stack):
                 self,
                 'DatasetGlueProfilingTrigger',
                 name=dataset.GlueProfilingTriggerName,
+                description=f'datall Glue Profiling trigger schedule for dataset {dataset.label}',
                 type='SCHEDULED',
                 schedule=dataset.GlueProfilingTriggerSchedule,
                 start_on_creation=True,

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -441,7 +441,7 @@ class Dataset(Stack):
                     'LocationUri': f's3://{dataset.S3BucketName}/',
                     'Name': f'{dataset.GlueDatabaseName}',
                     'CreateTableDefaultPermissions': [],
-                    'Imported': 'IMPORTED-' if dataset.imported else ''
+                    'Imported': 'IMPORTED-' if dataset.imported else 'CREATED-'
                 },
                 'DatabaseAdministrators': dataset_admins
             },

--- a/backend/dataall/db/api/dataset.py
+++ b/backend/dataall/db/api/dataset.py
@@ -169,13 +169,20 @@ class Dataset:
             dataset.IAMDatasetAdminRoleArn = iam_role_arn
             dataset.IAMDatasetAdminUserArn = iam_role_arn
 
-        dataset.GlueCrawlerName = f'{dataset.S3BucketName}-{dataset.datasetUri}-crawler'
-        dataset.GlueProfilingJobName = f'{dataset.S3BucketName}-{dataset.datasetUri}-profiler'
+        glue_etl_basename = NamingConventionService(
+            target_uri=dataset.datasetUri,
+            target_label=dataset.label,
+            pattern=NamingConventionPattern.GLUE_ETL,
+            resource_prefix=environment.resourcePrefix,
+        ).build_compliant_name()
+
+        dataset.GlueCrawlerName = f"{glue_etl_basename}-crawler"
+        dataset.GlueProfilingJobName = f"{glue_etl_basename}-profiler"
         dataset.GlueProfilingTriggerSchedule = None
-        dataset.GlueProfilingTriggerName = f'{dataset.S3BucketName}-{dataset.datasetUri}-trigger'
-        dataset.GlueDataQualityJobName = f'{dataset.S3BucketName}-{dataset.datasetUri}-dataquality'
+        dataset.GlueProfilingTriggerName = f"{glue_etl_basename}-trigger"
+        dataset.GlueDataQualityJobName = f"{glue_etl_basename}-dataquality"
         dataset.GlueDataQualitySchedule = None
-        dataset.GlueDataQualityTriggerName = f'{dataset.S3BucketName}-{dataset.datasetUri}-dqtrigger'
+        dataset.GlueDataQualityTriggerName = f"{glue_etl_basename}-dqtrigger"
         return dataset
 
     @staticmethod

--- a/backend/dataall/db/api/dataset.py
+++ b/backend/dataall/db/api/dataset.py
@@ -149,8 +149,7 @@ class Dataset:
         ).build_compliant_name()
         dataset.GlueDatabaseName = data.get('glueDatabaseName') or glue_db_name
 
-        kms_alias = bucket_name
-        dataset.KmsAlias = data.get('KmsKeyAlias') or kms_alias
+        dataset.KmsAlias = bucket_name
 
         iam_role_name = NamingConventionService(
             target_uri=dataset.datasetUri,

--- a/backend/dataall/utils/naming_convention.py
+++ b/backend/dataall/utils/naming_convention.py
@@ -10,6 +10,7 @@ class NamingConventionPattern(Enum):
     S3 = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}
     GLUE = {'regex': '[^a-zA-Z0-9_]', 'separator': '_', 'max_length': 63}
+    GLUE_ETL = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 52}
     NOTEBOOK = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}
     DEFAULT = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}
 
@@ -40,6 +41,9 @@ class NamingConventionService:
         elif self.service == NamingConventionPattern.GLUE:
             regex = self.service.GLUE.value['regex']
             return self.build_glue_compliant_name(regex)
+        elif self.service == NamingConventionPattern.GLUE_ETL:
+            regex = self.service.GLUE_ETL.value['regex']
+            return self.build_glue_etl_compliant_name(regex)
         elif self.service == NamingConventionPattern.NOTEBOOK:
             regex = self.service.NOTEBOOK.value['regex']
             return self.build_notebook_compliant_name(regex)
@@ -55,6 +59,9 @@ class NamingConventionService:
 
     def build_glue_compliant_name(self, regex) -> str:
         return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.GLUE.value['max_length'] - len(self.resource_prefix + self.target_uri))] + '-' + self.target_uri, regex_pattern=fr'{regex}', separator=self.service.GLUE.value['separator'], lowercase=True)}"
+
+    def build_glue_etl_compliant_name(self, regex) -> str:
+        return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.GLUE_ETL.value['max_length'] - len(self.resource_prefix + self.target_uri))] + '-' + self.target_uri, regex_pattern=fr'{regex}', separator=self.service.GLUE_ETL.value['separator'], lowercase=True)}"
 
     def build_notebook_compliant_name(self, regex) -> str:
         return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.NOTEBOOK.value['max_length'] - len(self.resource_prefix +self.target_uri))] + '-' + self.target_uri, regex_pattern=fr'{regex}', separator=self.service.NOTEBOOK.value['separator'], lowercase=True)}"

--- a/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
+++ b/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
@@ -32,33 +32,7 @@ class Environment(Resource, Base):
     organizationUri = Column(String, nullable=False)
     environmentUri = Column(String, primary_key=True, default=utils.uuid('environment'))
     AwsAccountId = Column(String, nullable=False)
-    region = Column(String, nullable=False, default='eu-west-1')
-    cognitoGroupName = Column(String, nullable=True)
-
-    validated = Column(Boolean, default=False)
-    environmentType = Column(String, nullable=False, default='Data')
-    isOrganizationDefaultEnvironment = Column(Boolean, default=False)
-    EnvironmentDefaultIAMRoleName = Column(String, nullable=False)
-    EnvironmentDefaultIAMRoleArn = Column(String, nullable=False)
-    EnvironmentDefaultBucketName = Column(String)
-    roleCreated = Column(Boolean, nullable=False, default=False)
-
-    dashboardsEnabled = Column(Boolean, default=False)
-    notebooksEnabled = Column(Boolean, default=True)
-    mlStudiosEnabled = Column(Boolean, default=True)
-    pipelinesEnabled = Column(Boolean, default=True)
-    warehousesEnabled = Column(Boolean, default=True)
-
-    userRoleInEnvironment = query_expression()
-
-    SamlGroupName = Column(String, nullable=True)
-    CDKRoleArn = Column(String, nullable=False)
-
-    subscriptionsEnabled = Column(Boolean, default=False)
-    subscriptionsProducersTopicName = Column(String)
-    subscriptionsProducersTopicImported = Column(Boolean, default=False)
-    subscriptionsConsumersTopicName = Column(String)
-    subscriptionsConsumersTopicImported = Column(Boolean, default=False)
+    resourcePrefix = Column(String, nullable=False, default='dataall')
 
 
 class Dataset(Resource, Base):

--- a/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
+++ b/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
@@ -101,6 +101,9 @@ def upgrade():
             dataset.GlueProfilingTriggerName = f"{glue_etl_basename}-trigger"
             dataset.GlueDataQualityJobName = f"{glue_etl_basename}-dataquality"
             dataset.GlueDataQualityTriggerName = f"{glue_etl_basename}-dqtrigger"
+            if not dataset.importedKmsKey:
+                # Not adding downgrade for this line because this is a fix not an upgrade
+                dataset.KmsAlias = "Undefined"
             session.commit()
         print('imported Datasets resources updated successfully')
     except Exception as e:
@@ -115,15 +118,12 @@ def downgrade():
         imported_datasets: [Dataset] = session.query(Dataset).filter(Dataset.imported.is_(True))
         for dataset in imported_datasets:
             print(f"Updating dataset {dataset.datasetUri}")
-            glue_etl_basename = dataset.S3BucketName
+            glue_etl_basename = f"{dataset.S3BucketName}-{dataset.datasetUri}"
             dataset.GlueCrawlerName = f"{glue_etl_basename}-crawler"
             dataset.GlueProfilingJobName = f"{glue_etl_basename}-profiler"
             dataset.GlueProfilingTriggerName = f"{glue_etl_basename}-trigger"
             dataset.GlueDataQualityJobName = f"{glue_etl_basename}-dataquality"
             dataset.GlueDataQualityTriggerName = f"{glue_etl_basename}-dqtrigger"
-            if not dataset.importedKmsKey:
-                # Not adding downgrade for this line because this is a fix not an upgrade
-                dataset.KmsAlias = "Undefined"
             session.commit()
         print('imported Datasets resources updated successfully')
     except Exception as e:

--- a/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
+++ b/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
@@ -1,0 +1,156 @@
+"""rename_imported_dataset_aws_resources
+
+Revision ID: e1cd4927482b
+Revises: 72b8a90b6ee8
+Create Date: 2023-07-13 09:20:20.091639
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm, Column, String, Boolean
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import query_expression
+
+from dataall.db import utils, Resource
+from dataall.utils.naming_convention import (
+    NamingConventionService,
+    NamingConventionPattern,
+)
+
+# revision identifiers, used by Alembic.
+revision = 'e1cd4927482b'
+down_revision = '72b8a90b6ee8'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+class Environment(Resource, Base):
+    __tablename__ = 'environment'
+    organizationUri = Column(String, nullable=False)
+    environmentUri = Column(String, primary_key=True, default=utils.uuid('environment'))
+    AwsAccountId = Column(String, nullable=False)
+    region = Column(String, nullable=False, default='eu-west-1')
+    cognitoGroupName = Column(String, nullable=True)
+
+    validated = Column(Boolean, default=False)
+    environmentType = Column(String, nullable=False, default='Data')
+    isOrganizationDefaultEnvironment = Column(Boolean, default=False)
+    EnvironmentDefaultIAMRoleName = Column(String, nullable=False)
+    EnvironmentDefaultIAMRoleArn = Column(String, nullable=False)
+    EnvironmentDefaultBucketName = Column(String)
+    roleCreated = Column(Boolean, nullable=False, default=False)
+
+    dashboardsEnabled = Column(Boolean, default=False)
+    notebooksEnabled = Column(Boolean, default=True)
+    mlStudiosEnabled = Column(Boolean, default=True)
+    pipelinesEnabled = Column(Boolean, default=True)
+    warehousesEnabled = Column(Boolean, default=True)
+
+    userRoleInEnvironment = query_expression()
+
+    SamlGroupName = Column(String, nullable=True)
+    CDKRoleArn = Column(String, nullable=False)
+
+    subscriptionsEnabled = Column(Boolean, default=False)
+    subscriptionsProducersTopicName = Column(String)
+    subscriptionsProducersTopicImported = Column(Boolean, default=False)
+    subscriptionsConsumersTopicName = Column(String)
+    subscriptionsConsumersTopicImported = Column(Boolean, default=False)
+
+
+class Dataset(Resource, Base):
+    __tablename__ = 'dataset'
+    environmentUri = Column(String, nullable=False)
+    organizationUri = Column(String, nullable=False)
+    datasetUri = Column(String, primary_key=True, default=utils.uuid('dataset'))
+    region = Column(String, default='eu-west-1')
+    AwsAccountId = Column(String, nullable=False)
+    S3BucketName = Column(String, nullable=False)
+    GlueDatabaseName = Column(String, nullable=False)
+    GlueProfilingJobName = Column(String)
+    GlueProfilingTriggerSchedule = Column(String)
+    GlueProfilingTriggerName = Column(String)
+    GlueDataQualityJobName = Column(String)
+    GlueDataQualitySchedule = Column(String)
+    GlueDataQualityTriggerName = Column(String)
+    IAMDatasetAdminRoleArn = Column(String, nullable=False)
+    IAMDatasetAdminUserArn = Column(String, nullable=False)
+    KmsAlias = Column(String, nullable=False)
+    language = Column(String, nullable=False, default='English')
+    topics = Column(postgresql.ARRAY(String), nullable=True)
+    confidentiality = Column(String, nullable=False, default='Unclassified')
+    tags = Column(postgresql.ARRAY(String))
+
+    bucketCreated = Column(Boolean, default=False)
+    glueDatabaseCreated = Column(Boolean, default=False)
+    iamAdminRoleCreated = Column(Boolean, default=False)
+    iamAdminUserCreated = Column(Boolean, default=False)
+    kmsAliasCreated = Column(Boolean, default=False)
+    lakeformationLocationCreated = Column(Boolean, default=False)
+    bucketPolicyCreated = Column(Boolean, default=False)
+
+    businessOwnerEmail = Column(String, nullable=True)
+    businessOwnerDelegationEmails = Column(postgresql.ARRAY(String), nullable=True)
+    stewards = Column(String, nullable=True)
+
+    SamlAdminGroupName = Column(String, nullable=True)
+
+    importedS3Bucket = Column(Boolean, default=False)
+    importedGlueDatabase = Column(Boolean, default=False)
+    importedKmsKey = Column(Boolean, default=False)
+    importedAdminRole = Column(Boolean, default=False)
+    imported = Column(Boolean, default=False)
+
+
+def upgrade():
+    try:
+        bind = op.get_bind()
+        session = orm.Session(bind=bind)
+        print('Updating imported dataset aws resources names...')
+        imported_datasets: [Dataset] = session.query(Dataset).filter(Dataset.imported.is_(True))
+        for dataset in imported_datasets:
+            print(f"Updating dataset {dataset.datasetUri}")
+            environment: [Environment] = session.query(Environment).filter(
+                Environment.environmentUri == dataset.environmentUri
+            ).first()
+            glue_etl_basename = NamingConventionService(
+                target_uri=dataset.datasetUri,
+                target_label=dataset.label,
+                pattern=NamingConventionPattern.GLUE_ETL,
+                resource_prefix=environment.resourcePrefix,
+            ).build_compliant_name()
+            dataset.GlueCrawlerName = f"{glue_etl_basename}-crawler"
+            dataset.GlueProfilingJobName = f"{glue_etl_basename}-profiler"
+            dataset.GlueProfilingTriggerName = f"{glue_etl_basename}-trigger"
+            dataset.GlueDataQualityJobName = f"{glue_etl_basename}-dataquality"
+            dataset.GlueDataQualityTriggerName = f"{glue_etl_basename}-dqtrigger"
+            session.commit()
+        print('imported Datasets resources updated successfully')
+    except Exception as e:
+        print(f'Failed to update imported dataset aws resources names due to: {e}')
+
+
+def downgrade():
+    try:
+        bind = op.get_bind()
+        session = orm.Session(bind=bind)
+        print('Updating imported dataset aws resources names to previous...')
+        imported_datasets: [Dataset] = session.query(Dataset).filter(Dataset.imported.is_(True))
+        for dataset in imported_datasets:
+            print(f"Updating dataset {dataset.datasetUri}")
+            glue_etl_basename = dataset.S3BucketName
+            dataset.GlueCrawlerName = f"{glue_etl_basename}-crawler"
+            dataset.GlueProfilingJobName = f"{glue_etl_basename}-profiler"
+            dataset.GlueProfilingTriggerName = f"{glue_etl_basename}-trigger"
+            dataset.GlueDataQualityJobName = f"{glue_etl_basename}-dataquality"
+            dataset.GlueDataQualityTriggerName = f"{glue_etl_basename}-dqtrigger"
+            if not dataset.importedKmsKey:
+                # Not adding downgrade for this line because this is a fix not an upgrade
+                dataset.KmsAlias = "Undefined"
+            session.commit()
+        print('imported Datasets resources updated successfully')
+    except Exception as e:
+        print(f'Failed to update imported dataset aws resources to previous names due to: {e}')

--- a/frontend/src/views/Datasets/DatasetConsoleAccess.js
+++ b/frontend/src/views/Datasets/DatasetConsoleAccess.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  Divider,
-  Typography
+    Box,
+    Card,
+    CardContent,
+    CardHeader,
+    Divider,
+    Typography
 } from '@mui/material';
 
 const DatasetConsoleAccess = (props) => {
@@ -47,14 +48,26 @@ const DatasetConsoleAccess = (props) => {
           {dataset.IAMDatasetAdminRoleArn}
         </Typography>
       </CardContent>
-      <CardContent>
+      { dataset.KmsAlias === "SSE-S3" || dataset.KmsAlias === "Undefined" ?
+        <CardContent>
           <Typography color="textSecondary" variant="subtitle2">
-            KMS alias
+            S3 Encryption
+          </Typography>
+          <Typography color="textPrimary" variant="body2">
+            {`${dataset.KmsAlias}`}
+          </Typography>
+        </CardContent>
+          :
+          <CardContent>
+          <Typography color="textSecondary" variant="subtitle2">
+            S3 Encryption SSE-KMS
           </Typography>
           <Typography color="textPrimary" variant="body2">
             {`arn:aws:kms:${dataset.region}:${dataset.AwsAccountId}/alias:${dataset.KmsAlias}`}
           </Typography>
       </CardContent>
+
+        }
     </Card>
   );
 };

--- a/frontend/src/views/Datasets/DatasetImportForm.js
+++ b/frontend/src/views/Datasets/DatasetImportForm.js
@@ -231,6 +231,7 @@ const DatasetImportForm = (props) => {
                 environment: Yup.object().required('*Environment is required'),
                 tags: Yup.array().min(1).required('*Tags are required'),
                 glueDatabaseName: Yup.string().max(255),
+                KmsKeyAlias: Yup.string().max(255),
                 bucketName: Yup.string()
                   .max(255)
                   .required('*S3 bucket name is required'),

--- a/frontend/src/views/Datasets/DatasetImportForm.js
+++ b/frontend/src/views/Datasets/DatasetImportForm.js
@@ -234,9 +234,6 @@ const DatasetImportForm = (props) => {
                 bucketName: Yup.string()
                   .max(255)
                   .required('*S3 bucket name is required'),
-                KmsKeyAlias: Yup.string()
-                  .max(255)
-                  .required('*KMS key Alias is required'),
                 confidentiality: Yup.string()
                   .max(255)
                   .required('*Confidentiality is required')
@@ -466,7 +463,7 @@ const DatasetImportForm = (props) => {
                             )}
                             fullWidth
                             helperText={touched.KmsKeyAlias && errors.KmsKeyAlias}
-                            label="Amazon KMS key Alias"
+                            label="Amazon KMS key Alias (if SSE-KMS encryption is used)"
                             name="KmsKeyAlias"
                             onBlur={handleBlur}
                             onChange={handleChange}


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
#### SSE-S3 for imported datasets 
With #515 we added the possibility to introduce the KMS key that encrypts the imported bucket when importing a dataset. This is a required field that cannot be empty. In this PR we allow customers to leave the field empty for the case in which no KMS key is used. We assume that if no key is defined, then the bucket is encrypted using SSE-S3 encryption.

- changes in frontend views
- changes in definition of RDS column values
- added line in migration script to backfill `undefined` keys with the `undefined` value for previously imported datasets.

#### Rename imported dataset resources
In #535 the permissions given to the pivot role were restricted to more specific resources. Most policies where updated to access `resource-prefix` AWS resources only. For imported datasets some of the data.all created resources in the dataset stack (Glue crawler ....) do not follow this naming pattern. In this PR we update the name of those resources to include the prefix. This way the pivot role will be able to execute actions on them.

- Added naming convention pattern
- Enforce pattern in dataset import
- Added migration script to update the names of existing imported datasets

⚠️ After the migration script is executed, dataset stacks need to be updated for the AWS resources to be updated ⚠️ 

### Testing - in-progress
I tested locally, but now I am also testing in a real deployment:
- [ ] CICD pipeline completes successfully
- [ ] KMS RDS info updated as expected
- [ ] KMS RDS info of new created and imported datasets as expected
- [ ] CloudFormation stacks of updated stacks of imported and created datasets successful (resources updated)
- [ ] CloudFormation stacks of new stacks of imported and created datasets successful (resources prefixed)
- [ ] Crawlers can be run for all dataset cases

### Relates
- #535
- #515

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
