### PR TITLE
DA v2: Fix Lakeformation Registered Location Check Dataset Stack

### DIFF
--- a/backend/dataall/modules/datasets/aws/lf_dataset_client.py
+++ b/backend/dataall/modules/datasets/aws/lf_dataset_client.py
@@ -27,7 +27,7 @@ class LakeFormationDatasetClient:
         try:
 
             response = self._client.describe_resource(ResourceArn=resource_arn)
-            registered_role_name = response['ResourceInfo']['RoleArn'].lstrip(f"arn:aws:iam::{self._env}:role/")
+            registered_role_name = response['ResourceInfo']['RoleArn'].lstrip(f"arn:aws:iam::{self._dataset.AwsAccountId}:role/")
             log.info(f'LF data location already registered: {response}, registered with role {registered_role_name}')
             if (
                 registered_role_name.startswith(PIVOT_ROLE_NAME_PREFIX)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- In v2 code, when creating/updating a dataset stack it would go back and forth creating and deleting the `Lakeformation::Resource` construct in Cloudformation which was registering/un-registering the resource 
  - This led to issues querying the data in Athena with a `Permissions denied on S3 Path` error
  - The root cause was when performing `check_existing_lf_registered_location()` in the dataset stack synth we were passing the wrong variable to resolve the AWS Account Id for the role arn returned from the API call `lakeformation.describe_resource()`


### Relates
- https://github.com/awslabs/aws-dataall/issues/672
- https://github.com/awslabs/aws-dataall/issues/671

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

NA

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
