### PR TITLE
Adding configurable session timeout to IDP

### DIFF
--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -50,6 +50,7 @@ class BackendStack(Stack):
         enable_opensearch_serverless=False,
         codeartifact_domain_name=None,
         codeartifact_pip_repo_name=None,
+        cognito_user_session_timeout_inmins=43200,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -113,6 +114,7 @@ class BackendStack(Stack):
             internet_facing=internet_facing,
             tooling_account_id=tooling_account_id,
             enable_cw_rum=enable_cw_rum,
+            cognito_user_session_timeout_inmins=cognito_user_session_timeout_inmins,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -32,6 +32,7 @@ class BackendStage(Stage):
         enable_pivot_role_auto_create=False,
         codeartifact_domain_name=None,
         codeartifact_pip_repo_name=None,
+        cognito_user_session_timeout_inmins=43200,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -61,6 +62,7 @@ class BackendStage(Stage):
             enable_pivot_role_auto_create=enable_pivot_role_auto_create,
             codeartifact_domain_name=codeartifact_domain_name,
             codeartifact_pip_repo_name=codeartifact_pip_repo_name,
+            cognito_user_session_timeout_inmins=cognito_user_session_timeout_inmins,
             **kwargs,
         )
 

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -28,6 +28,7 @@ class IdpStack(pyNestedClass):
         internet_facing=True,
         tooling_account_id=None,
         enable_cw_rum=False,
+        cognito_user_session_timeout_inmins=43200,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -63,6 +64,7 @@ class IdpStack(pyNestedClass):
             f'AppClient-{envname}',
             user_pool=self.user_pool,
             prevent_user_existence_errors=True,
+            refresh_token_validity=Duration.minutes(cognito_user_session_timeout_inmins),
         )
 
         if enable_cw_rum:

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -372,7 +372,7 @@ class PipelineStack(Stack):
                         resources=[f'arn:aws:codecommit:{self.region}:{self.account}:dataall'],
                     )
                 ],
-            )   
+            )
 
     def validate_deployment_params(self, git_branch, resource_prefix, target_envs):
         if not bool(re.match(r'^[a-zA-Z0-9-_]+$', git_branch)):
@@ -635,6 +635,7 @@ class PipelineStack(Stack):
                 enable_pivot_role_auto_create=target_env.get('enable_pivot_role_auto_create', False),
                 codeartifact_domain_name=self.codeartifact.codeartifact_domain_name,
                 codeartifact_pip_repo_name=self.codeartifact.codeartifact_pip_repo_name,
+                cognito_user_session_timeout_inmins=target_env.get('cognito_user_session_timeout_inmins', 43200),
             )
         )
         return backend_stage

--- a/template_cdk.json
+++ b/template_cdk.json
@@ -37,7 +37,8 @@
         "enable_quicksight_monitoring": "boolean_ENABLE_CONNECTION_QUICKSIGHT_RDS|DEFAULT=false",
         "enable_opensearch_serverless": "boolean_USE_OPENSEARCH_SERVERLESS|DEFAULT=false",
         "enable_pivot_role_auto_create": "boolean_ENABLE_PIVOT_ROLE_AUTO_CREATE_IN_ENVIRONMENT|DEFAULT=false",
-        "enable_update_dataall_stacks_in_cicd_pipeline": "boolean_ENABLE_UPDATE_DATAALL_STACKS_IN_CICD_PIPELINE|DEFAULT=false"
+        "enable_update_dataall_stacks_in_cicd_pipeline": "boolean_ENABLE_UPDATE_DATAALL_STACKS_IN_CICD_PIPELINE|DEFAULT=false",
+        "cognito_user_session_timeout_inmins": "integer_COGNITO_USER_SESSION_TIMEOUT_INMINS|DEFAULT=43200"
       }
     ]
   }


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
Allows user to configure a session timeout . Today data.all by default sets the refresh token to 30 days but with this change it becomes configurable

### Relates
https://github.com/awslabs/aws-dataall/issues/421

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
