### PR TITLE
Change Env IAM Role Names to Role ARNS

### DIFF
--- a/backend/dataall/base/aws/iam.py
+++ b/backend/dataall/base/aws/iam.py
@@ -29,6 +29,22 @@ class IAM:
             return response["Role"]
 
     @staticmethod
+    def get_role_arn_by_name(account_id: str, role_name: str, role=None):
+        log.info(f"Getting IAM role name= {role_name}")
+        try:
+            iamcli = IAM.client(account_id=account_id, role=role)
+            response = iamcli.get_role(
+                RoleName=role_name
+            )
+        except Exception as e:
+            log.error(
+                f'Failed to get role {role_name} due to: {e}'
+            )
+            return None
+        else:
+            return response["Role"]["Arn"]
+
+    @staticmethod
     def update_role_policy(
         account_id: str,
         role_name: str,

--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -31,7 +31,7 @@ NewEnvironmentInput = gql.InputType(
         gql.Argument('vpcId', gql.String),
         gql.Argument('privateSubnetIds', gql.ArrayType(gql.String)),
         gql.Argument('publicSubnetIds', gql.ArrayType(gql.String)),
-        gql.Argument('EnvironmentDefaultIAMRoleName', gql.String),
+        gql.Argument('EnvironmentDefaultIAMRoleArn', gql.String),
         gql.Argument('resourcePrefix', gql.String),
         gql.Argument('parameters', gql.ArrayType(ModifyEnvironmentParameterInput))
 
@@ -98,7 +98,7 @@ InviteGroupOnEnvironmentInput = gql.InputType(
         gql.Argument('permissions', gql.ArrayType(gql.String)),
         gql.Argument('environmentUri', gql.NonNullableType(gql.String)),
         gql.Argument('groupUri', gql.NonNullableType(gql.String)),
-        gql.Argument('environmentIAMRoleName', gql.String),
+        gql.Argument('environmentIAMRoleArn', gql.String),
     ],
 )
 

--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -408,7 +408,7 @@ class EnvironmentSetup(Stack):
                 iam.Role.from_role_arn(
                     self,
                     f'{group.groupUri + group.environmentIAMRoleName}',
-                    role_arn=f'arn:aws:iam::{self._environment.AwsAccountId}:role/{group.environmentIAMRoleName}',
+                    role_arn=group.environmentIAMRoleArn,
                 )
         return group_roles
 

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -54,6 +54,7 @@ class EnvironmentService:
             validated=False,
             isOrganizationDefaultEnvironment=False,
             userRoleInEnvironment=EnvironmentPermission.Owner.value,
+            EnvironmentDefaultIAMRoleName=data.get('EnvironmentDefaultIAMRoleArn', 'unknown').split("/")[-1],
             EnvironmentDefaultIAMRoleArn=data.get('EnvironmentDefaultIAMRoleArn', 'unknown'),
             CDKRoleArn=f"arn:aws:iam::{data.get('AwsAccountId')}:role/{data['cdk_role_name']}",
             resourcePrefix=data.get('resourcePrefix'),

--- a/backend/dataall/modules/dataset_sharing/services/share_managers/lf_share_manager.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_managers/lf_share_manager.py
@@ -10,6 +10,7 @@ from dataall.core.environment.services.environment_service import EnvironmentSer
 from dataall.modules.dataset_sharing.aws.glue_client import GlueClient
 from dataall.modules.dataset_sharing.aws.lakeformation_client import LakeFormationClient
 from dataall.base.aws.quicksight import QuicksightClient
+from dataall.base.aws.iam import IAM
 from dataall.base.aws.sts import SessionHelper
 from dataall.base.db import exceptions
 from dataall.modules.datasets_base.db.dataset_models import DatasetTable, Dataset
@@ -61,7 +62,12 @@ class LFShareManager:
         -------
         List of principals
         """
-        principals = [f"arn:aws:iam::{self.target_environment.AwsAccountId}:role/{self.share.principalIAMRoleName}"]
+
+        principal_iam_role_arn = IAM.get_role_arn_by_name(
+            account_id=self.target_environment.AwsAccountId,
+            role_name=self.share.principalIAMRoleName
+        )
+        principals = [principal_iam_role_arn]
         dashboard_enabled = EnvironmentService.get_boolean_env_param(self.session, self.target_environment, "dashboardsEnabled")
 
         if dashboard_enabled:

--- a/frontend/src/modules/Environments/components/EnvironmentTeamInviteForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeamInviteForm.js
@@ -239,8 +239,8 @@ export const EnvironmentTeamInviteForm = (props) => {
                         touched.environmentIAMRoleArn &&
                         errors.environmentIAMRoleArn
                       }
-                      label="IAM Role ARN"
-                      placeholder="Bring your own IAM role (Optional - Specify Entire Role ARN)"
+                      label="(Optional) IAM Role ARN"
+                      placeholder="(Optional) Bring your own IAM role - Specify Entire Role ARN"
                       name="environmentIAMRoleArn"
                       onChange={handleChange}
                       value={values.environmentIAMRoleArn}

--- a/frontend/src/modules/Environments/components/EnvironmentTeamInviteForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeamInviteForm.js
@@ -113,7 +113,7 @@ export const EnvironmentTeamInviteForm = (props) => {
           inviteGroupOnEnvironment({
             groupUri: values.groupUri,
             environmentUri: environment.environmentUri,
-            environmentIAMRoleName: values.environmentIAMRoleName,
+            environmentIAMRoleArn: values.environmentIAMRoleArn,
             permissions
           })
         );
@@ -231,19 +231,19 @@ export const EnvironmentTeamInviteForm = (props) => {
                   <CardContent>
                     <TextField
                       error={Boolean(
-                        touched.environmentIAMRoleName &&
-                          errors.environmentIAMRoleName
+                        touched.environmentIAMRoleArn &&
+                          errors.environmentIAMRoleArn
                       )}
                       fullWidth
                       helperText={
-                        touched.environmentIAMRoleName &&
-                        errors.environmentIAMRoleName
+                        touched.environmentIAMRoleArn &&
+                        errors.environmentIAMRoleArn
                       }
-                      label="IAM Role Name"
-                      placeholder="Bring your own IAM role (Optional)"
-                      name="environmentIAMRoleName"
+                      label="IAM Role ARN"
+                      placeholder="Bring your own IAM role (Optional - Specify Entire Role ARN)"
+                      name="environmentIAMRoleArn"
                       onChange={handleChange}
-                      value={values.environmentIAMRoleName}
+                      value={values.environmentIAMRoleArn}
                       variant="outlined"
                     />
                   </CardContent>

--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -836,8 +836,8 @@ const EnvironmentCreateForm = (props) => {
                                 touched.EnvironmentDefaultIAMRoleArn &&
                                 errors.EnvironmentDefaultIAMRoleArn
                               }
-                              label="IAM Role ARN"
-                              placeholder="Bring your own IAM role (Optionally - Specify Entire Role ARN)"
+                              label="(Optional) IAM Role ARN"
+                              placeholder="(Optional) Bring your own IAM role - Specify Entire Role ARN"
                               name="EnvironmentDefaultIAMRoleArn"
                               onBlur={handleBlur}
                               onChange={handleChange}

--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -172,7 +172,7 @@ const EnvironmentCreateForm = (props) => {
           tags: values.tags,
           description: values.description,
           region: values.region,
-          EnvironmentDefaultIAMRoleName: values.EnvironmentDefaultIAMRoleName,
+          EnvironmentDefaultIAMRoleArn: values.EnvironmentDefaultIAMRoleArn,
           resourcePrefix: values.resourcePrefix,
           parameters: [
             {
@@ -478,7 +478,7 @@ const EnvironmentCreateForm = (props) => {
                 notebooksEnabled: true,
                 mlStudiosEnabled: true,
                 pipelinesEnabled: true,
-                EnvironmentDefaultIAMRoleName: '',
+                EnvironmentDefaultIAMRoleArn: '',
                 resourcePrefix: 'dataall'
               }}
               validationSchema={Yup.object().shape({
@@ -506,7 +506,7 @@ const EnvironmentCreateForm = (props) => {
                 privateSubnetIds: Yup.array().nullable(),
                 publicSubnetIds: Yup.array().nullable(),
                 vpcId: Yup.string().nullable(),
-                EnvironmentDefaultIAMRoleName: Yup.string().nullable(),
+                EnvironmentDefaultIAMRoleArn: Yup.string().nullable(),
                 resourcePrefix: Yup.string()
                   .trim()
                   .matches(
@@ -828,20 +828,20 @@ const EnvironmentCreateForm = (props) => {
                           <CardContent>
                             <TextField
                               error={Boolean(
-                                touched.EnvironmentDefaultIAMRoleName &&
-                                  errors.EnvironmentDefaultIAMRoleName
+                                touched.EnvironmentDefaultIAMRoleArn &&
+                                  errors.EnvironmentDefaultIAMRoleArn
                               )}
                               fullWidth
                               helperText={
-                                touched.EnvironmentDefaultIAMRoleName &&
-                                errors.EnvironmentDefaultIAMRoleName
+                                touched.EnvironmentDefaultIAMRoleArn &&
+                                errors.EnvironmentDefaultIAMRoleArn
                               }
-                              label="IAM Role Name"
-                              placeholder="Bring your own IAM role (Optional)"
-                              name="EnvironmentDefaultIAMRoleName"
+                              label="IAM Role ARN"
+                              placeholder="Bring your own IAM role (Optionally - Specify Entire Role ARN)"
+                              name="EnvironmentDefaultIAMRoleArn"
                               onBlur={handleBlur}
                               onChange={handleChange}
-                              value={values.EnvironmentDefaultIAMRoleName}
+                              value={values.EnvironmentDefaultIAMRoleArn}
                               variant="outlined"
                             />
                           </CardContent>

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -62,7 +62,7 @@ def environment(db):
         label: str,
         owner: str,
         samlGroupName: str,
-        environmentDefaultIAMRoleName: str,
+        environmentDefaultIAMRoleArn: str,
     ) -> Environment:
         with db.scoped_session() as session:
             env = Environment(
@@ -74,8 +74,8 @@ def environment(db):
                 tags=[],
                 description="desc",
                 SamlGroupName=samlGroupName,
-                EnvironmentDefaultIAMRoleName=environmentDefaultIAMRoleName,
-                EnvironmentDefaultIAMRoleArn=f"arn:aws:iam::{awsAccountId}:role/{environmentDefaultIAMRoleName}",
+                EnvironmentDefaultIAMRoleName=environmentDefaultIAMRoleArn.split("/")[-1],
+                EnvironmentDefaultIAMRoleArn=environmentDefaultIAMRoleArn,
                 CDKRoleArn=f"arn:aws::{awsAccountId}:role/EnvRole",
             )
             session.add(env)

--- a/tests/core/environments/test_environment.py
+++ b/tests/core/environments/test_environment.py
@@ -379,7 +379,7 @@ def test_group_invitation(db, client, env_fixture, org_fixture, group2, user, gr
             environmentUri=env_fixture.environmentUri,
             groupUri=group2.name,
             permissions=env_permissions,
-            environmentIAMRoleName='myteamrole',
+            environmentIAMRoleArn=f'arn:aws::{env_fixture.awsAccountId}:role/myteamrole',
         ),
         groups=[group.name, group2.name],
     )
@@ -650,7 +650,7 @@ def test_create_environment(db, client, org_fixture, env_fixture, user, group):
         input={
             'label': f'dev',
             'description': f'test',
-            'EnvironmentDefaultIAMRoleName': 'myOwnIamRole',
+            'EnvironmentDefaultIAMRoleArn': f'arn:aws:iam::{env_fixture.AwsAccountId}:role/myOwnIamRole',
             'organizationUri': org_fixture.organizationUri,
             'AwsAccountId': env_fixture.AwsAccountId,
             'tags': ['a', 'b', 'c'],

--- a/tests/modules/datasets/tasks/test_lf_share_manager.py
+++ b/tests/modules/datasets/tasks/test_lf_share_manager.py
@@ -211,6 +211,14 @@ def mock_glue_client(mocker):
     )
     yield mock_client
 
+@pytest.fixture(scope="function")
+def mock_iam_client(mocker):
+    mock_client = MagicMock()
+    mocker.patch(
+        "dataall.base.aws.iam.IAM",
+        mock_client
+    )
+    yield mock_client
 
 def test_init(processor_same_account, processor_cross_account):
     assert processor_same_account.dataset
@@ -231,6 +239,7 @@ def test_build_shared_db_name(
 
 
 def test_get_share_principals(
+        mocker,
         processor_same_account: ProcessLFSameAccountShare,
         processor_cross_account: ProcessLFCrossAccountShare,
         source_environment: Environment,
@@ -239,9 +248,18 @@ def test_get_share_principals(
         share_cross_account: ShareObject,
 ):
     # Given a dataset and its share, build db_share name
+    get_iam_role_arn_mock = mocker.patch(
+        "dataall.base.aws.iam.IAM.get_role_arn_by_name",
+        side_effect = lambda account_id, role_name : f"arn:aws:iam::{account_id}:role/{role_name}"
+    )
+
     # Then, it should return
     assert processor_same_account.get_share_principals() == [f"arn:aws:iam::{source_environment.AwsAccountId}:role/{share_same_account.principalIAMRoleName}"]
+    get_iam_role_arn_mock.assert_called_once()
+    get_iam_role_arn_mock.reset_mock()
+
     assert processor_cross_account.get_share_principals() == [f"arn:aws:iam::{target_environment.AwsAccountId}:role/{share_cross_account.principalIAMRoleName}"]
+    get_iam_role_arn_mock.assert_called_once()
 
 
 def test_create_shared_database(
@@ -354,7 +372,7 @@ def test_build_share_data(
         'target': {
             'accountid': source_environment.AwsAccountId,
             'region': source_environment.region,
-            'principals': [f"arn:aws:iam::{source_environment.AwsAccountId}:role/{share_same_account.principalIAMRoleName}"],
+            'principals': [None],
             'database': (dataset1.GlueDatabaseName + '_shared_' + share_same_account.shareUri)[:254],
         },
     }
@@ -372,7 +390,7 @@ def test_build_share_data(
         'target': {
             'accountid': target_environment.AwsAccountId,
             'region': target_environment.region,
-            'principals': [f"arn:aws:iam::{target_environment.AwsAccountId}:role/{share_cross_account.principalIAMRoleName}"],
+            'principals': [None],
             'database': (dataset1.GlueDatabaseName + '_shared_' + share_cross_account.shareUri)[:254],
         },
     }

--- a/tests/modules/datasets/test_dataset_resource_found.py
+++ b/tests/modules/datasets/test_dataset_resource_found.py
@@ -67,7 +67,7 @@ def test_dataset_resource_found(db, client, env_fixture, org_fixture, group2, us
             environmentUri=env_fixture.environmentUri,
             groupUri=group2.name,
             permissions=env_permissions,
-            environmentIAMRoleName='myteamrole',
+            environmentIAMRoleArn=f'arn:aws::{env_fixture.AwsAccountId}:role/myteamrole',
         ),
         groups=[group.name, group2.name],
     )


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature / Bugfix

### Detail
- When creating an environment and specifying default Env IAM Role we assume it is of the structure 
`arn:aws:iam::ACCOUNT:role/NAME_SPECIFIED`

- This does not work when there is a service path in the role such as with SSO:
`arn:aws:iam::ACCOUNT:role/sso/NAME_SPECIFIED`


### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
