### PR TITLE
Fix Check other share exists before clean up

### DIFF
--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -775,13 +775,18 @@ class ShareObjectRepository:
 
     @staticmethod
     def other_approved_share_object_exists(session, environment_uri, dataset_uri):
+        share_item_shared_states = ShareItemSM.get_share_item_shared_states()
         return (
             session.query(ShareObject)
+            .join(
+                ShareObjectItem,
+                ShareObject.shareUri == ShareObjectItem.shareUri,
+            )
             .filter(
                 and_(
-                    Environment.environmentUri == environment_uri,
-                    ShareObject.status == ShareObjectStatus.Approved.value,
+                    ShareObject.environmentUri == environment_uri,
                     ShareObject.datasetUri == dataset_uri,
+                    ShareObjectItem.status.in_(share_item_shared_states)
                 )
             )
             .all()


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Fix method to detect if other share objects exist on the environment before cleaning up environment-level shared resources (i.e. RAM invitation and PivotRole permissions)
  - Originally, if EnvA had 2 shares approved and succeeded on DatasetB and EnvA rejects 1 of the pre-existing shares, the method `other_approved_share_object_exists` was returning `False`and deleting necessary permissions for the other existing Share 
  - Also disables the other existing shares ability to Revoke since pivotRole no longer has permissions

### Security
NA
```
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
