### PR TITLE
Fix canary user pw creation

### DIFF
--- a/deploy/configs/cognito_urls_config.py
+++ b/deploy/configs/cognito_urls_config.py
@@ -7,6 +7,11 @@ import boto3
 from botocore.exceptions import ClientError
 
 
+def shuffle_password(pwd):
+    chars = list(pwd)
+    random.shuffle(chars)
+    return ''.join(chars)
+
 def setup_cognito(
     region,
     resource_prefix,
@@ -109,7 +114,7 @@ def setup_cognito(
                     UserAttributes=[
                         {'Name': 'email', 'Value': f'{username}@amazonaws.com'}
                     ],
-                    TemporaryPassword='da@'
+                    TemporaryPassword=shuffle_password('da@'
                     + random.SystemRandom().choice(string.ascii_uppercase)
                     + random.SystemRandom().choice(string.digits)
                     + ''.join(
@@ -117,7 +122,7 @@ def setup_cognito(
                             string.ascii_uppercase + string.digits
                         )
                         for _ in range(11)
-                    ),
+                    )),
                     MessageAction='SUPPRESS',
                 )
                 print(f'User Created Successfully...: {response}')

--- a/deploy/configs/cognito_urls_config.py
+++ b/deploy/configs/cognito_urls_config.py
@@ -114,15 +114,17 @@ def setup_cognito(
                     UserAttributes=[
                         {'Name': 'email', 'Value': f'{username}@amazonaws.com'}
                     ],
-                    TemporaryPassword=shuffle_password('da@'
-                    + random.SystemRandom().choice(string.ascii_uppercase)
-                    + random.SystemRandom().choice(string.digits)
-                    + ''.join(
-                        random.SystemRandom().choice(
-                            string.ascii_uppercase + string.digits
+                    TemporaryPassword='da@'
+                    + shuffle_password(
+                        random.SystemRandom().choice(string.ascii_uppercase)
+                        + random.SystemRandom().choice(string.digits)
+                        + ''.join(
+                            random.SystemRandom().choice(
+                                string.ascii_uppercase + string.digits
+                            )
+                            for _ in range(11)
                         )
-                        for _ in range(11)
-                    )),
+                    ),
                     MessageAction='SUPPRESS',
                 )
                 print(f'User Created Successfully...: {response}')

--- a/deploy/configs/cognito_urls_config.py
+++ b/deploy/configs/cognito_urls_config.py
@@ -110,11 +110,13 @@ def setup_cognito(
                         {'Name': 'email', 'Value': f'{username}@amazonaws.com'}
                     ],
                     TemporaryPassword='da@'
+                    + random.SystemRandom().choice(string.ascii_uppercase)
+                    + random.SystemRandom().choice(string.digits)
                     + ''.join(
                         random.SystemRandom().choice(
                             string.ascii_uppercase + string.digits
                         )
-                        for _ in range(13)
+                        for _ in range(11)
                     ),
                     MessageAction='SUPPRESS',
                 )


### PR DESCRIPTION
In rare cases the current way of generating a Canary user password in Cognito can result in a string containing no numerical values, hence following error is thrown during deployment ( requires **enable_cw_canaries** config parameter set to True in cdk.json):
`botocore.errorfactory.InvalidPasswordException: An error occurred (InvalidPasswordException) when calling the AdminCreateUser operation: Password did not conform with password policy: Password must have numeric characters`

Changing the password creation to contain at least 1 uppercase and 1 numerical character.


### Feature or Bugfix
- Bugfix


### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

n/a

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
