### PR TITLE
Resolve Dataset Profiling Glue Job

### DIFF
--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
@@ -52,7 +52,7 @@ def on_create(event):
     default_db_exists = False
     try:
         glue_client.get_database(Name="default")
-        exists = True
+        default_db_exists = True
     except ClientError as e:
         pass
 

--- a/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
+++ b/backend/dataall/cdkproxy/assets/gluedatabasecustomresource/index.py
@@ -48,7 +48,7 @@ def on_create(event):
         exists = True
     except ClientError as e:
         pass
-    
+
     default_db_exists = False
     try:
         glue_client.get_database(Name="default")
@@ -123,7 +123,6 @@ def on_create(event):
                     'Permissions': ['Describe'.upper()],
                 }
             )
-
 
     lf_client.batch_grant_permissions(CatalogId=props['CatalogId'], Entries=Entries)
     physical_id = props['DatabaseInput']['Imported'] + props['DatabaseInput']['Name']

--- a/backend/dataall/cdkproxy/assets/glueprofilingjob/glue_script.py
+++ b/backend/dataall/cdkproxy/assets/glueprofilingjob/glue_script.py
@@ -1,4 +1,5 @@
 import json
+import os
 import logging
 import pprint
 import sys
@@ -8,7 +9,6 @@ from awsglue.context import GlueContext
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from pydeequ.profiles import *
 
 sc = SparkContext.getOrCreate()
 sc._jsc.hadoopConfiguration().set('fs.s3.canned.acl', 'BucketOwnerFullControl')
@@ -32,6 +32,7 @@ list_args = [
     'environmentBucket',
     'dataallRegion',
     'table',
+    "SPARK_VERSION"
 ]
 try:
     args = getResolvedOptions(sys.argv, list_args)
@@ -42,6 +43,10 @@ except Exception as e:
     logger.info(f'No Table arg passed profiling will run on all dataset tables: {e}')
     list_args.remove('table')
     args = getResolvedOptions(sys.argv, list_args)
+
+os.environ["SPARK_VERSION"] = args.get("SPARK_VERSION", "3.1")
+
+from pydeequ.profiles import *
 
 logger.info('Parsed Retrieved parameters')
 

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -445,7 +445,8 @@ class Dataset(Stack):
                     'CreateTableDefaultPermissions': [],
                     'Imported': 'IMPORTED-' if dataset.imported else 'CREATED-'
                 },
-                'DatabaseAdministrators': dataset_admins
+                'DatabaseAdministrators': dataset_admins,
+                'TriggerUpdate': True
             },
         )
 

--- a/backend/dataall/cdkproxy/stacks/dataset.py
+++ b/backend/dataall/cdkproxy/stacks/dataset.py
@@ -295,7 +295,7 @@ class Dataset(Stack):
                     ]
                 ),
                 iam.PolicyStatement(
-                    sid="CreateLoggingGlueCrawler",
+                    sid="CreateLoggingGlue",
                     actions=[
                         'logs:CreateLogGroup',
                         'logs:CreateLogStream',
@@ -303,16 +303,18 @@ class Dataset(Stack):
                     effect=iam.Effect.ALLOW,
                     resources=[
                         f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/crawlers*',
+                        f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/jobs/*',
                     ],
                 ),
                 iam.PolicyStatement(
-                    sid="LoggingGlueCrawler",
+                    sid="LoggingGlue",
                     actions=[
                         'logs:PutLogEvents',
                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[
                         f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/crawlers:log-stream:{dataset.GlueCrawlerName}',
+                        f'arn:aws:logs:{dataset.region}:{dataset.AwsAccountId}:log-group:/aws-glue/jobs/*',
                     ],
                 ),
                 iam.PolicyStatement(
@@ -484,6 +486,7 @@ class Dataset(Stack):
             '--enable-metrics': 'true',
             '--enable-continuous-cloudwatch-log': 'true',
             '--enable-glue-datacatalog': 'true',
+            '--SPARK_VERSION': '3.1',
         }
 
         job = glue.CfnJob(

--- a/documentation/userguide/docs/tables.md
+++ b/documentation/userguide/docs/tables.md
@@ -70,6 +70,9 @@ By selecting the **Metrics** tab of your data table you can run a profiling job 
 
 ![](pictures/tables/table_metrics.png#zoom#shadow)
 
+!!! warning "Profiling Job Prerequisite"
+    Before running the profiling job you will need to ensure that the **default** Glue Database exists in the AWS Account where the data exists (by default this database exists for new accounts). This is required to enable the Glue profiling job to use the metadata stored in the Glue Catalog. 
+
 ### :material-trash-can-outline: **Delete a table**
 Deleting a table means deleting it from the data.all Catalog, but it will be still available on the AWS Glue Catalog.
 Moreover, when data owners


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
-  Specify `SPARK_VERSION` as an environment variable for `pydeequ` before import
- Add IAM Permissions to Dataset IAM Role to Allow for Glue Job logging in CloudWatch
- Add LF Permissions to resolve insufficient permissions error thrown when looking for `default` database

### Relates


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
