### PR TITLE
Change Defaut Cloudfront TLS Feature Flag

### DIFF
--- a/backend/dataall/base/cdkproxy/cdk.json
+++ b/backend/dataall/base/cdkproxy/cdk.json
@@ -2,7 +2,7 @@
   "__app": "python app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false
   }

--- a/cdk.json
+++ b/cdk.json
@@ -2,7 +2,7 @@
   "app": "python ./deploy/app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false
   }

--- a/template_cdk.json
+++ b/template_cdk.json
@@ -2,7 +2,7 @@
   "app": "python ./deploy/app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_region": "string_TOOLING_REGION|DEFAULT=eu-west-1",


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Change cdk context CloudFront feature flag in `cdk.json` from `"@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false` to `true`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
