### PR TITLE
Build Compliant Names for Opensearch Resources

### DIFF
--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -13,6 +13,7 @@ class NamingConventionPattern(Enum):
     GLUE_ETL = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 52}
     NOTEBOOK = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}
     DEFAULT = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}
+    OPENSEARCH = {'regex': '[^a-z0-9-]', 'separator': '-', 'max_length': 27}
 
 
 class NamingConventionService:
@@ -47,6 +48,9 @@ class NamingConventionService:
         elif self.service == NamingConventionPattern.NOTEBOOK:
             regex = self.service.NOTEBOOK.value['regex']
             return self.build_notebook_compliant_name(regex)
+        elif self.service == NamingConventionPattern.OPENSEARCH:
+            regex = self.service.OPENSEARCH.value['regex']
+            return self.build_opensearch_compliant_name(regex)
         else:
             regex = self.service.DEFAULT.value['regex']
             return self.build_default_compliant_name(regex)
@@ -65,6 +69,9 @@ class NamingConventionService:
 
     def build_notebook_compliant_name(self, regex) -> str:
         return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.NOTEBOOK.value['max_length'] - len(self.resource_prefix +self.target_uri))] + '-' + self.target_uri, regex_pattern=fr'{regex}', separator=self.service.NOTEBOOK.value['separator'], lowercase=True)}"
+
+    def build_opensearch_compliant_name(self, regex) -> str:
+        return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.OPENSEARCH.value['max_length'] - len(self.resource_prefix))], regex_pattern=fr'{regex}', separator=self.service.OPENSEARCH.value['separator'], lowercase=True)}"
 
     def build_default_compliant_name(self, regex) -> str:
         return f"{slugify(self.resource_prefix + '-' + self.target_label[:(self.service.DEFAULT.value['max_length'] - len(self.resource_prefix +self.target_uri))] + '-' + self.target_uri, regex_pattern=fr'{regex}', separator=self.service.DEFAULT.value['separator'], lowercase=True)}"

--- a/deploy/stacks/opensearch.py
+++ b/deploy/stacks/opensearch.py
@@ -9,6 +9,11 @@ from aws_cdk import (
     RemovalPolicy,
 )
 
+from backend.dataall.base.utils.naming_convention import (
+    NamingConventionService,
+    NamingConventionPattern,
+)
+
 from .pyNestedStack import pyNestedClass
 
 
@@ -59,7 +64,7 @@ class OpenSearchStack(pyNestedClass):
         self.domain = opensearch.Domain(
             self,
             f'OpenSearchDomain{envname}',
-            domain_name=f'{resource_prefix}-{envname}-domain',
+            domain_name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='domain'),
             version=opensearch.EngineVersion.OPENSEARCH_1_1,
             capacity=opensearch.CapacityConfig(
                 data_nodes=2, master_nodes=3 if prod_sizing else 0
@@ -143,3 +148,13 @@ class OpenSearchStack(pyNestedClass):
     @property
     def domain_endpoint(self) -> str:
         return self.domain.domain_endpoint
+
+    @staticmethod
+    def _set_os_compliant_name(prefix: str, name: str) -> str:
+        compliant_name = NamingConventionService(
+            target_uri=None,
+            target_label=name,
+            pattern=NamingConventionPattern.OPENSEARCH,
+            resource_prefix=prefix,
+        ).build_compliant_name()
+        return compliant_name

--- a/deploy/stacks/opensearch_serverless.py
+++ b/deploy/stacks/opensearch_serverless.py
@@ -10,6 +10,11 @@ from aws_cdk import (
     RemovalPolicy,
 )
 
+from backend.dataall.base.utils.naming_convention import (
+    NamingConventionService,
+    NamingConventionPattern,
+)
+
 from .pyNestedStack import pyNestedClass
 
 
@@ -32,7 +37,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         self.cfn_collection = opensearchserverless.CfnCollection(
             self,
             f'OpenSearchCollection{envname}',
-            name=f'{resource_prefix}-{envname}-collection',
+            name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='collection'),
             type="SEARCH",
         )
 
@@ -49,7 +54,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_encryption_policy = opensearchserverless.CfnSecurityPolicy(
             self,
             f'OpenSearchCollectionEncryptionPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-encryption-policy',
+            name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='encryption-policy'),
             type='encryption',
             policy=self._get_encryption_policy(
                 collection_name=self.cfn_collection.name,
@@ -60,7 +65,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_vpc_endpoint = opensearchserverless.CfnVpcEndpoint(
             self,
             f'OpenSearchCollectionVpcEndpoint{envname}',
-            name=f'{resource_prefix}-{envname}-vpc-endpoint',
+            name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='vpc-endpoint'),
             vpc_id=vpc.vpc_id,
             security_group_ids=[vpc_endpoints_sg.security_group_id],
             subnet_ids=[subnet.subnet_id for subnet in vpc.private_subnets],
@@ -69,7 +74,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         cfn_network_policy = opensearchserverless.CfnSecurityPolicy(
             self,
             f'OpenSearchCollectionNetworkPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-network-policy',
+            name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='network-policy'),
             type='network',
             policy=self._get_network_policy(
                 collection_name=self.cfn_collection.name,
@@ -87,7 +92,7 @@ class OpenSearchServerlessStack(pyNestedClass):
         opensearchserverless.CfnAccessPolicy(
             self,
             f'OpenSearchCollectionAccessPolicy{envname}',
-            name=f'{resource_prefix}-{envname}-access-policy',
+            name=self._set_os_compliant_name(prefix=f'{resource_prefix}-{envname}', name='access-policy'),
             type='data',
             policy=self._get_access_policy(
                 collection_name=self.cfn_collection.name,
@@ -196,3 +201,13 @@ class OpenSearchServerlessStack(pyNestedClass):
             }
         ]
         return json.dumps(policy)
+
+    @staticmethod
+    def _set_os_compliant_name(prefix: str, name: str) -> str:
+        compliant_name = NamingConventionService(
+            target_uri=None,
+            target_label=name,
+            pattern=NamingConventionPattern.OPENSEARCH,
+            resource_prefix=prefix,
+        ).build_compliant_name()
+        return compliant_name


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement / Bugfix

### Detail
- Ensure the names passed for OpenSearch Domain and OpenSearch Serverless Collection, Access Policy, Security Policy, and VPC Endpoint all follow naming conventions required by the service, meaning

    - The name must start with a lowercase letter
    - Must be between 3 and 28 characters
    - Valid characters are a-z (lowercase only), 0-9, and - (hyphen).

### Relates
- #540 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
