### PR TITLE
Fix module dependency loading.

### DIFF
--- a/backend/dataall/modules/catalog/__init__.py
+++ b/backend/dataall/modules/catalog/__init__.py
@@ -1,7 +1,19 @@
 from typing import Set
 
 from dataall.base.loader import ModuleInterface, ImportMode
-from dataall.modules.catalog import tasks
+
+
+class CatalogIndexerModuleInterface(ModuleInterface):
+    """
+    Base code that can be imported with all modes
+    """
+
+    @staticmethod
+    def is_supported(modes: Set[ImportMode]) -> bool:
+        return ImportMode.CATALOG_INDEXER_TASK in modes
+
+    def __init__(self):
+        from dataall.modules.catalog import tasks
 
 
 class CatalogApiModuleInterface(ModuleInterface):

--- a/backend/dataall/modules/dashboards/__init__.py
+++ b/backend/dataall/modules/dashboards/__init__.py
@@ -3,12 +3,10 @@ import logging
 from typing import Set, List, Type
 
 from dataall.core.environment.services.environment_resource_manager import EnvironmentResourceManager
-from dataall.modules.catalog import CatalogApiModuleInterface
 from dataall.modules.dashboards.db.dashboard_repository import DashboardRepository
 from dataall.modules.dashboards.db.models import Dashboard
 from dataall.base.loader import ImportMode, ModuleInterface
-from dataall.modules.feed import FeedApiModuleInterface
-from dataall.modules.vote import VoteApiModuleInterface
+
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +20,10 @@ class DashboardApiModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
+        from dataall.modules.feed import FeedApiModuleInterface
+        from dataall.modules.vote import VoteApiModuleInterface
+        from dataall.modules.catalog import CatalogApiModuleInterface
+
         return [FeedApiModuleInterface, CatalogApiModuleInterface, VoteApiModuleInterface]
 
     def __init__(self):
@@ -65,7 +67,8 @@ class DashboardCatalogIndexerModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
-        return [CatalogApiModuleInterface]
+        from dataall.modules.catalog import CatalogIndexerModuleInterface
+        return [CatalogIndexerModuleInterface]
 
     def __init__(self):
         from dataall.modules.dashboards.indexers.dashboard_catalog_indexer import DashboardCatalogIndexer

--- a/backend/dataall/modules/datapipelines/__init__.py
+++ b/backend/dataall/modules/datapipelines/__init__.py
@@ -8,7 +8,6 @@ from dataall.modules.datapipelines.db.models import DataPipeline
 from dataall.modules.datapipelines.db.datapipelines_repository import DatapipelinesRepository
 from dataall.modules.datapipelines.services.datapipelines_permissions import \
     GET_PIPELINE, UPDATE_PIPELINE
-from dataall.modules.feed import FeedApiModuleInterface
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +21,8 @@ class DatapipelinesApiModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
+        from dataall.modules.feed import FeedApiModuleInterface
+
         return [FeedApiModuleInterface]
 
     def __init__(self):

--- a/backend/dataall/modules/datasets/__init__.py
+++ b/backend/dataall/modules/datasets/__init__.py
@@ -3,14 +3,11 @@ import logging
 from typing import List, Type, Set
 
 from dataall.base.loader import ModuleInterface, ImportMode
-from dataall.modules.catalog import CatalogApiModuleInterface
-from dataall.modules.dataset_sharing import DataSharingCdkModuleInterface
 from dataall.modules.datasets.services.dataset_permissions import GET_DATASET, UPDATE_DATASET
 from dataall.modules.datasets_base import DatasetBaseModuleInterface
 from dataall.modules.datasets_base.db.dataset_repository import DatasetRepository
 from dataall.modules.datasets_base.db.models import DatasetTableColumn, DatasetStorageLocation, DatasetTable, Dataset
-from dataall.modules.feed import FeedApiModuleInterface
-from dataall.modules.vote import VoteApiModuleInterface
+
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +22,9 @@ class DatasetApiModuleInterface(ModuleInterface):
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
         from dataall.modules.dataset_sharing import SharingApiModuleInterface
+        from dataall.modules.catalog import CatalogApiModuleInterface
+        from dataall.modules.feed import FeedApiModuleInterface
+        from dataall.modules.vote import VoteApiModuleInterface
 
         return [
             SharingApiModuleInterface, DatasetBaseModuleInterface, CatalogApiModuleInterface,
@@ -107,6 +107,7 @@ class DatasetCdkModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
+        from dataall.modules.dataset_sharing import DataSharingCdkModuleInterface
         return [DatasetBaseModuleInterface, DataSharingCdkModuleInterface]
 
     def __init__(self):
@@ -146,7 +147,9 @@ class DatasetCatalogIndexerModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
-        return [DatasetBaseModuleInterface, CatalogApiModuleInterface]
+        from dataall.modules.catalog import CatalogIndexerModuleInterface
+
+        return [DatasetBaseModuleInterface, CatalogIndexerModuleInterface]
 
     def __init__(self):
         from dataall.modules.datasets.indexers.dataset_catalog_indexer import DatasetCatalogIndexer

--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -14,6 +14,7 @@ from dataall.core.stacks.api import stack_helper
 from dataall.core.stacks.db.keyvaluetag import KeyValueTag
 from dataall.core.stacks.db.stack import Stack
 from dataall.core.tasks.db.task_models import Task
+from dataall.modules.catalog.db.glossary import Glossary
 from dataall.modules.vote.db.vote import Vote
 from dataall.base.db.exceptions import AWSResourceNotFound, UnauthorizedOperation
 from dataall.modules.dataset_sharing.aws.kms_client import KmsClient
@@ -203,7 +204,8 @@ class DatasetService:
                     resource_uri=dataset.datasetUri,
                     resource_type=Dataset.__name__,
                 )
-                DatasetRepository.update_dataset_glossary_terms(session, username, uri, data)
+                if data.get('terms'):
+                    Glossary.set_glossary_terms_links(session, username, uri, 'Dataset', data.get('terms'))
                 DatasetRepository.update_dataset_activity(session, dataset, username)
 
             DatasetIndexer.upsert(session, dataset_uri=uri)
@@ -366,7 +368,7 @@ class DatasetService:
             DatasetIndexer.delete_doc(doc_id=uri)
 
             ShareObjectRepository.delete_shares_with_no_shared_items(session, uri)
-            DatasetRepository.delete_dataset_term_links(session, uri)
+            DatasetService.delete_dataset_term_links(session, uri)
             DatasetTableRepository.delete_dataset_tables(session, dataset.datasetUri)
             DatasetLocationRepository.delete_dataset_locations(session, dataset.datasetUri)
             KeyValueTag.delete_key_value_tags(session, dataset.datasetUri, 'dataset')
@@ -523,3 +525,10 @@ class DatasetService:
                         resource_uri=share.shareUri,
                     )
         return dataset
+
+    @staticmethod
+    def delete_dataset_term_links(session, dataset_uri):
+        tables = [t.tableUri for t in DatasetRepository.get_dataset_tables(session, dataset_uri)]
+        for table_uri in tables:
+            Glossary.delete_glossary_terms_links(session, table_uri, 'DatasetTable')
+        Glossary.delete_glossary_terms_links(session, dataset_uri, 'Dataset')

--- a/backend/dataall/modules/datasets_base/db/dataset_repository.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repository.py
@@ -4,7 +4,6 @@ from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
 
 from dataall.core.activity.db.activity_models import Activity
-from dataall.modules.catalog.db.glossary_models import TermLink, GlossaryNode
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.organizations.db.organization import Organization
 from dataall.base.db import paginate
@@ -194,37 +193,6 @@ class DatasetRepository(EnvironmentResource):
         session.commit()
 
     @staticmethod
-    def update_dataset_glossary_terms(session, username, uri, data):
-        if data.get('terms'):
-            input_terms = data.get('terms', [])
-            current_links = session.query(TermLink).filter(
-                TermLink.targetUri == uri
-            )
-            for current_link in current_links:
-                if current_link not in input_terms:
-                    session.delete(current_link)
-            for nodeUri in input_terms:
-                term = session.query(GlossaryNode).get(nodeUri)
-                if term:
-                    link = (
-                        session.query(TermLink)
-                        .filter(
-                            TermLink.targetUri == uri,
-                            TermLink.nodeUri == nodeUri,
-                        )
-                        .first()
-                    )
-                    if not link:
-                        new_link = TermLink(
-                            targetUri=uri,
-                            nodeUri=nodeUri,
-                            targetType='Dataset',
-                            owner=username,
-                            approvedByOwner=True,
-                        )
-                        session.add(new_link)
-
-    @staticmethod
     def update_bucket_status(session, dataset_uri):
         """
         helper method to update the dataset bucket status
@@ -254,36 +222,6 @@ class DatasetRepository(EnvironmentResource):
     def delete_dataset(session, dataset) -> bool:
         session.delete(dataset)
         return True
-
-    @staticmethod
-    def delete_dataset_term_links(session, uri):
-        tables = [t.tableUri for t in DatasetRepository.get_dataset_tables(session, uri)]
-        for tableUri in tables:
-            term_links = (
-                session.query(TermLink)
-                .filter(
-                    and_(
-                        TermLink.targetUri == tableUri,
-                        TermLink.targetType == 'DatasetTable',
-                    )
-                )
-                .all()
-            )
-            for link in term_links:
-                session.delete(link)
-                session.commit()
-        term_links = (
-            session.query(TermLink)
-            .filter(
-                and_(
-                    TermLink.targetUri == uri,
-                    TermLink.targetType == 'Dataset',
-                )
-            )
-            .all()
-        )
-        for link in term_links:
-            session.delete(link)
 
     @staticmethod
     def list_all_datasets(session) -> [Dataset]:

--- a/backend/dataall/modules/vote/__init__.py
+++ b/backend/dataall/modules/vote/__init__.py
@@ -1,7 +1,6 @@
 from typing import Set, List, Type
 
 from dataall.base.loader import ModuleInterface, ImportMode
-from dataall.modules.vote import api
 
 
 class VoteApiModuleInterface(ModuleInterface):

--- a/backend/dataall/modules/vote/__init__.py
+++ b/backend/dataall/modules/vote/__init__.py
@@ -1,7 +1,6 @@
 from typing import Set, List, Type
 
 from dataall.base.loader import ModuleInterface, ImportMode
-from dataall.modules.catalog import CatalogApiModuleInterface
 from dataall.modules.vote import api
 
 
@@ -13,6 +12,8 @@ class VoteApiModuleInterface(ModuleInterface):
 
     @staticmethod
     def depends_on() -> List[Type['ModuleInterface']]:
+        from dataall.modules.catalog import CatalogApiModuleInterface
+
         return [CatalogApiModuleInterface]
 
     def __init__(self):


### PR DESCRIPTION
The corresponding module interface for a dependency should be loaded locally

- Bugfix

There is a issue with the loading of modules for cdkproxy task. The issue appears since the loading of dependency happens in the module scope, but should be local for each `ModuleInterface`

For instance, when there is `from dataall.modules.catalog import api` in `dataall.modules.datasets.__init__` the Catalog API will be loaded for each dataset module interfaces.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
