### PR TITLE
Fix: allow to submit a share when you are both and approver and a requester

### DIFF
--- a/backend/dataall/modules/dataset_sharing/api/enums.py
+++ b/backend/dataall/modules/dataset_sharing/api/enums.py
@@ -9,6 +9,7 @@ class ShareableType(GraphQLEnumMapper):
 
 class ShareObjectPermission(GraphQLEnumMapper):
     Approvers = '999'
+    ApproversAndRequesters = '900'
     Requesters = '800'
     DatasetAdmins = '700'
     NoPermission = '000'

--- a/backend/dataall/modules/dataset_sharing/api/resolvers.py
+++ b/backend/dataall/modules/dataset_sharing/api/resolvers.py
@@ -92,16 +92,16 @@ def resolve_user_role(context: Context, source: ShareObject, **kwargs):
         dataset: Dataset = DatasetRepository.get_dataset_by_uri(session, source.datasetUri)
 
         can_approve = True if (
-                dataset and (
+            dataset and (
                 dataset.stewards in context.groups
                 or dataset.SamlAdminGroupName in context.groups
                 or dataset.owner == context.username
-        )
+            )
         ) else False
 
         can_request = True if (
-                source.owner == context.username
-                or source.groupUri in context.groups
+            source.owner == context.username
+            or source.groupUri in context.groups
         ) else False
 
         return (

--- a/backend/dataall/modules/dataset_sharing/db/enums.py
+++ b/backend/dataall/modules/dataset_sharing/db/enums.py
@@ -15,6 +15,7 @@ class ShareObjectStatus(Enum):
 
 class ShareObjectPermission(Enum):
     Approvers = '999'
+    ApproversAndRequesters = '900'
     Requesters = '800'
     DatasetAdmins = '700'
     NoPermission = '000'

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -238,7 +238,8 @@ function ShareViewHeader(props) {
               >
                 Refresh
               </Button>
-              {share.userRoleForShareObject === 'Approvers' ? (
+              {(share.userRoleForShareObject === 'Approvers' ||
+                share.userRoleForShareObject === 'ApproversAndRequesters') && (
                 <>
                   {share.status === 'Submitted' && (
                     <>
@@ -267,7 +268,10 @@ function ShareViewHeader(props) {
                     </>
                   )}
                 </>
-              ) : (
+              )}
+
+              {(share.userRoleForShareObject === 'Requesters' ||
+                share.userRoleForShareObject === 'ApproversAndRequesters') && (
                 <>
                   {(share.status === 'Draft' ||
                     share.status === 'Rejected') && (
@@ -733,7 +737,9 @@ const ShareView = () => {
                     <Box sx={{ mt: 3 }}>
                       <Typography color="textSecondary" variant="subtitle2">
                         Request Purpose
-                        {share.userRoleForShareObject === 'Requesters' && (
+                        {(share.userRoleForShareObject === 'Requesters' ||
+                          share.userRoleForShareObject ===
+                            'ApproversAndRequesters') && (
                           <UpdateRequestReason
                             share={share}
                             client={client}
@@ -756,7 +762,9 @@ const ShareView = () => {
                     <Box sx={{ mt: 3 }}>
                       <Typography color="textSecondary" variant="subtitle2">
                         Reject Purpose
-                        {share.userRoleForShareObject === 'Approvers' && (
+                        {(share.userRoleForShareObject === 'Approvers' ||
+                          share.userRoleForShareObject ===
+                            'ApproversAndRequesters') && (
                           <UpdateRejectReason
                             share={share}
                             client={client}

--- a/tests/modules/datasets/test_share.py
+++ b/tests/modules/datasets/test_share.py
@@ -844,7 +844,7 @@ def test_create_share_object_unauthorized(client, group3, dataset1, env2, env2gr
     assert 'Unauthorized' in create_share_object_response.errors[0].message
 
 
-def test_create_share_object_authorized(client, user2, group2, env2group, env2, dataset1):
+def test_create_share_object_as_requester(client, user2, group2, env2group, env2, dataset1):
     # Given
     # Existing dataset, target environment and group
     # When a user that belongs to environment and group creates request
@@ -860,6 +860,24 @@ def test_create_share_object_authorized(client, user2, group2, env2group, env2, 
     assert create_share_object_response.data.createShareObject.shareUri
     assert create_share_object_response.data.createShareObject.status == ShareObjectStatus.Draft.value
     assert create_share_object_response.data.createShareObject.userRoleForShareObject == 'Requesters'
+    assert create_share_object_response.data.createShareObject.requestPurpose == 'testShare'
+
+def test_create_share_object_as_approver_and_requester(client, user, group2, env2group, env2, dataset1):
+    # Given
+    # Existing dataset, target environment and group
+    # When a user that belongs to environment and group creates request
+    create_share_object_response = create_share_object(
+        client=client,
+        username=user.username,
+        group=group2,
+        groupUri=env2group.groupUri,
+        environmentUri=env2.environmentUri,
+        datasetUri=dataset1.datasetUri
+    )
+    # Then share object created with status Draft and user is 'Requester'
+    assert create_share_object_response.data.createShareObject.shareUri
+    assert create_share_object_response.data.createShareObject.status == ShareObjectStatus.Draft.value
+    assert create_share_object_response.data.createShareObject.userRoleForShareObject == 'ApproversAndRequesters'
     assert create_share_object_response.data.createShareObject.requestPurpose == 'testShare'
 
 def test_create_share_object_with_item_authorized(client, user2, group2, env2group, env2, dataset1, table1):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Allowing to submit a share when you are both an approver and a requester

### Security

**DOES NOT APPLY**

Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
