### PR TITLE
Make hosted_zone_id optional, code update

### DIFF
--- a/deploy/stacks/albfront_stack.py
+++ b/deploy/stacks/albfront_stack.py
@@ -149,7 +149,7 @@ class AlbFrontStack(Stack):
         if custom_domain and custom_domain.get('certificate_arn'):
             certificate = acm.Certificate.from_certificate_arn(self, "CustomDomainCertificate",
                                                                custom_domain.get('certificate_arn'))
-        else:
+        elif custom_domain and custom_domain.get('hosted_zone_name'):
             certificate = acm.Certificate(
                 self,
                 'CustomDomainCertificate',
@@ -157,6 +157,8 @@ class AlbFrontStack(Stack):
                 subject_alternative_names=[f'*.{custom_domain["hosted_zone_name"]}'],
                 validation=acm.CertificateValidation.from_dns(hosted_zone=hosted_zone),
             )
+        else:
+            raise ValueError("Configuration parameter custom_domain['hosted_zone_name'] in cdk.json is REQUIRED if internet_facing=false")
 
         frontend_sg = ec2.SecurityGroup(
             self,

--- a/deploy/stacks/albfront_stack.py
+++ b/deploy/stacks/albfront_stack.py
@@ -158,7 +158,7 @@ class AlbFrontStack(Stack):
                 validation=acm.CertificateValidation.from_dns(hosted_zone=hosted_zone),
             )
         else:
-            raise ValueError("Configuration parameter custom_domain['hosted_zone_name'] in cdk.json is REQUIRED if internet_facing=false")
+            raise ValueError("Configuration parameter custom_domain['hosted_zone_name'] in cdk.json is REQUIRED when internet_facing=false")
 
         frontend_sg = ec2.SecurityGroup(
             self,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Make `hosted_zone_id` optional, code update

### Relates
- #797 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?  N/A
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. YES

### Description

Make `hosted_zone_id` optional and provide `HostedZoneId` and `DNSName` in CloudFormation Stack Output, so users can create their own [Route53 AliasTarget](https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html).

Following validation checks in `ecs_patterns.ApplicationLoadBalancedFargateService` were considered:
* `frontend_alternate_domain` and `userguide_alternate_domain` have to be `None` when the `hosted_zone` is `None`, see checks in [multiple-target-groups-service-base.ts#L463](https://github.com/aws/aws-cdk/blob/c445b8cc6e20d17e4a536f17262646b291a0fe36/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/network-multiple-target-groups-service-base.ts#L463), or else a `A Route53 hosted domain zone name is required to configure the specified domain name` error is raised
* for a HTTPS ALB listener, only the `certificate` is ultimately required, and not the `domainName` or `domainZone`, as per evaluation logic in [application-load-balanced-service-base.ts#L509](https://github.com/aws/aws-cdk/blob/c445b8cc6e20d17e4a536f17262646b291a0fe36/packages/aws-cdk-lib/aws-ecs-patterns/lib/base/application-load-balanced-service-base.ts#L509)