### PR TITLE
Add Glue Resource Policy Permissions for cross account share requests

### DIFF
--- a/backend/dataall/cdkproxy/stacks/pivot_role.py
+++ b/backend/dataall/cdkproxy/stacks/pivot_role.py
@@ -171,7 +171,7 @@ class PivotRole(NestedStack):
                     ],
                     resources=[f'arn:aws:s3:*:{self.account}:accesspoint/*'],
                 ),
-                # Glue - needed to handle databases and tables
+                # Glue - needed to handle databases and tables and cross-account shares
                 iam.PolicyStatement(
                     sid='GlueCatalog',
                     effect=iam.Effect.ALLOW,
@@ -193,6 +193,8 @@ class PivotRole(NestedStack):
                         'glue:UpdatePartition',
                         'glue:UpdateTable',
                         'glue:TagResource',
+                        'glue:DeleteResourcePolicy',
+                        'glue:PutResourcePolicy',
                     ],
                     resources=['*'],
                 ),

--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -140,6 +140,8 @@ Resources:
               - 'glue:UpdatePartition'
               - 'glue:UpdateTable'
               - 'glue:TagResource'
+              - 'glue:DeleteResourcePolicy'
+              - 'glue:PutResourcePolicy'
             Effect: Allow
             Resource: '*'
           - Sid: GlueETL


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
- For cross-account shares of data all tables using LF named resources and RAM for share invitations we require `glue:PutResourcePolicy` and `glue:DeleteResourcePolicy` permissions for the pivotRoles handling management of RAM share invitations
- Without the above permissions - the sharing of tables cross-account to other data.all environments failed with a similar error to the following:

```
Failed granting principal arn:aws:iam::ACCOUNT_A:role/TARGET_ROLE read access to resource link on target 
ACCOUNT_B://GLUE_DB/TABLE_NAME due to: An error occurred (AccessDeniedException) when calling the 
GrantPermissions operation: Insufficient Glue permissions to access table TABLE_NAME
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
