### PR TITLE
feat: Handle Pre-filtering of tables

### DIFF
--- a/backend/dataall/modules/datasets/api/table/mutations.py
+++ b/backend/dataall/modules/datasets/api/table/mutations.py
@@ -23,7 +23,9 @@ deleteDatasetTable = gql.MutationField(
 
 syncTables = gql.MutationField(
     name='syncTables',
-    args=[gql.Argument(name='datasetUri', type=gql.NonNullableType(gql.String))],
+    args=[
+        gql.Argument(name='datasetUri', type=gql.NonNullableType(gql.String))
+    ],
     type=gql.Ref('DatasetTableSearchResult'),
     resolver=sync_tables,
 )

--- a/backend/dataall/modules/datasets/services/dataset_table_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_table_service.py
@@ -121,8 +121,8 @@ class DatasetTableService:
         context = get_context()
         with context.db_engine.scoped_session() as session:
             dataset = DatasetRepository.get_dataset_by_uri(session, uri)
-
-            tables = DatasetCrawler(dataset).list_glue_database_tables()
+            S3Prefix = dataset.S3BucketName
+            tables = DatasetCrawler(dataset).list_glue_database_tables(S3Prefix)
             cls.sync_existing_tables(session, dataset.datasetUri, glue_tables=tables)
             DatasetTableIndexer.upsert_all(
                 session=session, dataset_uri=dataset.datasetUri

--- a/backend/dataall/modules/datasets/tasks/tables_syncer.py
+++ b/backend/dataall/modules/datasets/tasks/tables_syncer.py
@@ -56,7 +56,7 @@ def sync_tables(engine):
                     )
                 else:
 
-                    tables = DatasetCrawler(dataset).list_glue_database_tables()
+                    tables = DatasetCrawler(dataset).list_glue_database_tables(dataset.S3BucketName)
 
                     log.info(
                         f'Found {len(tables)} tables on Glue database {dataset.GlueDatabaseName}'


### PR DESCRIPTION
### Feature or Bugfix

- Feature

### Detail
- For a dataset to make sense all the tables within a dataset should have their location pointing to the same place as the dataset S3 bucket. However it is possible that a database can have tables which do not point to the same bucket which is perfectly legal in LakeFormation. Therefore we propose that data.all automatically only lists tables that have the same S3 bucket location as the dataset. This will solve a problem for Yahoo where we want to import a database that contains many tables with different buckets. Additionally Catalog UI should also only list prefiltered tables.

### Testing
- Tested this in local env. I was able to create and share datasets even after pre-filtering process takes place.
- Will send separate PR for unit testing. 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
