### PR TITLE
DA v2: Fix Handling of Delete Dataset Resources

### DIFF
--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -358,12 +358,12 @@ class DatasetService:
                 )
 
             tables = [t.tableUri for t in DatasetRepository.get_dataset_tables(session, uri)]
-            for uri in tables:
-                DatasetIndexer.delete_doc(doc_id=uri)
+            for tableUri in tables:
+                DatasetIndexer.delete_doc(doc_id=tableUri)
 
             folders = [f.locationUri for f in DatasetLocationRepository.get_dataset_folders(session, uri)]
-            for uri in folders:
-                DatasetIndexer.delete_doc(doc_id=uri)
+            for folderUri in folders:
+                DatasetIndexer.delete_doc(doc_id=folderUri)
 
             DatasetIndexer.delete_doc(doc_id=uri)
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix in V2.0 data.all code


### Detail
- When deleting a dataset - we were redefining the `uri` variable used to track the datasetUri. This caused errors with:
  - Folders to not be removed from opensearch catalog
  - Folders to not be removed from opensearch catalog
  - Deletion of outstanding shares with no shared items on the dataset (if they exist)
  - Deletion of Glossary Term Links on the Dataset or Dataset Tables (if they exist)
  - Deletion of Resource Policies on the Dataset
  - Deletion of the Dataset CloudFormation Stack (if enabled)

- The above handling of deletion should be resolved as of this PR


### Relates
- #733 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

NA
```
- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
