### PR TITLE
Networking Configuration Support for Multi-Region Data All Resources

### DIFF
--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -393,11 +393,11 @@ class ContainerStack(pyNestedClass):
                         'Allow Lambda to ECS Connection'
                     )
 
-            # Add NAT Gateway Access for RAM API Access
-            sg_connection.add_egress_rule(
+            # Add NAT Gateway Access for Cross-region requests in same region the more specific rules apply
+            sg_connection.allow_to(
                 ec2.Peer.any_ipv4(),
                 ec2.Port.tcp(443),
-                'Allow NAT Internet Access SG Egress',
+                'Allow NAT Internet Access SG Egress'
             )
 
         # Create SSM of Security Group IDs

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -393,12 +393,12 @@ class ContainerStack(pyNestedClass):
                         'Allow Lambda to ECS Connection'
                     )
 
-        # Add NAT Gateway Access for RAM API Access
-        share_manager_sg.add_egress_rule(
-            ec2.Peer.any_ipv4(),
-            ec2.Port.tcp(443),
-            'Allow NAT Internet Access SG Egress',
-        )
+            # Add NAT Gateway Access for RAM API Access
+            sg_connection.add_egress_rule(
+                ec2.Peer.any_ipv4(),
+                ec2.Port.tcp(443),
+                'Allow NAT Internet Access SG Egress',
+            )
 
         # Create SSM of Security Group IDs
         ssm.StringParameter(

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -153,6 +153,11 @@ class LambdaApiStack(pyNestedClass):
             ec2.Port.tcp(443),
             'Allow NAT Internet Access SG Egress'
         )
+        self.aws_handler.connections.allow_to(
+            ec2.Peer.any_ipv4(),
+            ec2.Port.tcp(443),
+            'Allow NAT Internet Access SG Egress'
+        )
 
         self.backend_api_name = f'{resource_prefix}-{envname}-api'
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix


### Detail
- Allow Traffic to other AWS Regions to support Data All resources in other regions (e.g. Deployment in `us-east-1` and Link Environment in `us-west-2`)
- Based on Route Priority in AWS [Docs](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#route-tables-priority) routes will prioritize the most specific CIDR Blocks first as preferred method of traffic
  - Same region resources as the deployment account region should defer to private communication while deployment of resources to regions different from the deployment region will be able to use NAT Gateway from the private subnet to deploy the stacks
  - Alternative to this solution is to specify VPC Endpoints for every Region where data all related resources could/would be deployed to

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
