### PR TITLE
Missing GlueCrawlerName from Dataset definition

### DIFF
--- a/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
+++ b/backend/migrations/versions/e1cd4927482b_rename_imported_dataset_aws_resources.py
@@ -44,6 +44,8 @@ class Dataset(Resource, Base):
     AwsAccountId = Column(String, nullable=False)
     S3BucketName = Column(String, nullable=False)
     GlueDatabaseName = Column(String, nullable=False)
+    GlueCrawlerName = Column(String)
+    GlueCrawlerSchedule = Column(String)
     GlueProfilingJobName = Column(String)
     GlueProfilingTriggerSchedule = Column(String)
     GlueProfilingTriggerName = Column(String)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- missing definition of field in Dataset class results in skipping one of the RDS updates (for GlueCrawler name)

### Relates
Release v1.6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
