### PR TITLE
Update Lambda runtime

### DIFF
--- a/backend/dataall/base/cdkproxy/requirements.txt
+++ b/backend/dataall/base/cdkproxy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.83.1
+aws-cdk-lib==2.99.0
 boto3==1.24.85
 boto3-stubs==1.24.85
 botocore==1.27.85

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.78.0
+aws-cdk-lib==2.99.0
 boto3-stubs==1.20.20
 boto3==1.24.85
 botocore==1.27.85

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -11,5 +11,5 @@ setuptools.setup(
     author=__author__,
     package_dir={'': 'stacks'},
     packages=setuptools.find_packages(where='stacks'),
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )

--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -487,7 +487,7 @@ class CloudfrontDistro(pyNestedClass):
                     iam.ServicePrincipal('lambda.amazonaws.com'),
                 ),
             ),
-            runtime=_lambda.Runtime.NODEJS_14_X,
+            runtime=_lambda.Runtime.NODEJS_18_X,
         )
 
         http_header_func_version = http_header_func.current_version


### PR DESCRIPTION
### Feature or Bugfix
Update

### Detail


### Relates
See #655: 
> In Nov 27, 2023 the Lambda runtime node14 and Python3.7 will be deprecated!

Checked all lambdas that explicitly set the runtime engine: only cognito httpheader redirection lambda used node14.
All lambdas use python3.8 and node16 or node18.

For cdk dependencies: upgraded to a newest `aws-cdk-lib` `v2.99.0` just in case if python3.7 is hardcoded somewhere inside of 2.78.0 (shouldn't be)

### 
Testing: 
- [x] uploaded the changes to my isengard account
- [x] deployment is green 
- [x] could access app page, userguide page, and userguide from the app page.

### Security
`N/A` - upgraded to a newer version of node js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
