### PR TITLE
DA v2: Dataset IAM Role Default DB Glue Permissions

### DIFF
--- a/backend/dataall/modules/datasets/cdk/assets/gluedatabasecustomresource/index.py
+++ b/backend/dataall/modules/datasets/cdk/assets/gluedatabasecustomresource/index.py
@@ -49,13 +49,6 @@ def on_create(event):
     except ClientError as e:
         pass
 
-    default_db_exists = False
-    try:
-        glue_client.get_database(Name="default")
-        default_db_exists = True
-    except ClientError as e:
-        pass
-
     if not exists:
         try:
             db_input = props.get('DatabaseInput').copy()
@@ -110,6 +103,15 @@ def on_create(event):
                 'PermissionsWithGrantOption': ['SELECT', 'ALTER', 'DESCRIBE'],
             }
         )
+
+        default_db_exists = False
+        try:
+            glue_client.get_database(Name="default")
+            default_db_exists = True
+        except ClientError as e:
+            log.exception(f'Failed to get default glue database due to: {e}')
+            raise Exception(f'Failed to get default glue database due to: {e}')
+
         if default_db_exists:
             Entries.append(
                 {

--- a/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
@@ -80,7 +80,7 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
                 'DataLakeAdmins': [
                     f'arn:aws:iam::{setup.environment().AwsAccountId}:role/{setup.pivot_role_name}',
                 ],
-                'Version':"data.all V2"
+                'Version': "data.all V2"
             },
         )
 

--- a/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
@@ -79,7 +79,8 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             properties={
                 'DataLakeAdmins': [
                     f'arn:aws:iam::{setup.environment().AwsAccountId}:role/{setup.pivot_role_name}',
-                ]
+                ],
+                'Version':"data.all V2"
             },
         )
 

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -298,12 +298,10 @@ class DatasetStack(Stack):
                     sid="GlueAccessDefault",
                     actions=[
                         "glue:GetDatabase",
-                        "glue:CreateDatabase",
                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[
                         f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/default",
-                        f"arn:aws:glue:*:{dataset.AwsAccountId}:catalog",
                     ]
                 ),
                 iam.PolicyStatement(

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -298,10 +298,12 @@ class DatasetStack(Stack):
                     sid="GlueAccessDefault",
                     actions=[
                         "glue:GetDatabase",
+                        "glue:CreateDatabase",
                     ],
                     effect=iam.Effect.ALLOW,
                     resources=[
                         f"arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/default",
+                        f"arn:aws:glue:*:{dataset.AwsAccountId}:catalog",
                     ]
                 ),
                 iam.PolicyStatement(

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -451,7 +451,6 @@ class DatasetStack(Stack):
                     'Imported': 'IMPORTED-' if dataset.imported else 'CREATED-'
                 },
                 'DatabaseAdministrators': dataset_admins,
-                'TriggerUpdate': True
             },
         )
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- In the case where the `default` Glue Database does not already exist
  - Glue Script is failing with "DATASET IAM ROLE  is not authorized to perform: glue:CreateDatabase on resource XXX"

- Root Casue
  - The Glue Job needs to verify that the default database exists and if it does not it needs to create the default DB
  - Adding the glue:CreateDatabase permissions on the catalog and only for the default DB resolves the issue

- POTENTIAL ISSUE:
  - In the Custom Resource of Dataset Stack we add permission for the dataset IAM Role to the default DB if it exists

  - In the scenario where default DB does not already exist and we create Dataset1 and Dataset2
  - Then Dataset1 Role creates default DB when running profiling job and the Dataset2 IAM Role never gets proper LF Permissions 
  - On testing - I tried a Dataset Stack update but it determines "No Change Set" on the Cloudformation Stack so the Custom Resource does not re-run to add the required permissions
  - A potential solution is to pass a randomly generated uuid as part of the Custom Resource properties to trigger a run of the Lambda each time? 

### Relates
- <URL or Ticket>

### Security

Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
