### PR TITLE
Update cloudfront feature flag in docs cdk json

### DIFF
--- a/pages/deploy/deploy_aws.md
+++ b/pages/deploy/deploy_aws.md
@@ -83,7 +83,7 @@ of our repository. Open it, you should be seen something like:
   "app": "python ./deploy/app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_region": "string_TOOLING_REGION|DEFAULT=eu-west-1",
@@ -166,7 +166,7 @@ and find 2 examples of cdk.json files.
   "app": "python ./deploy/app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false,
     "DeploymentEnvironments": [
@@ -190,7 +190,7 @@ deploy to 2 deployments accounts.
   "app": "python ./deploy/app.py",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_vpc_id": "vpc-1234567890EXAMPLE",


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Documentation

### Detail
- Change documentation on `cdk.json` from "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false to true



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
