### PR TITLE
Add Additional Error Messages for KMS Key lookup on imported dataset

### DIFF
--- a/backend/dataall/modules/dataset_sharing/aws/kms_client.py
+++ b/backend/dataall/modules/dataset_sharing/aws/kms_client.py
@@ -52,3 +52,20 @@ class KmsClient:
             return None
         else:
             return response['KeyMetadata']['KeyId']
+
+    def check_key_exists(self, key_alias: str):
+        try:
+            key_exist = False
+            paginator = self._client.get_paginator('list_aliases')
+            for page in paginator.paginate():
+                key_aliases = [alias["AliasName"] for alias in page['Aliases']]
+                if key_alias in key_aliases:
+                    key_exist = True
+                    break
+        except Exception as e:
+            log.error(
+                f'Failed to list kms key aliases in account {self._account_id}: {e}'
+            )
+            return None
+        else:
+            return key_exist

--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -54,13 +54,22 @@ class DatasetService:
     def check_imported_resources(environment, data):
         kms_alias = data.get('KmsKeyAlias')
         if kms_alias not in [None, "Undefined", "", "SSE-S3"]:
+            key_exists = KmsClient(environment.AwsAccountId, environment.region).check_key_exists(
+                key_alias=f"alias/{kms_alias}"
+            )
+            if not key_exists:
+                raise exceptions.AWSResourceNotFound(
+                    action=IMPORT_DATASET,
+                    message=f'KMS key with alias={kms_alias} cannot be found - Please check if KMS Key Alias exists in account {environment.AwsAccountId}',
+                )
+
             key_id = KmsClient(environment.AwsAccountId, environment.region).get_key_id(
                 key_alias=f"alias/{kms_alias}"
             )
             if not key_id:
                 raise exceptions.AWSResourceNotFound(
                     action=IMPORT_DATASET,
-                    message=f'KMS key with alias={kms_alias} cannot be found',
+                    message=f'Data.all Environment Pivot Role does not have kms:DescribeKey Permission to KMS key with alias={kms_alias}',
                 )
         return True
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature Enhancement

### Detail
- Adding additional error messages for KMS Key lookup when importing a new dataset
  - 1 Error message to determine if the KMS Key Alias Exists
  - 1 Error message to determine if the PivotRole has permissions to describe the KMS Key 

### Relates
- #712 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
