### PR TITLE
Fix assume role for the fresh account

### DIFF
--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -130,16 +130,17 @@ def _get_external_id_value(envname, account_id, region):
         region_name=region,
         endpoint_url=f"https://sts.{region}.amazonaws.com"
     )
-    response = sts.assume_role(**assume_role_dict)
-    session = boto3.Session(
-        aws_access_key_id=response['Credentials']['AccessKeyId'],
-        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
-        aws_session_token=response['Credentials']['SessionToken'],
-    )
-
-    secret_id = f"dataall-externalId-{envname}"
-    parameter_path = f"/dataall/{envname}/pivotRole/externalId"
     try:
+        response = sts.assume_role(**assume_role_dict)
+        session = boto3.Session(
+            aws_access_key_id=response['Credentials']['AccessKeyId'],
+            aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+            aws_session_token=response['Credentials']['SessionToken'],
+        )
+
+        secret_id = f"dataall-externalId-{envname}"
+        parameter_path = f"/dataall/{envname}/pivotRole/externalId"
+
         ssm_client = session.client('ssm', region_name=region)
         parameter_value = ssm_client.get_parameter(Name=parameter_path)['Parameter']['Value']
         return parameter_value


### PR DESCRIPTION
New accounts doesn't have cdk-hnb659fds-lookup-role it leads to issue

Implementation details:
According to description of 
```
For first deployments it returns False,
for existing deployments it returns the ssm parameter value generated in the first deployment
for prior to V1.5.1 upgrades it returns the secret from secrets manager
```
For first deployments  it fails because there is no role to assume 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
