### PR TITLE
Handle External ID SSM v1.6.1>

### DIFF
--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -130,29 +130,21 @@ def _get_external_id_value(envname, account_id, region):
         region_name=region,
         endpoint_url=f"https://sts.{region}.amazonaws.com"
     )
-    response = sts.assume_role(**assume_role_dict)
-    session = boto3.Session(
-        aws_access_key_id=response['Credentials']['AccessKeyId'],
-        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
-        aws_session_token=response['Credentials']['SessionToken'],
-    )
-
-    secret_id = f"dataall-externalId-{envname}"
     parameter_path = f"/dataall/{envname}/pivotRole/externalId"
+
     try:
+        response = sts.assume_role(**assume_role_dict)
+        session = boto3.Session(
+            aws_access_key_id=response['Credentials']['AccessKeyId'],
+            aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+            aws_session_token=response['Credentials']['SessionToken'],
+        )
         ssm_client = session.client('ssm', region_name=region)
         parameter_value = ssm_client.get_parameter(Name=parameter_path)['Parameter']['Value']
         return parameter_value
     except:
-        try:
-            secrets_client = session.client('secretsmanager', region_name=region)
-            if secrets_client.describe_secret(SecretId=secret_id):
-                secret_value = SecretValue.secrets_manager(secret_id).unsafe_unwrap()
-            else:
-                raise Exception
-            return secret_value
-        except:
-            return False
+        return False
+
 
 def _generate_external_id():
     allowed_chars = string.ascii_uppercase + string.ascii_lowercase + string.digits

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -115,9 +115,9 @@ class ParamStoreStack(pyNestedClass):
         )
 
 def _get_external_id_value(envname, account_id, region):
-    """For first deployments it returns False,
-    for existing deployments it returns the ssm parameter value generated in the first deployment
-    for prior to V1.5.1 upgrades it returns the secret from secrets manager
+    """
+    For first deployments and upgrades from <=V1.5.6 to >=v1.6 - returns False and a new ssm parameter created,
+    For existing >=v1.6 deployments - returns the ssm parameter value generated in the first deployment
     """
     cdk_look_up_role = 'arn:aws:iam::{}:role/cdk-hnb659fds-lookup-role-{}-{}'.format(account_id, account_id, region)
     base_session = boto3.Session()


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- As part of v1.6 Data.All moved away from storing the externalID as a rotated secret in Secret Manager and instead placed the external ID in SSM Parameter Store.
  - In the current implementation in v1.6.1 we check if the secret exists and the ssm parameter does not and if these conditions are met the secret value is retrieved and a new ssm parameter is set with the same externalID
  -  The problem with the above is CDK uses dynamic references to resolve the secret value (meaning in the first upgrade deployment we set ssm parameter as ref to secret value and delete secret, in 2nd and so one deployments it will fail with `Secrets Manager can't find the specified secret.`)

- Alternatively we can not use the CDK bootstrap role, such as the look up role, and boto3 SDK commands to retrieve the secret value during `synth` because IAM permissions out of the box do not allow said actions
  - This would theoretically be a way to overcome the dynamic reference issue mentioned above 

- This PR reverts to a more straightforward approach where we create a new SSM Parameter if one does not exist already for the external ID and does not reference the previously created secret externalID 
  -  NOTE: In order to keep the same externalID and prevent additional manual work to update the pivotRole's using this value one would have to 
    - retain the current externalID in Secret Manager (named `dataall-externalId-{envname}`) from version <= 1.5X
    - Run the upgrade to v1.6.1
    - Replace the newly created SSM (parameter named `/dataall/{envname}/pivotRole/externalId"`) with the original value for external ID


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
