### PR TITLE
Git branch truncate to 100 chars

### DIFF
--- a/deploy/app.py
+++ b/deploy/app.py
@@ -30,7 +30,7 @@ else:
     git_branch = os.environ.get("DATAALL_REPO_BRANCH")
 
 
-git_branch = re.sub('[^a-zA-Z0-9-_]', '', git_branch)[:12] if git_branch != "" else "main"
+git_branch = re.sub('[^a-zA-Z0-9-_]', '', git_branch)[:99] if git_branch != "" else "main"
 
 # Configuration of the cdk.json SSM or in Repository
 if os.getenv("GITHUB_ACTIONS"):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Modified the truncate of the gitbranch in app.py to 100 characters instead of 12 characters to follow documentation:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html#cfn-codepipeline-pipeline-name

### Relates
- #767 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
