### PR TITLE
Feat: limit pivot role S3 permissions

### DIFF
--- a/backend/dataall/base/utils/iam_policy_utils.py
+++ b/backend/dataall/base/utils/iam_policy_utils.py
@@ -1,0 +1,58 @@
+from typing import List
+
+POLICY_LIMIT = 6144
+
+def split_policy_statements_in_chunks(statements: List):
+    """
+    Splits a list of IAM policy statements into a list of lists (chunks)
+    For each chunk, the size should remain below the POLICY LIMIT
+    """
+    chunks = []
+    index = 0
+    print("Initial loop")
+    # Index = number of statements
+    print(f"statements = {len(statements)}")
+    while index < len(statements):
+        chunk = []
+        chunk_size = len(statements[index].to_string())
+        print(f"-----------------")
+        print(f"chunk = {chunk}")
+        print(f"chunk_size = {chunk_size}")
+        while chunk_size + len(statements[index].to_string()) < POLICY_LIMIT:
+            for statement in statements[index:]:
+                print(statement.to_string())
+                chunk.append(statement)
+                print(f"statement size= {len(statement.to_string())}")
+                chunk_size += len(statement.to_string())
+                index += 1
+                print(f"################")
+                #print(f"chunk = {chunk}")
+                print(f"chunk_size = {chunk_size}")
+                print(f"index={index}")
+        chunks.append(chunk)
+        print(chunks)
+
+    return chunks
+
+
+def split_policy_with_resources_in_statements(statement_without_resources, resources):
+    """
+    Ensures that the size of an IAM statement is below the POLICY LIMIT
+    If it exceeds the POLICY LIMIT, it breaks the statement in multiple statements
+    """
+    resulting_statement = statement_without_resources.replace("RESOURCES", resources)
+    if len(str(resulting_statement)) < POLICY_LIMIT:
+        return [resulting_statement]
+    else:
+        resulting_statements = []
+        splits = len(str(resources))/(POLICY_LIMIT-len(str(statement_without_resources)))
+        print(splits)
+        split_size = len(str(resulting_statement))/splits
+        for index in range(splits):
+            print(index)
+            print(index+split_size)
+            resulting_statement = statement_without_resources.replace("RESOURCES", resources[index,index+split_size])
+            resulting_statements.append((resulting_statement))
+    return resulting_statements
+
+

--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -148,6 +148,7 @@ class EnvironmentSetup(Stack):
                 'accountId': self.dataall_central_account,
                 'externalId': self.external_id,
                 'resourcePrefix': self._environment.resourcePrefix,
+                'environmentUri': self._environment.environmentUri
             }
             pivot_role_stack = PivotRole(self, 'PivotRoleStack', config)
             self.pivot_role = iam.Role.from_role_arn(

--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -1,11 +1,9 @@
 import logging
 import os
-import pathlib
 from abc import abstractmethod
 from typing import List, Type
 
 from aws_cdk import (
-    custom_resources as cr,
     aws_s3 as s3,
     aws_iam as iam,
     aws_sns as sns,

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -13,13 +13,15 @@ class PivotRoleStatementSet(object):
             env_resource_prefix,
             role_name,
             account,
-            region
+            region,
+            environmentUri
     ):
         self.stack = stack
         self.env_resource_prefix = env_resource_prefix
         self.role_name = role_name
         self.account = account
         self.region = region
+        self.environmentUri = environmentUri
 
     def generate_policies(self) -> List[iam.ManagedPolicy]:
         """
@@ -66,6 +68,7 @@ class PivotRole(NestedStack):
         super().__init__(scope, construct_id, **kwargs)
         self.env_resource_prefix = config['resourcePrefix']
         self.role_name = config['roleName']
+        self.environmentUri = config['environmentUri']
 
         from dataall.core.environment.cdk import pivot_role_core_policies
 
@@ -94,7 +97,8 @@ class PivotRole(NestedStack):
             env_resource_prefix=self.env_resource_prefix,
             role_name=self.role_name,
             account=self.account,
-            region=self.region
+            region=self.region,
+            environmentUri=self.environmentUri
         ).generate_policies()
 
         logger.info(f'Managed Policies: {managed_policies}')

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -41,10 +41,6 @@ class PivotRoleStatementSet(object):
 
         statements_chunks = split_policy_statements_in_chunks(statements)
 
-        # statements_chunks: list = [
-        #     statements[i: i + 10] for i in range(0, len(statements), 10)
-        # ]
-
         for index, chunk in enumerate(statements_chunks):
             policies.append(
                 iam.ManagedPolicy(

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -2,6 +2,7 @@ import logging
 from typing import List
 from constructs import Construct
 from aws_cdk import Duration, aws_iam as iam, NestedStack
+from dataall.base.utils.iam_policy_utils import split_policy_statements_in_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +39,11 @@ class PivotRoleStatementSet(object):
             logger.info(f'Adding {service.__name__} statements to policy')
             logger.info(f'statements: {str(service.get_statements(self))}')
 
-        statements_chunks: list = [
-            statements[i: i + 10] for i in range(0, len(statements), 10)
-        ]
+        statements_chunks = split_policy_statements_in_chunks(statements)
+
+        # statements_chunks: list = [
+        #     statements[i: i + 10] for i in range(0, len(statements), 10)
+        # ]
 
         for index, chunk in enumerate(statements_chunks):
             policies.append(

--- a/backend/dataall/modules/datasets/aws/s3_dataset_client.py
+++ b/backend/dataall/modules/datasets/aws/s3_dataset_client.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 class S3DatasetClient:
 
     def __init__(self, dataset: Dataset):
-        self._client = SessionHelper.remote_session(dataset.AwsAccountId).client(
+        self._client = SessionHelper.remote_session(accountid=dataset.AwsAccountId, role=dataset.IAMDatasetAdminRoleArn).client(
             's3',
             region_name=dataset.region,
             config=Config(signature_version='s3v4', s3={'addressing_style': 'virtual'}),

--- a/backend/dataall/modules/datasets/aws/s3_dataset_client.py
+++ b/backend/dataall/modules/datasets/aws/s3_dataset_client.py
@@ -13,7 +13,13 @@ log = logging.getLogger(__name__)
 class S3DatasetClient:
 
     def __init__(self, dataset: Dataset):
-        self._client = SessionHelper.remote_session(accountid=dataset.AwsAccountId, role=dataset.IAMDatasetAdminRoleArn).client(
+        """
+        It first starts a session assuming the pivot role,
+        then we define another session assuming the dataset role from the pivot role
+        """
+        pivot_role_session = SessionHelper.remote_session(accountid=dataset.AwsAccountId)
+        session = SessionHelper.get_session(base_session=pivot_role_session, role_arn=dataset.IAMDatasetAdminRoleArn)
+        self._client = session.client(
             's3',
             region_name=dataset.region,
             config=Config(signature_version='s3v4', s3={'addressing_style': 'virtual'}),

--- a/backend/dataall/modules/datasets/aws/s3_location_client.py
+++ b/backend/dataall/modules/datasets/aws/s3_location_client.py
@@ -9,7 +9,12 @@ log = logging.getLogger(__name__)
 class S3LocationClient:
 
     def __init__(self, location: DatasetStorageLocation, dataset: Dataset):
-        session = SessionHelper.remote_session(accountid=location.AWSAccountId, role=dataset.IAMDatasetAdminRoleArn)
+        """
+        It first starts a session assuming the pivot role,
+        then we define another session assuming the dataset role from the pivot role
+        """
+        pivot_role_session = SessionHelper.remote_session(accountid=location.AWSAccountId)
+        session = SessionHelper.get_session(base_session=pivot_role_session, role_arn=dataset.IAMDatasetAdminRoleArn)
         self._client = session.client('s3', region_name=location.region)
         self._location = location
 

--- a/backend/dataall/modules/datasets/aws/s3_location_client.py
+++ b/backend/dataall/modules/datasets/aws/s3_location_client.py
@@ -1,15 +1,15 @@
 import logging
 
 from dataall.base.aws.sts import SessionHelper
-from dataall.modules.datasets_base.db.dataset_models import DatasetStorageLocation
+from dataall.modules.datasets_base.db.dataset_models import DatasetStorageLocation, Dataset
 
 log = logging.getLogger(__name__)
 
 
 class S3LocationClient:
 
-    def __init__(self, location: DatasetStorageLocation):
-        session = SessionHelper.remote_session(accountid=location.AWSAccountId)
+    def __init__(self, location: DatasetStorageLocation, dataset: Dataset):
+        session = SessionHelper.remote_session(accountid=location.AWSAccountId, role=dataset.IAMDatasetAdminRoleArn)
         self._client = session.client('s3', region_name=location.region)
         self._location = location
 

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -379,7 +379,7 @@ class DatasetStack(Stack):
             role_name=dataset.IAMDatasetAdminRoleArn.split('/')[-1],
             assumed_by=iam.CompositePrincipal(
                 iam.ArnPrincipal(
-                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'  # TODO: issues in local testing
+                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'
                 ),
                 iam.ServicePrincipal('glue.amazonaws.com'),
             ),

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -379,7 +379,7 @@ class DatasetStack(Stack):
             role_name=dataset.IAMDatasetAdminRoleArn.split('/')[-1],
             assumed_by=iam.CompositePrincipal(
                 iam.ArnPrincipal(
-                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}' #TODO: issues in local testing
+                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'  # TODO: issues in local testing
                 ),
                 iam.ServicePrincipal('glue.amazonaws.com'),
             ),

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -242,7 +242,8 @@ class DatasetStack(Stack):
                     sid="ListDatasetBucket",
                     actions=[
                         "s3:ListBucket",
-                        "s3:GetBucketLocation"
+                        "s3:GetBucketLocation",
+                        "s3:GetBucketAcl"
                     ],
                     resources=[dataset_bucket.bucket_arn],
                     effect=iam.Effect.ALLOW,
@@ -378,7 +379,7 @@ class DatasetStack(Stack):
             role_name=dataset.IAMDatasetAdminRoleArn.split('/')[-1],
             assumed_by=iam.CompositePrincipal(
                 iam.ArnPrincipal(
-                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'
+                    f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}' #TODO: issues in local testing
                 ),
                 iam.ServicePrincipal('glue.amazonaws.com'),
             ),
@@ -413,7 +414,7 @@ class DatasetStack(Stack):
                 type='AWS::LakeFormation::Resource',
                 properties={
                     'ResourceArn': f'arn:aws:s3:::{dataset.S3BucketName}',
-                    'RoleArn': f'arn:aws:iam::{env.AwsAccountId}:role/{self.pivot_role_name}',
+                    'RoleArn': dataset_admin_role.role_arn,
                     'UseServiceLinkedRole': False,
                 },
             )

--- a/backend/dataall/modules/datasets/cdk/pivot_role_datasets_policy.py
+++ b/backend/dataall/modules/datasets/cdk/pivot_role_datasets_policy.py
@@ -1,4 +1,5 @@
-from dataall.base.context import get_context
+import os
+from dataall.base import db
 from dataall.core.environment.cdk.pivot_role_stack import PivotRoleStatementSet
 from dataall.modules.datasets_base.db.dataset_repositories import DatasetRepository
 from dataall.modules.datasets_base.db.dataset_models import Dataset
@@ -13,8 +14,8 @@ class DatasetsPivotRole(PivotRoleStatementSet):
     """
     def get_statements(self):
         allowed_buckets = []
-        context = get_context()
-        with context.db_engine.scoped_session() as session:
+        engine = db.get_engine(envname=os.environ.get('envname', 'local'))
+        with engine.scoped_session() as session:
             datasets = DatasetRepository.query_environment_datasets(
                 session, uri=self.environmentUri, filter=None
             )

--- a/backend/dataall/modules/datasets/cdk/pivot_role_datasets_policy.py
+++ b/backend/dataall/modules/datasets/cdk/pivot_role_datasets_policy.py
@@ -136,14 +136,11 @@ class DatasetsPivotRole(PivotRoleStatementSet):
                 dataset: Dataset
                 for dataset in datasets:
                     allowed_buckets.append(f'arn:aws:s3:::{dataset.S3BucketName}')
-                for i in range(10):
-                    allowed_buckets.append(f'arn:aws:s3:::fakedataset-{i}')
 
         if allowed_buckets:
             # Imported Dataset S3 Buckets, created bucket permissions are added in core S3 permissions
-
-            base_statement = iam.PolicyStatement(
-                sid='ImportedDatasetBuckets',
+            dataset_statement = split_policy_with_resources_in_statements(
+                base_sid='ImportedDatasetBuckets',
                 effect=iam.Effect.ALLOW,
                 actions=[
                     's3:List*',
@@ -155,10 +152,6 @@ class DatasetsPivotRole(PivotRoleStatementSet):
                     's3:PutObjectAcl',
                     's3:PutBucketOwnershipControls',
                 ],
-                resources="RESOURCES",
-            )
-            dataset_statement = split_policy_with_resources_in_statements(
-                statement_without_resources=base_statement,
                 resources=allowed_buckets
             )
             statements.extend(dataset_statement)

--- a/backend/dataall/modules/datasets/services/dataset_location_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_location_service.py
@@ -36,7 +36,7 @@ class DatasetLocationService:
             if 'terms' in data.keys():
                 DatasetLocationService._create_glossary_links(session, location, data['terms'])
 
-            S3LocationClient(location).create_bucket_prefix()
+            S3LocationClient(location, dataset).create_bucket_prefix()
 
         DatasetLocationIndexer.upsert(session=session, folder_uri=location.locationUri)
         return location

--- a/backend/dataall/modules/datasets_base/db/dataset_repositories.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repositories.py
@@ -291,6 +291,27 @@ class DatasetRepository(EnvironmentResource):
         return query
 
     @staticmethod
+    def query_environment_imported_datasets(session, uri, filter) -> Query:
+        query = session.query(Dataset).filter(
+            and_(
+                Dataset.environmentUri == uri,
+                Dataset.deleted.is_(None),
+                Dataset.imported.is_(True)
+            )
+        )
+        if filter and filter.get('term'):
+            term = filter['term']
+            query = query.filter(
+                or_(
+                    Dataset.label.ilike('%' + term + '%'),
+                    Dataset.description.ilike('%' + term + '%'),
+                    Dataset.tags.contains(f'{{{term}}}'),
+                    Dataset.region.ilike('%' + term + '%'),
+                )
+            )
+        return query
+
+    @staticmethod
     def paginated_environment_datasets(
             session, uri, data=None,
     ) -> dict:


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
The guiding principle is that:
1. dataset IAM role is the role accessing data
2. pivot role is the role used by the central account to perform SDK calls in the environment account

In this PR we
- Replace pivot role by dataset role in dataset Lake Formation registration
- Use pivot role to trigger upload files feature and create folder feature, but use the dataset IAM role to perform the putObject operations-> removes the need for read and `putObject` permissions. for the pivot role
- Redefine pivot role CDK stack to manage S3 buckets (bucket policies) for only the datasets S3 buckets that have been created or imported in the environment.
- implement IAM policy utils to handle the new dynamic policies. We need to verify that the created policy statements do not exceed the maximum policy size. In addition we replace the previous "divide in chunks of 10 statements" by a function that divides in chunks based on the size of the policy statements. This way we optimize the policy size, which helps us in reducing the number of managed policies attached to the pivot role. --> it can be re-used in other "chunkenization" of policies
- We did not implement force update of environments (pivot role nested stack) with new datasets added because it is already forced in `backend/dataall/modules/datasets/services/dataset_service.py`

### Backwards compatibility Testing

Pre-update setup:
- 1 environment (auto-created pivot role)
- 2 datasets in environment, 1 created, 1 imported: with tables and folders
- Run profiling jobs in tables

Update with the branch changes:
- [X] CICD pipeline runs successfully
- [X] Click update environment on environment -> successfully updated policy of pivot role with imported datasets in policy. Reduction of policies
- [X] Click update datasets --> registration in Lake formation updated to dataset role
- [X] Update files works
- [X] Create folder works
- [X] Crawler and profiling jobs work
 

### Relates
- #580 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Are you introducing any new policies/roles/users? `Yes`
  - Have you used the least-privilege principle? How? `In this PR we restrict the permissions of the pivot role, a super role that handles SDK calls in the environment accounts. Instead of granting permissions to all S3 buckets, we restrict it to data.all handled S3 buckets only`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
