### PR TITLE
Fix codebuild policy length

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -304,7 +304,7 @@ class PipelineStack(Stack):
                         f'arn:aws:s3:::{self.resource_prefix}*',
                         f'arn:aws:s3:::{self.resource_prefix}*/*',
                         f'arn:aws:codebuild:{self.region}:{self.account}:project/*{self.resource_prefix}*',
-                        f'arn:aws:codebuild:{self.region}:{self.account}:report-group/{self.resource_prefix}*'
+                        f'arn:aws:codebuild:{self.region}:{self.account}:report-group/{self.resource_prefix}*',
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{self.resource_prefix}*',
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                         f'arn:aws:kms:{self.region}:{self.account}:key/*',

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -143,7 +143,7 @@ class PipelineStack(Stack):
                     'cdk synth',
                     'echo ${CODEBUILD_SOURCE_VERSION}'
                 ],
-                role=self.baseline_codebuild_role,
+                role=self.baseline_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
             cross_account_keys=True,
@@ -225,10 +225,10 @@ class PipelineStack(Stack):
             assumed_by=iam.ServicePrincipal('codebuild.amazonaws.com'),
         )
 
-        self.baseline_codebuild_policy = iam.Policy(
+        self.baseline_codebuild_policy = iam.ManagedPolicy(
             self,
-            'BaselineCodeBuildPolicy',
-            policy_name=f'{self.resource_prefix}-{self.git_branch}-baseline-codebuild-policy',
+            'BaselineCodeBuildManagedPolicy',
+            managed_policy_name=f'{self.resource_prefix}-{self.git_branch}-baseline-cb-policy',
             roles=[self.baseline_codebuild_role, self.expanded_codebuild_role],
             statements= [
                 iam.PolicyStatement(
@@ -252,7 +252,14 @@ class PipelineStack(Stack):
                     actions=[
                         'ecr:GetAuthorizationToken',
                         'ec2:DescribePrefixLists',
-                        'ec2:DescribeManagedPrefixLists'
+                        'ec2:DescribeManagedPrefixLists',
+                        'ec2:CreateNetworkInterface',
+                        'ec2:DescribeNetworkInterfaces',
+                        'ec2:DeleteNetworkInterface',
+                        'ec2:DescribeSubnets',
+                        'ec2:DescribeSecurityGroups',
+                        'ec2:DescribeDhcpOptions',
+                        'ec2:DescribeVpcs',
                     ],
                     resources=['*'],
                 ),
@@ -272,6 +279,8 @@ class PipelineStack(Stack):
                         'kms:Decrypt',
                         'kms:Encrypt',
                         'kms:GenerateDataKey',
+                        'kms:ReEncrypt*',
+                        'kms:DescribeKey',
                         'secretsmanager:GetSecretValue',
                         'secretsmanager:DescribeSecret',
                         'ssm:GetParametersByPath',
@@ -285,12 +294,17 @@ class PipelineStack(Stack):
                         'codebuild:UpdateReport',
                         'codebuild:BatchPutTestCases',
                         'codebuild:BatchPutCodeCoverages',
-                        'ec2:GetManagedPrefixListEntries'
+                        'ec2:GetManagedPrefixListEntries',
+                        'ec2:CreateNetworkInterfacePermission',
+                        'logs:CreateLogGroup',
+                        'logs:CreateLogStream',
+                        'logs:PutLogEvents',
                     ],
                     resources=[
                         f'arn:aws:s3:::{self.resource_prefix}*',
                         f'arn:aws:s3:::{self.resource_prefix}*/*',
                         f'arn:aws:codebuild:{self.region}:{self.account}:project/*{self.resource_prefix}*',
+                        f'arn:aws:codebuild:{self.region}:{self.account}:report-group/{self.resource_prefix}*'
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*{self.resource_prefix}*',
                         f'arn:aws:secretsmanager:{self.region}:{self.account}:secret:*dataall*',
                         f'arn:aws:kms:{self.region}:{self.account}:key/*',
@@ -300,14 +314,16 @@ class PipelineStack(Stack):
                         f'arn:aws:codeartifact:{self.region}:{self.account}:repository/{self.resource_prefix}*',
                         f'arn:aws:codeartifact:{self.region}:{self.account}:domain/{self.resource_prefix}*',
                         f'arn:aws:ec2:{self.region}:{self.account}:prefix-list/*',
+                        f'arn:aws:ec2:{self.region}:{self.account}:network-interface/*',
+                        f'arn:aws:logs:{self.region}:{self.account}:log-group:/aws/codebuild/{self.resource_prefix}*',
                     ],
                 ),
             ],
         )
-        self.expanded_codebuild_policy = iam.Policy(
+        self.expanded_codebuild_policy = iam.ManagedPolicy(
             self,
-            'ExpandedCodeBuildPolicy',
-            policy_name=f'{self.resource_prefix}-{self.git_branch}-expanded-codebuild-policy',
+            'ExpandedCodeBuildManagedPolicy',
+            managed_policy_name=f'{self.resource_prefix}-{self.git_branch}-expanded-cb-policy',
             roles=[self.expanded_codebuild_role],
             statements= [
                 iam.PolicyStatement(
@@ -334,10 +350,10 @@ class PipelineStack(Stack):
             )
             self.expanded_codebuild_policy.attach_to_role(self.git_project_role)
             self.baseline_codebuild_policy.attach_to_role(self.git_project_role)
-            self.git_release_policy = iam.Policy(
+            self.git_release_policy = iam.ManagedPolicy(
                 self,
-                'GitReleasePolicy',
-                policy_name=f'{self.resource_prefix}-{self.git_branch}-git-release-policy',
+                'GitReleaseManagedPolicy',
+                managed_policy_name=f'{self.resource_prefix}-{self.git_branch}-gitrelease-policy',
                 roles=[self.git_project_role],
                 statements= [
                     iam.PolicyStatement(
@@ -416,7 +432,7 @@ class PipelineStack(Stack):
                         'make drop-tables',
                         'make upgrade-db',
                     ],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                     security_groups=[self.codebuild_sg],
                 ),
@@ -432,7 +448,7 @@ class PipelineStack(Stack):
                         '. env/bin/activate',
                         'make check-security',
                     ],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                 ),
                 pipelines.CodeBuildStep(
@@ -452,7 +468,7 @@ class PipelineStack(Stack):
                         'npm run copy-config',
                         'npm run lint -- --quiet',
                     ],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                 ),
             )
@@ -487,7 +503,7 @@ class PipelineStack(Stack):
                         )
                     ),
                     commands=[],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                     security_groups=[self.codebuild_sg],
                 ),
@@ -503,7 +519,7 @@ class PipelineStack(Stack):
                         'cd source_build/ && zip -r ../source_build/source_build.zip *',
                         f'aws s3api put-object --bucket {self.pipeline_bucket.bucket_name}  --key source_build.zip --body source_build.zip',
                     ],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                     security_groups=[self.codebuild_sg],
                 ),
@@ -523,7 +539,7 @@ class PipelineStack(Stack):
                         'cd source_build/ && zip -r ../source_build/source_build.zip *',
                         f'aws s3api put-object --bucket {self.pipeline_bucket.bucket_name}  --key source_build.zip --body source_build.zip',
                     ],
-                    role=self.baseline_codebuild_role,
+                    role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                     security_groups=[self.codebuild_sg],
                 ),
@@ -564,7 +580,7 @@ class PipelineStack(Stack):
                 commands=[
                     f"make deploy-image type=lambda image-tag=$IMAGE_TAG account={target_env['account']} region={target_env['region']} repo={repository_name}",
                 ],
-                role=self.baseline_codebuild_role,
+                role=self.baseline_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
             pipelines.CodeBuildStep(
@@ -582,7 +598,7 @@ class PipelineStack(Stack):
                 commands=[
                     f"make deploy-image type=ecs image-tag=$IMAGE_TAG account={target_env['account']} region={target_env['region']} repo={repository_name}",
                 ],
-                role=self.baseline_codebuild_role,
+                role=self.baseline_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
         )
@@ -648,7 +664,7 @@ class PipelineStack(Stack):
                     'if [ "$(jq -r .builds[0].buildStatus codebuild-output.json)" = "FAILED" ]; then echo "Failed";  cat codebuild-output.json; exit -1; fi',
                     'cat codebuild-output.json ',
                 ],
-                role=self.expanded_codebuild_role,
+                role=self.expanded_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
         )
@@ -680,7 +696,7 @@ class PipelineStack(Stack):
                     f'cluster_arn="arn:aws:ecs:{target_env["region"]}:{target_env["account"]}:cluster/$cluster_name"',
                     f'aws --profile buildprofile ecs run-task --task-definition $task_definition --cluster "$cluster_arn" --launch-type "FARGATE" --network-configuration "$network_config" --launch-type FARGATE --propagate-tags TASK_DEFINITION',
                 ],
-                role=self.expanded_codebuild_role,
+                role=self.expanded_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
         )
@@ -735,7 +751,7 @@ class PipelineStack(Stack):
                     'aws s3 sync build/ s3://$bucket --profile buildprofile',
                     "aws cloudfront create-invalidation --distribution-id $distributionId --paths '/*' --profile buildprofile",
                 ],
-                role=self.expanded_codebuild_role,
+                role=self.expanded_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
             self.cognito_config_action(target_env),
@@ -770,7 +786,7 @@ class PipelineStack(Stack):
                     'aws s3 sync site/ s3://$bucket',
                     "aws cloudfront create-invalidation --distribution-id $distributionId --paths '/*'",
                 ],
-                role=self.expanded_codebuild_role,
+                role=self.expanded_codebuild_role.without_policy_updates(),
                 vpc=self.vpc,
             ),
         )
@@ -797,7 +813,7 @@ class PipelineStack(Stack):
                 'pip install boto3==1.20.46',
                 'python deploy/configs/rum_config.py',
             ],
-            role=self.expanded_codebuild_role,
+            role=self.expanded_codebuild_role.without_policy_updates(),
             vpc=self.vpc,
         )
 
@@ -824,7 +840,7 @@ class PipelineStack(Stack):
                 'pip install boto3==1.20.46',
                 'python deploy/configs/cognito_urls_config.py',
             ],
-            role=self.expanded_codebuild_role,
+            role=self.expanded_codebuild_role.without_policy_updates(),
             vpc=self.vpc,
         )
 
@@ -882,7 +898,7 @@ class PipelineStack(Stack):
                         'docker tag $IMAGE_TAG:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG',
                         'docker push $REPOSITORY_URI:$IMAGE_TAG',
                     ],
-                    role=self.expanded_codebuild_role,
+                    role=self.expanded_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                 ),
                 pipelines.CodeBuildStep(
@@ -906,7 +922,7 @@ class PipelineStack(Stack):
                         'docker tag $IMAGE_TAG:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG',
                         'docker push $REPOSITORY_URI:$IMAGE_TAG',
                     ],
-                    role=self.expanded_codebuild_role,
+                    role=self.expanded_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                 ),
             ],
@@ -957,7 +973,7 @@ class PipelineStack(Stack):
                         },
                     )
                 ),
-                role=self.git_project_role,
+                role=self.git_project_role.without_policy_updates(),
                 vpc=self.vpc,
                 security_groups=[self.codebuild_sg],
                 commands=[],


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- There is a limit of 10,240 characters aggregate across all inline policies that are able to be attached to an IAM Role
  - By default, codebuild adds its own IAM permission statements as inline policies to the attached execution role to the Build Project unless otherwise specified
  - On certain deployment configurations we will exceed the 10,240 character limit because we use the same IAM role for many CodeBuild Steps and each CodeBuild Project will add addition IAM inline statements

In this PR, to resolve we:
- Add the missing IAM permissions that CodeBuild would add by default to the IAM Role
- Switch the IAM policy we add to the IAM Role from inline to customer managed policy (as a best practice)
- Pass a copy of the IAM Role with `.without_policy_updates()` to each `CodeBuildStep` to prevent CodeBuild from adding additional permissions statements and exceeding the character limit


### Relates
- #773 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
