### PR TITLE
Fix wrong update of externalId for pivotRole

### DIFF
--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -147,7 +147,11 @@ def _get_external_id_value(envname, account_id, region):
         return parameter_value
     except:
         try:
-            secret_value = SecretValue.secrets_manager(secret_id).unsafe_unwrap()
+            secrets_client = session.client('secretsmanager', region_name=region)
+            if secrets_client.describe_secret(SecretId=secret_id):
+                secret_value = SecretValue.secrets_manager(secret_id).unsafe_unwrap()
+            else:
+                raise Exception
             return secret_value
         except:
             return False

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -1,6 +1,5 @@
 import random
 import string
-import os
 
 import boto3
 from aws_cdk import (
@@ -105,9 +104,6 @@ class ParamStoreStack(pyNestedClass):
             string_value=str(pivot_role_name),
             description=f"Stores dataall pivot role name for environment {envname}",
         )
-
-        # account_id = os.environ.get("CDK_DEPLOY_ACCOUNT", os.environ["CDK_DEFAULT_ACCOUNT"])
-        # region = os.environ.get("CDK_DEPLOY_REGION", os.environ["CDK_DEFAULT_REGION"])
 
         existing_external_id = _get_external_id_value(envname=envname, account_id=self.account, region=self.region)
         external_id_value = existing_external_id if existing_external_id else _generate_external_id()

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -104,7 +104,7 @@ class ParamStoreStack(pyNestedClass):
         )
         try:
             parameter_path = f"/dataall/{envname}/pivotRole/externalId"
-            external_id_value = aws_ssm.StringParameter.value_for_string_paramete(self, parameter_path)
+            external_id_value = aws_ssm.StringParameter.value_for_string_parameter(self, parameter_path)
         except:
             secret_id = f"dataall-externalId-{envname}"
             try:

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -1,5 +1,6 @@
 import random
 import string
+import os
 
 import boto3
 from aws_cdk import (
@@ -105,7 +106,10 @@ class ParamStoreStack(pyNestedClass):
             description=f"Stores dataall pivot role name for environment {envname}",
         )
 
-        existing_external_id = _get_external_id_value(envname=envname, account_id=self.env.get('account'), region=self.env.get('region'))
+        account_id = os.environ.get("CDK_DEPLOY_ACCOUNT", os.environ["CDK_DEFAULT_ACCOUNT"])
+        region = os.environ.get("CDK_DEPLOY_REGION", os.environ["CDK_DEFAULT_REGION"])
+
+        existing_external_id = _get_external_id_value(envname=envname, account_id=account_id, region=region)
         external_id_value = existing_external_id if existing_external_id else _generate_external_id()
 
         aws_ssm.StringParameter(

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -4,6 +4,7 @@ import string
 import boto3
 from aws_cdk import (
     aws_ssm,
+    SecretValue
 )
 
 from .pyNestedStack import pyNestedClass
@@ -146,8 +147,7 @@ def _get_external_id_value(envname, account_id, region):
         return parameter_value
     except:
         try:
-            secrets_client = session.client('secretsmanager', region_name=region)
-            secret_value = secrets_client.get_secret_value(SecretId=secret_id)['SecretString']
+            secret_value = SecretValue.secrets_manager(secret_id).unsafe_unwrap()
             return secret_value
         except:
             return False

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -106,10 +106,10 @@ class ParamStoreStack(pyNestedClass):
             description=f"Stores dataall pivot role name for environment {envname}",
         )
 
-        account_id = os.environ.get("CDK_DEPLOY_ACCOUNT", os.environ["CDK_DEFAULT_ACCOUNT"])
-        region = os.environ.get("CDK_DEPLOY_REGION", os.environ["CDK_DEFAULT_REGION"])
+        # account_id = os.environ.get("CDK_DEPLOY_ACCOUNT", os.environ["CDK_DEFAULT_ACCOUNT"])
+        # region = os.environ.get("CDK_DEPLOY_REGION", os.environ["CDK_DEFAULT_REGION"])
 
-        existing_external_id = _get_external_id_value(envname=envname, account_id=account_id, region=region)
+        existing_external_id = _get_external_id_value(envname=envname, account_id=self.account, region=self.region)
         external_id_value = existing_external_id if existing_external_id else _generate_external_id()
 
         aws_ssm.StringParameter(

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -27,8 +27,6 @@ class ParamStoreStack(pyNestedClass):
     ):
         super().__init__(scope, id, **kwargs)
 
-        self.env = kwargs.get('env')
-
         self.resource_prefix_param = aws_ssm.StringParameter(
             self,
             f'ResourcePrefixParam{envname}',

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -104,7 +104,7 @@ class ParamStoreStack(pyNestedClass):
         )
         try:
             parameter_path = f"/dataall/{envname}/pivotRole/externalId"
-            external_id_value = aws_ssm.StringParameter.value_from_lookup(self, parameter_path)
+            external_id_value = aws_ssm.StringParameter.value_for_string_paramete(self, parameter_path)
         except:
             secret_id = f"dataall-externalId-{envname}"
             try:

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -4,7 +4,6 @@ import string
 import boto3
 from aws_cdk import (
     aws_ssm,
-    aws_secretsmanager
 )
 
 from .pyNestedStack import pyNestedClass
@@ -26,6 +25,8 @@ class ParamStoreStack(pyNestedClass):
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
+
+        self.env = kwargs.get('env')
 
         self.resource_prefix_param = aws_ssm.StringParameter(
             self,
@@ -102,16 +103,9 @@ class ParamStoreStack(pyNestedClass):
             string_value=str(pivot_role_name),
             description=f"Stores dataall pivot role name for environment {envname}",
         )
-        try:
-            parameter_path = f"/dataall/{envname}/pivotRole/externalId"
-            external_id_value = aws_ssm.StringParameter.value_for_string_parameter(self, parameter_path)
-        except:
-            secret_id = f"dataall-externalId-{envname}"
-            try:
-                external_id_value = aws_secretsmanager.Secret.from_secret_complete_arn(self, "lookUpSecret", f"arn:aws:secretsmanager:{self.region}:{self.account}:secret:{secret_id}")
-            except:
-                external_id_value = _generate_external_id()
 
+        existing_external_id = _get_external_id_value(envname=envname, account_id=self.env.get('account'), region=self.env.get('region'))
+        external_id_value = existing_external_id if existing_external_id else _generate_external_id()
 
         aws_ssm.StringParameter(
             self,
@@ -120,6 +114,43 @@ class ParamStoreStack(pyNestedClass):
             string_value=str(external_id_value),
             description=f"Stores dataall external id for environment {envname}",
         )
+
+def _get_external_id_value(envname, account_id, region):
+    """For first deployments it returns False,
+    for existing deployments it returns the ssm parameter value generated in the first deployment
+    for prior to V1.5.1 upgrades it returns the secret from secrets manager
+    """
+    cdk_look_up_role = 'arn:aws:iam::{}:role/cdk-hnb659fds-lookup-role-{}-{}'.format(account_id, account_id, region)
+    base_session = boto3.Session()
+    assume_role_dict = dict(
+        RoleArn=cdk_look_up_role,
+        RoleSessionName=cdk_look_up_role.split('/')[1],
+    )
+    sts = base_session.client(
+        'sts',
+        region_name=region,
+        endpoint_url=f"https://sts.{region}.amazonaws.com"
+    )
+    response = sts.assume_role(**assume_role_dict)
+    session = boto3.Session(
+        aws_access_key_id=response['Credentials']['AccessKeyId'],
+        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+        aws_session_token=response['Credentials']['SessionToken'],
+    )
+
+    secret_id = f"dataall-externalId-{envname}"
+    parameter_path = f"/dataall/{envname}/pivotRole/externalId"
+    try:
+        ssm_client = session.client('ssm', region_name=region)
+        parameter_value = ssm_client.get_parameter(Name=parameter_path)['Parameter']['Value']
+        return parameter_value
+    except:
+        try:
+            secrets_client = session.client('secretsmanager', region_name=region)
+            secret_value = secrets_client.get_secret_value(SecretId=secret_id)['SecretString']
+            return secret_value
+        except:
+            return False
 
 def _generate_external_id():
     allowed_chars = string.ascii_uppercase + string.ascii_lowercase + string.digits

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -233,6 +233,14 @@ class PipelineStack(Stack):
             statements= [
                 iam.PolicyStatement(
                     actions=[
+                        'sts:AssumeRole',
+                    ],
+                    resources=[
+                        'arn:aws:iam::*:role/cdk-hnb659fds-lookup-role*'
+                    ],
+                ),
+                iam.PolicyStatement(
+                    actions=[
                         'sts:GetServiceBearerToken',
                     ],
                     resources=['*'],


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fixes #589 by: 
- using CDK constructs to check the existence of an externalID in Secrets Manager
- using boto3 calls using the CDK look up role in the deployment accounts to find an externalID in the Systems Manager Parameter Store

## Manual operations needed ONLY if upgrading. Fresh deployments are unaffected

In the first run the CodePipeline will fail in the `CDK Synth` stage if no additional changes are done:
```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::111111111111:assumed-role/SOME ROLE/... is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::222222222222:role/cdk-hnb659fds-lookup-role-22222222222-eu-west-1
```
CodeBuild needs additional permissions to assume the IAM role in the CDK Synth stage. Since we cannot update this CodeBuild stage without running it, the permissions need to be added manually.

### Upgrading from V1.6.0 to v1.6.1
The role that we need to update is a role named `<PREFIX>-<GITBRANCH>-codebuild-baseline-role`. It will say it in the error message in the CodeBuild logs

 1. Go to the IAM role (`<PREFIX>-<GITBRANCH>-codebuild-baseline-role`) and click on `Add permissions` > `Create inline policy`
<img width="1482" alt="image" src="https://github.com/awslabs/aws-dataall/assets/71252798/5d13ac5a-1576-4774-b81a-9f03fbbdcc0e">
2. Update the policy, use the JSON and copy the policy below:
<img width="1464" alt="image" src="https://github.com/awslabs/aws-dataall/assets/71252798/c58be26b-c7f0-4cfa-8253-a97757191618">

The policy of the Codebuild execution role need to include the following:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": "sts:AssumeRole",
            "Resource": "arn:aws:iam::*:role/cdk-hnb659fds-lookup-role*"
        }
    ]
}
```
After the pipeline has successfully run, go back to the IAM role and remove the manually added policy. The policy is now added as part of infrastructure as code.
<img width="1482" alt="image" src="https://github.com/awslabs/aws-dataall/assets/71252798/c246a53c-9c55-4127-8cbd-e0a6ebc4b48d">

### Upgrading from <V1.6.0 to v1.6.1
The error points at a different role some. A role created by CDK that looks like the following in the CodeBuild logs:
```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts:::111111111111:assumed-role/dataall-sbx8-cicd-stack-dataallsbx8cdkpipelinePipe-HMXY7D9OX4FM/AWSCodeBuild-30c50765-4529-4d20-99ce-88f82139a82c is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::22222222222:role/cdk-hnb659fds-lookup-role-22222222222-eu-west-1
```
We find the role and update it as we explained in the "Upgrading from V1.6.0 to v1.6.1" section. 
<img width="1453" alt="image" src="https://github.com/awslabs/aws-dataall/assets/71252798/53afd449-83c6-4119-b988-3c2d89a1be08">

Once that is done, retry the CodeBuild Synth stage. In this case you do NOT need to cleanup the manually added policies as this role will be deleted.

## Tests
[X] Tested by merging this branch into a deployment initially in V1.6.0 -> SSM parameter value unmodified
[X] Tested by merging this branch into a deployment initially in V1.5.6 -> Secret value copied to SSM parameter unmodified
[X] Tested by deploying this branch on a fresh account


### Relates
- #589

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
