### PR TITLE
re create pivot roles on upgrade to v2

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -45,7 +45,7 @@ class PivotRoleStatementSet(object):
                 iam.ManagedPolicy(
                     self.stack,
                     f'PivotRolePolicy-{index+1}',
-                    managed_policy_name=f'{self.env_resource_prefix}-pivotrole-cdk-policy-{index+1}',
+                    managed_policy_name=f'{self.env_resource_prefix}-pivot-role-cdk-policy-{index+1}',
                     statements=chunk,
                 )
             )

--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -79,7 +79,7 @@ Resources:
               - 'iam:CreatePolicyVersion'
               - 'iam:DeletePolicyVersion'
             Resource:
-               - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/service-role/AWSQuickSight*'
+               - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*'
           - Sid: QuickSight
             Effect: Allow
             Action:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Change name of pivot role policies created via CDK to handle upgrades from v1.6.2 to v2.X
  - Originally throwing an error on updates to the environment stack `res-pivotrole-cdk-policy-2 already exists in stack `arn:aws:cloudformation:eu-west-1:xxxxxxxx:stack/PIVOTROLESTACKNAME`

- Add permissions required by Custom CDK Exec Role to create policy versions for stack upgrades



### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
