### PR TITLE
feat: allow redefine undefined imported kms keys

### DIFF
--- a/backend/dataall/api/Objects/Dataset/input_types.py
+++ b/backend/dataall/api/Objects/Dataset/input_types.py
@@ -42,6 +42,7 @@ ModifyDatasetInput = gql.InputType(
         gql.Argument('language', gql.Ref('Language')),
         gql.Argument('confidentiality', gql.Ref('ConfidentialityClassification')),
         gql.Argument(name='stewards', type=gql.String),
+        gql.Argument('KmsAlias', gql.NonNullableType(gql.String)),
     ],
 )
 

--- a/backend/dataall/api/Objects/Dataset/resolvers.py
+++ b/backend/dataall/api/Objects/Dataset/resolvers.py
@@ -13,7 +13,8 @@ from ....api.context import Context
 from ....aws.handlers.glue import Glue
 from ....aws.handlers.service_handlers import Worker
 from ....aws.handlers.sts import SessionHelper
-from ....aws.handlers.sns import Sns
+from ....aws.handlers.kms import KMS
+
 from ....aws.handlers.quicksight import Quicksight
 from ....db import paginate, exceptions, permissions, models
 from ....db.api import Dataset, Environment, ShareObject, ResourcePolicy
@@ -29,6 +30,21 @@ def check_dataset_account(environment):
         if quicksight_subscription:
             group = Quicksight.create_quicksight_group(AwsAccountId=environment.AwsAccountId)
             return True if group else False
+    return True
+
+
+def check_imported_resources(environment, kmsAlias):
+    if kmsAlias not in ["Undefined", "", "SSE-S3"]:
+        key_id = KMS.get_key_id(
+            account_id=environment.AwsAccountId,
+            region=environment.region,
+            key_alias=f"alias/{kmsAlias}"
+        )
+        if not key_id:
+            raise exceptions.AWSResourceNotFound(
+                action=permissions.IMPORT_DATASET,
+                message=f'KMS key with alias={kmsAlias} cannot be found',
+            )
     return True
 
 
@@ -71,6 +87,7 @@ def import_dataset(context: Context, source, input=None):
     with context.engine.scoped_session() as session:
         environment = Environment.get_environment_by_uri(session, input.get('environmentUri'))
         check_dataset_account(environment=environment)
+        check_imported_resources(environment=environment, kmsAlias=input.get('KmsKeyAlias', ""))
 
         dataset = Dataset.create_dataset(
             session=session,
@@ -231,6 +248,7 @@ def update_dataset(context, source, datasetUri: str = None, input: dict = None):
         dataset = Dataset.get_dataset_by_uri(session, datasetUri)
         environment = Environment.get_environment_by_uri(session, dataset.environmentUri)
         check_dataset_account(environment=environment)
+        check_imported_resources(environment=environment, kmsAlias=input.get('KmsAlias', ""))
         updated_dataset = Dataset.update_dataset(
             session=session,
             username=context.username,

--- a/backend/dataall/cdkproxy/stacks/policies/data_policy.py
+++ b/backend/dataall/cdkproxy/stacks/policies/data_policy.py
@@ -129,13 +129,14 @@ class DataPolicy:
         if self.datasets:
             dataset: models.Dataset
             for dataset in self.datasets:
-                if dataset.imported:
+                if dataset.imported and dataset.importedKmsKey:
                     key_id = KMS.get_key_id(
                         account_id=dataset.AwsAccountId,
                         region=dataset.region,
                         key_alias=f"alias/{dataset.KmsAlias}"
                     )
-                    allowed_buckets_kms_keys.append(f"arn:aws:kms:{dataset.region}:{dataset.AwsAccountId}:key/{key_id}")
+                    if key_id:
+                        allowed_buckets_kms_keys.append(f"arn:aws:kms:{dataset.region}:{dataset.AwsAccountId}:key/{key_id}")
             if len(allowed_buckets_kms_keys):
                 statements.extend(
                     [

--- a/backend/dataall/db/api/dataset.py
+++ b/backend/dataall/db/api/dataset.py
@@ -332,6 +332,9 @@ class Dataset:
             for k in data.keys():
                 if k != 'stewards':
                     setattr(dataset, k, data.get(k))
+            if data.get('KmsAlias') not in ["Undefined"]:
+                dataset.KmsAlias = "SSE-S3" if data.get('KmsAlias') == "" else data.get('KmsAlias')
+                dataset.importedKmsKey = False if data.get('KmsAlias') == "" else True
             if data.get('stewards') and data.get('stewards') != dataset.stewards:
                 if data.get('stewards') != dataset.SamlAdminGroupName:
                     Dataset.transfer_stewardship_to_new_stewards(

--- a/frontend/src/views/Datasets/DatasetEditForm.js
+++ b/frontend/src/views/Datasets/DatasetEditForm.js
@@ -149,7 +149,8 @@ const DatasetEditForm = (props) => {
             terms: values.terms.nodes
               ? values.terms.nodes.map((t) => t.nodeUri)
               : values.terms.map((t) => t.nodeUri),
-            confidentiality: values.confidentiality
+            confidentiality: values.confidentiality,
+            KmsAlias: values.KmsAlias
           }
         })
       );
@@ -254,13 +255,15 @@ const DatasetEditForm = (props) => {
                 tags: dataset.tags,
                 terms: dataset.terms || [],
                 stewards: dataset.stewards,
-                confidentiality: dataset.confidentiality
+                confidentiality: dataset.confidentiality,
+                KmsAlias: dataset.KmsAlias
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
                   .max(255)
                   .required('*Dataset name is required'),
                 description: Yup.string().max(5000),
+                KmsAlias: Yup.string().max(255),
                 topics: Yup.array().min(1).required('*Topics are required'),
                 tags: Yup.array().min(1).required('*Tags are required'),
                 confidentiality: Yup.string().required(
@@ -480,6 +483,23 @@ const DatasetEditForm = (props) => {
                             variant="outlined"
                           />
                         </CardContent>
+                        { dataset.imported && dataset.KmsAlias === 'Undefined' &&
+                          <CardContent>
+                            <TextField
+                              error={Boolean(
+                                touched.KmsAlias && errors.KmsAlias
+                              )}
+                              fullWidth
+                              helperText={touched.KmsAlias && errors.KmsAlias}
+                              label="Amazon KMS key Alias (if SSE-KMS encryption is used). Otherwise leave empty."
+                              name="KmsAlias"
+                              onBlur={handleBlur}
+                              onChange={handleChange}
+                              value={values.KmsAlias}
+                              variant="outlined"
+                            />
+                         </CardContent>
+                        }
                       </Card>
                       <Card>
                         <CardHeader title="Governance" />

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -100,7 +100,11 @@ def test_list_datasets(client, dataset1, group):
     assert response.data.listDatasets.nodes[0].datasetUri == dataset1.datasetUri
 
 
-def test_update_dataset(dataset1, client, group, group2):
+def test_update_dataset(dataset1, client, group, group2, module_mocker):
+    module_mocker.patch(
+        'dataall.aws.handlers.kms.KMS.get_key_id',
+        return_value={"some_key"},
+    )
     response = client.query(
         """
         mutation UpdateDataset($datasetUri:String!,$input:ModifyDatasetInput){
@@ -119,6 +123,7 @@ def test_update_dataset(dataset1, client, group, group2):
             'label': 'dataset1updated',
             'stewards': group2.name,
             'confidentiality': 'Secret',
+            'KmsAlias': ''
         },
         groups=[group.name],
     )
@@ -164,6 +169,7 @@ def test_update_dataset(dataset1, client, group, group2):
             'label': 'dataset1updated2',
             'stewards': dataset1.SamlAdminGroupName,
             'confidentiality': 'Official',
+            'KmsAlias': ''
         },
         groups=[group.name],
     )
@@ -212,7 +218,10 @@ def test_update_dataset_unauthorized(dataset1, client, group):
         """,
         username='anonymoususer',
         datasetUri=dataset1.datasetUri,
-        input={'label': 'dataset1updated'},
+        input={
+            'label': 'dataset1updated',
+            'KmsAlias': ''
+        },
     )
     assert 'UnauthorizedOperation' in response.errors[0].message
 

--- a/tests/api/test_glossary.py
+++ b/tests/api/test_glossary.py
@@ -316,7 +316,10 @@ def test_dataset_term_link_approval(db, client, t1, _dataset, user, group):
         username='alice',
         groups=[group.name],
         datasetUri=_dataset.datasetUri,
-        input={'terms': [t1.nodeUri]},
+        input={
+            'terms': [t1.nodeUri],
+            'KmsAlias': ''
+        },
     )
     with db.scoped_session() as session:
         link: models.TermLink = (


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Allow edition of KMS key alias for imported datasets that were created before v1.6.0
- Added check for imported KMS key alias
- Added check in data policy of env roles
- Fixed tests

### Relates
- #515 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
