### PR TITLE
Fix: Add global flag to replace and avoid scanning issues on incomplete-sanitization

### DIFF
--- a/frontend/src/services/hooks/useGroups.js
+++ b/frontend/src/services/hooks/useGroups.js
@@ -14,13 +14,13 @@ export const useGroups = () => {
     } else {
       const session = await Auth.currentSession();
       const cognitoGroups = session.getIdToken().payload['cognito:groups'];
-      const samlGroups = session.getIdToken().payload['custom:saml.groups'] // nosemgrep
-        ? session // nosemgrep
-            .getIdToken() // nosemgrep
-            .payload['custom:saml.groups'].replace('[', '') // nosemgrep
-            .replace(']', '') // nosemgrep
-            .replace(/, /g, ',') // nosemgrep
-            .split(',') // nosemgrep
+      const samlGroups = session.getIdToken().payload['custom:saml.groups']
+        ? session
+            .getIdToken()
+            .payload['custom:saml.groups'].replace('[/g', '')
+            .replace(']/g', '')
+            .replace(/, /g, ',')
+            .split(',')
         : [];
       setGroups([].concat(cognitoGroups).concat(samlGroups).filter(Boolean));
     }

--- a/frontend/src/services/hooks/useGroups.js
+++ b/frontend/src/services/hooks/useGroups.js
@@ -17,8 +17,8 @@ export const useGroups = () => {
       const samlGroups = session.getIdToken().payload['custom:saml.groups']
         ? session
             .getIdToken()
-            .payload['custom:saml.groups'].replace('[/g', '')
-            .replace(']/g', '')
+            .payload['custom:saml.groups'].replaceAll('[', '')
+            .replaceAll(']', '')
             .replace(/, /g, ',')
             .split(',')
         : [];


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
Use `replaceAll` instead of `replace` command in parsing the custom SAML groups. This way all appearances of `[` and `]` are replaced.
I did not want to modify the command more as it is touching the integration with other IdPs. 

### Relates
- #739 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized? ---> ⭐ exactly this is what this PR is trying to improve. 
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
