### PR TITLE
Setup modules absolute imports using jsconfig

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "authentication/*": ["src/authentication/*"],
+      "design/*": ["src/design/*"],
+      "globalErrors/*": ["src/globalErrors/*"],
+      "modules/*": ["src/modules/*"],
+      "services/*": ["src/services/*"],
+      "utils/*": ["src/utils/*"]
+    }
+  }
+}


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Setup frontend (React) modules absolute imports using jsconfig.json

### Relates
- https://github.com/awslabs/aws-dataall/issues/398

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
