### PR TITLE
Add conditions on catalog indexer tasks

### DIFF
--- a/deploy/stacks/run_if.py
+++ b/deploy/stacks/run_if.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .deploy_config import deploy_config
 
 
@@ -17,16 +19,20 @@ def _process_func(func):
     return fn, staticmethod if static_func else no_decorated
 
 
-def run_if(active_property: str):
+def run_if(active_properties: List[str]):
     """
     Decorator that check whether a method should be active or not.
-    The active_property must be a boolean value in the config file
+    The active_properties is a list of properties that must be a boolean value in the config file
+    IF at least one of the active_properties is set to True then the decorated function will be called
     """
     def decorator(f):
         fn, fn_decorator = _process_func(f)
 
         def decorated(*args, **kwargs):
-            is_active = deploy_config.get_property(active_property, False)
+            is_active = False
+            for active_property in active_properties:
+                is_active |= deploy_config.get_property(active_property, False)
+
             if not is_active:
                 return None
 


### PR DESCRIPTION
The catalog indexer fails if all modules are disabled. Here is a small improvement to fix it 

Checked against:
1)  all disabled
2)  all enabled
3) datasets enabled only
4) dashboards enabled only

### Security
`N/A` . it's a small improvement for disable/enabling tasks based on modules. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
