### PR TITLE
Fix path of patch_ssm() for pytest fixutre

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ def permissions(db):
 @pytest.fixture(scope='function', autouse=True)
 def patch_ssm(mocker):
     mocker.patch(
-        'dataall.utils.parameter.Parameter.get_parameter', return_value='param'
+        'dataall.base.utils.parameter.Parameter.get_parameter', return_value='param'
     )
 
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Fix path to parameter utils for local pytest
  - Originally local `make coverage` erroring out of `patch_ssm()` due to non-existing attribute `dataall.base.utils.parameter.Parameter.get_parameter`

### Relates
- NA

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

NA
```
- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
