### PR TITLE
Replace PostgreSQL 10 by YugabyteDB

### DIFF
--- a/compose/yugabytedb/Dockerfile
+++ b/compose/yugabytedb/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.io/yugabytedb/yugabyte:latest
+COPY entrypoint.sh /usr/local/bin/
+COPY healthcheck.sh /usr/local/bin/
+COPY config.flags /tmp/
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+RUN chmod a+x /usr/local/bin/healthcheck.sh
+VOLUME /var/lib/postgresql/data
+HEALTHCHECK --start-period=30s CMD /usr/local/bin/healthcheck.sh
+ENTRYPOINT /usr/local/bin/entrypoint.sh

--- a/compose/yugabytedb/Dockerfile
+++ b/compose/yugabytedb/Dockerfile
@@ -2,8 +2,8 @@ FROM docker.io/yugabytedb/yugabyte:latest
 COPY entrypoint.sh /usr/local/bin/
 COPY healthcheck.sh /usr/local/bin/
 COPY config.flags /tmp/
-RUN chmod a+x /usr/local/bin/entrypoint.sh
-RUN chmod a+x /usr/local/bin/healthcheck.sh
+RUN chmod 777 /usr/local/bin/entrypoint.sh
+RUN chmod 777 /usr/local/bin/healthcheck.sh
 VOLUME /var/lib/postgresql/data
 HEALTHCHECK --start-period=30s CMD /usr/local/bin/healthcheck.sh
-ENTRYPOINT /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/compose/yugabytedb/README.md
+++ b/compose/yugabytedb/README.md
@@ -1,0 +1,18 @@
+This builds an image with [YugabyteDB](https://www.yugabyte.com/yugabytedb/) (re-architected PostgreSQL to be cloud native with horizonztal scalability) configured to be a drop-in replacement of the [PostgreSQL docker image](https://hub.docker.com/_/postgres/) (same behavior, same environment variables)
+
+To run with it, replace `compose/postgres` by `compose/yugabytedb`. 
+You can add the port 15433 to access the YugabyteDB console.
+
+You can add more nodes with a service that joins the others with the `--join` option like this:
+```
+ db-dist:
+    build:
+      context: compose/yugabytedb
+    command: --join=aws-dataall-db-1.aws-dataall_default
+    deploy:
+      replicas: 2
+    depends_on:
+     db:
+      condition: service_healthy
+```
+This will replicate data. To connect to all nodes, the PyGreSQL should be replaced by the [Smart Driver](https://docs.yugabyte.com/preview/reference/drivers/python/yugabyte-psycopg2-reference/). If YugabyteDB is deployed from the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-whuefqd2j5an4?sr=0-1&ref_=beagle&applicationId=AWSMPContessa) it is not needed when connectin though an HA Proxy.

--- a/compose/yugabytedb/config.flags
+++ b/compose/yugabytedb/config.flags
@@ -1,0 +1,19 @@
+# Those settings keeps the PostgreSQL behavior.
+# To scale out the active tables, you can move them out of colocation
+# but this requires to define the hash or range sharding
+
+# postgres-like (range indexes) without distribution
+--ysql_colocate_database_by_default
+# same default as PostgreSQL
+--ysql_sequence_cache_minval=1
+
+# Read Committed with PostgreSQL-like locking (wait on lock)
+--yb_enable_read_committed_isolation=true
+--enable_deadlock_detection=true
+--enable_wait_queues=true
+
+# Allow logging statements and execution plans
+--ysql_pg_conf_csv=shared_preload_libraries='auto_explain'
+
+# ignore warning when running ANALYZE
+--ysql_beta_features=true

--- a/compose/yugabytedb/entrypoint.sh
+++ b/compose/yugabytedb/entrypoint.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/bash
+
 # This Dockefile is compatible with the PostgreSQL docker image environment variables
-set -x
 
 # Start YugabyteDB for the first time, to create the database and user
 # on port 5433 because some applications test the availability of the db by `nc -z 5432'
@@ -12,7 +13,7 @@ create user "${POSTGRES_USER}";
 alter user "${POSTGRES_USER}" password '${POSTGRES_PASSWORD}'
 SQL
 
-yugabyted start \
+yugabyted start $* \
  --ysql_port=5433 \
  --tserver_flags=flagfile=/tmp/config.flags \
  --master_flags=flagfile=/tmp/config.flags \
@@ -33,8 +34,12 @@ PGHOST=$(hostname) PGPORT=5432 ysqlsh \$@
 CAT
 chmod 744 /usr/local/bin/psql
 
-# final start
-yugabyted start \
+echo "
+
+ Restarting on port 5432...
+
+"
+yugabyted start $* \
  --ysql_port=5432 \
  --background=false \
  --base_dir=${PGDATA:-/var/lib/postgresql/data} 

--- a/compose/yugabytedb/entrypoint.sh
+++ b/compose/yugabytedb/entrypoint.sh
@@ -1,0 +1,41 @@
+# This Dockefile is compatible with the PostgreSQL docker image environment variables
+set -x
+
+# Start YugabyteDB for the first time, to create the database and user
+# on port 5433 because some applications test the availability of the db by `nc -z 5432'
+# and may think it is available too early
+
+mkdir -p /docker-entrypoint-initdb.d
+cat    > /docker-entrypoint-initdb.d/00000000.sql <<SQL
+create database "${POSTGRES_DB:-$POSTGRES_USER}";
+create user "${POSTGRES_USER}";
+alter user "${POSTGRES_USER}" password '${POSTGRES_PASSWORD}'
+SQL
+
+yugabyted start \
+ --ysql_port=5433 \
+ --tserver_flags=flagfile=/tmp/config.flags \
+ --master_flags=flagfile=/tmp/config.flags \
+ --initial_scripts_dir=/docker-entrypoint-initdb.d \
+ --base_dir=${PGDATA:-/var/lib/postgresql/data} 
+
+# stop to restart on port 5432
+yugabyted stop \
+ --base_dir=${PGDATA:-/var/lib/postgresql/data} 
+
+cat > ~/.pgpass <<CAT
+$(hostname):5432:${POSTGRES_USER}:${POSTGRES_DB:-$POSTGRES_USER}:${POSTGRES_USER}:${POSTGRES_PASSWORD}
+CAT
+chmod 600 ~/.pgpass
+
+cat >> /usr/local/bin/psql <<CAT
+PGHOST=$(hostname) PGPORT=5432 ysqlsh \$@
+CAT
+chmod 744 /usr/local/bin/psql
+
+# final start
+yugabyted start \
+ --ysql_port=5432 \
+ --background=false \
+ --base_dir=${PGDATA:-/var/lib/postgresql/data} 
+

--- a/compose/yugabytedb/healthcheck.sh
+++ b/compose/yugabytedb/healthcheck.sh
@@ -1,0 +1,1 @@
+/home/yugabyte/postgres/bin/pg_isready -h $(hostname) -p 5432

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
 
   db:
     build:
-      context: compose/postgres
+      context: compose/yugabytedb
     environment:
       POSTGRES_DB: 'dataall'
       POSTGRES_USER: 'postgres'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
     - 5432
     ports:
       - 5432:5432
+      - 15433:15433
     volumes:
       - type: volume
         target: /usr/share/postgresql/data


### PR DESCRIPTION
In case you are interested by it, I tested with YugabyteDB instead of PostgreSQL. It is compatible and has the advantage to scale out in a cloud environment (plus high availability, no need to vacuum...). Here is the configuration for it. It adds the build of docker image to be a drop-in replacement. If you want to add it but keep PostgreSQL as the default, simply do not change the [docker-compose.yaml](https://github.com/FranckPachot/aws-dataall/blob/8f60710c2cd65b7f3bcca62fb052879c7b9bfa11/docker-compose.yaml#L58)

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

YugabyteDB is Apache 2.0
