### PR TITLE
fix: pin version of npm@9 for VPC facing architecture

### DIFF
--- a/frontend/docker/prod/Dockerfile
+++ b/frontend/docker/prod/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.s
 RUN . ~/.nvm/nvm.sh && nvm install node
 RUN echo '. ~/.nvm/nvm.sh' >>  ~/.bashrc
 
-RUN . ~/.nvm/nvm.sh && npm install -g npm yarn
+RUN . ~/.nvm/nvm.sh && npm install -g npm@9 yarn
 
 WORKDIR /app
 COPY ./frontend/package.json ./frontend/yarn.lock ./


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In the [latest release of npm](https://github.com/npm/cli/releases/tag/v10.0.0) 4 days ago, node 16 is no longer supported. Which leads to failure of the frontend image building when using VPC-facing architecture. In this PR the version of npm is fixed to the previous version. It solves the issue and it is a quick fix, but we need to upgrade to node 18. There are GitHub issues ( #655 #38 ...) dedicated to the node version upgrade, which should be done in a separate PR.

I tried upgrading the version of node directly in the docker image, but it lead to deployment errors (different ones)

### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?

N/A for all

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
