### PR TITLE
feat: redirect upon creating a share request

### DIFF
--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -25,10 +25,12 @@ import {
   requestDashboardShare,
   useClient
 } from 'services';
+import { useNavigate } from 'react-router-dom';
 
 export const RequestAccessModal = (props) => {
   const { hit, onApply, onClose, open, stopLoader, ...other } = props;
   const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const client = useClient();
   const [environmentOptions, setEnvironmentOptions] = useState([]);
@@ -185,7 +187,7 @@ export const RequestAccessModal = (props) => {
       if (response && !response.errors) {
         setStatus({ success: true });
         setSubmitting(false);
-        enqueueSnackbar('Request sent', {
+        enqueueSnackbar('Draft share request created', {
           anchorOrigin: {
             horizontal: 'right',
             vertical: 'top'
@@ -195,6 +197,7 @@ export const RequestAccessModal = (props) => {
         if (onApply) {
           onApply();
         }
+        navigate(`/console/shares/${response.data.createShareObject.shareUri}`);
       } else {
         dispatch({ type: SET_ERROR, error: response.errors[0].message });
       }


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Adding a redirect to the share UI once a share object is created. Additionally updating the breadcrumb message to more clearly indicate that a "Draft share request is created" rather than suggesting that the share has actually been sent to the data owners team.

### Relates
N/A

### Security
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
