### PR TITLE
Add env URI to role share query

### DIFF
--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -332,6 +332,15 @@ class EnvironmentService:
                 message=f'Team: {group} has created {group_env_objects_count} resources on this environment.',
             )
 
+        group_env_consumption_roles = EnvironmentService.query_user_environment_consumption_roles(
+            session, [group], uri, {}
+        ).all()
+        if group_env_consumption_roles:
+            raise exceptions.EnvironmentResourcesFound(
+                action='Remove Team',
+                message=f'Team: {group} has consumption role(s) on this environment.',
+            )
+
         group_membership = EnvironmentService.find_environment_group(
             session, group, environment.environmentUri
         )

--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -318,11 +318,11 @@ class ShareItemSM:
 class ShareEnvironmentResource(EnvironmentResource):
     @staticmethod
     def count_resources(session, environment, group_uri) -> int:
-        return ShareObjectRepository.count_principal_shares(session, group_uri, PrincipalType.Group)
+        return ShareObjectRepository.count_principal_shares(session, group_uri, environment.environmentUri, PrincipalType.Group)
 
     @staticmethod
     def count_role_resources(session, role_uri):
-        return ShareObjectRepository.count_principal_shares(session, role_uri, PrincipalType.ConsumptionRole)
+        return ShareObjectRepository.count_role_principal_shares(session, role_uri, PrincipalType.ConsumptionRole)
 
     @staticmethod
     def delete_env(session, environment):
@@ -1149,13 +1149,27 @@ class ShareObjectRepository:
         ).all()
 
     @staticmethod
-    def count_principal_shares(session, principal_id: str, principal_type: PrincipalType):
+    def count_principal_shares(session, principal_id: str, environment_uri: str, principal_type: PrincipalType):
         return (
             session.query(ShareObject)
             .filter(
                 and_(
                     ShareObject.principalId == principal_id,
-                    ShareObject.principalType == principal_type.value
+                    ShareObject.principalType == principal_type.value,
+                    ShareObject.environmentUri == environment_uri
+                )
+            )
+            .count()
+        )
+
+    @staticmethod
+    def count_role_principal_shares(session, principal_id: str, principal_type: PrincipalType):
+        return (
+            session.query(ShareObject)
+            .filter(
+                and_(
+                    ShareObject.principalId == principal_id,
+                    ShareObject.principalType == principal_type.value,
                 )
             )
             .count()


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- If I have Group_1 that is invited to Env1 and Env2 and has existing shares for that group to Env1 - I still cannot remove the EnvGroup from Env2 (where no shares exists)
  - When we count resources to validate before removing group - for share objects in the `count_principal_resources()` we only filter by principalId and principalType but we also need to filter by environmentUri

- This PR fixes query to add environmentURI filter when counting envGroup resources before removing groups


### Relates

### Security
NA 
```
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
