### PR TITLE
feat: adding frontend and backend feature flags

### DIFF
--- a/backend/dataall/modules/datasets/api/dataset/resolvers.py
+++ b/backend/dataall/modules/datasets/api/dataset/resolvers.py
@@ -127,6 +127,7 @@ def get_dataset_statistics(context: Context, source: Dataset, **kwargs):
 def get_dataset_assume_role_url(context: Context, source, datasetUri: str = None):
     return DatasetService.get_dataset_assume_role_url(uri=datasetUri)
 
+
 @is_feature_enabled('modules.datasets.features.glue_crawler')
 def start_crawler(context: Context, source, datasetUri: str, input: dict = None):
     return DatasetService.start_crawler(uri=datasetUri, data=input)

--- a/backend/dataall/modules/datasets/api/dataset/resolvers.py
+++ b/backend/dataall/modules/datasets/api/dataset/resolvers.py
@@ -127,7 +127,7 @@ def get_dataset_statistics(context: Context, source: Dataset, **kwargs):
 def get_dataset_assume_role_url(context: Context, source, datasetUri: str = None):
     return DatasetService.get_dataset_assume_role_url(uri=datasetUri)
 
-
+@is_feature_enabled('modules.datasets.features.glue_crawler')
 def start_crawler(context: Context, source, datasetUri: str, input: dict = None):
     return DatasetService.start_crawler(uri=datasetUri, data=input)
 

--- a/backend/dataall/modules/datasets/api/table/resolvers.py
+++ b/backend/dataall/modules/datasets/api/table/resolvers.py
@@ -1,5 +1,6 @@
 import logging
 
+from dataall.core.feature_toggle_checker import is_feature_enabled
 from dataall.modules.catalog.db.glossary_repositories import GlossaryRepository
 from dataall.modules.datasets.api.dataset.resolvers import get_dataset
 from dataall.base.api.context import Context
@@ -22,7 +23,7 @@ def delete_table(context, source, tableUri: str = None):
         return False
     return DatasetTableService.delete_table(uri=tableUri)
 
-
+@is_feature_enabled('modules.datasets.features.preview_data')
 def preview(context, source, tableUri: str = None):
     if not tableUri:
         return None

--- a/backend/dataall/modules/datasets/api/table/resolvers.py
+++ b/backend/dataall/modules/datasets/api/table/resolvers.py
@@ -23,6 +23,7 @@ def delete_table(context, source, tableUri: str = None):
         return False
     return DatasetTableService.delete_table(uri=tableUri)
 
+
 @is_feature_enabled('modules.datasets.features.preview_data')
 def preview(context, source, tableUri: str = None):
     if not tableUri:

--- a/config.json
+++ b/config.json
@@ -14,7 +14,9 @@
             "features": {
                 "file_uploads": true,
                 "file_actions": true,
-                "aws_actions": true
+                "aws_actions": true,
+                "preview_data": true,
+                "glue_crawler": true
             }
         },
         "worksheets": {
@@ -26,7 +28,8 @@
     },
     "core": {
         "features": {
-            "env_aws_actions": true
+            "env_aws_actions": true,
+            "env_feature_management": true
         }
     }
 }

--- a/config.json
+++ b/config.json
@@ -28,8 +28,7 @@
     },
     "core": {
         "features": {
-            "env_aws_actions": true,
-            "env_feature_management": true
+            "env_aws_actions": true
         }
     }
 }

--- a/frontend/src/modules/Datasets/components/DatasetData.js
+++ b/frontend/src/modules/Datasets/components/DatasetData.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { DatasetTables } from './DatasetTables';
 import { DatasetFolders } from './DatasetFolders';
+import { isFeatureEnabled } from 'utils';
 
 export const DatasetData = (props) => {
   const { dataset, isAdmin } = props;
@@ -12,9 +13,11 @@ export const DatasetData = (props) => {
       <Box>
         <DatasetTables dataset={dataset} isAdmin={isAdmin} />
       </Box>
-      <Box sx={{ mt: 3 }}>
-        <DatasetFolders dataset={dataset} isAdmin={isAdmin} />
-      </Box>
+      {isFeatureEnabled('datasets', 'file_actions') && (
+        <Box sx={{ mt: 3 }}>
+          <DatasetFolders dataset={dataset} isAdmin={isAdmin} />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/modules/Datasets/components/DatasetTables.js
+++ b/frontend/src/modules/Datasets/components/DatasetTables.js
@@ -40,6 +40,7 @@ import { listDatasetTables, deleteDatasetTable, useClient } from 'services';
 import { syncTables } from '../services';
 
 import { DatasetStartCrawlerModal } from './DatasetStartCrawlerModal';
+import { isFeatureEnabled } from 'utils';
 
 export const DatasetTables = (props) => {
   const { dataset, isAdmin } = props;
@@ -216,15 +217,17 @@ export const DatasetTables = (props) => {
                 Synchronize
               </LoadingButton>
 
-              <LoadingButton
-                color="primary"
-                onClick={handleStartCrawlerModalOpen}
-                startIcon={<SearchIcon fontSize="small" />}
-                sx={{ m: 1 }}
-                variant="outlined"
-              >
-                Start Crawler
-              </LoadingButton>
+              {isFeatureEnabled('datasets', 'glue_crawler') && (
+                <LoadingButton
+                  color="primary"
+                  onClick={handleStartCrawlerModalOpen}
+                  startIcon={<SearchIcon fontSize="small" />}
+                  sx={{ m: 1 }}
+                  variant="outlined"
+                >
+                  Start Crawler
+                </LoadingButton>
+              )}
             </Grid>
           )}
         </Box>

--- a/frontend/src/modules/Datasets/views/DatasetView.js
+++ b/frontend/src/modules/Datasets/views/DatasetView.js
@@ -48,6 +48,7 @@ import {
   DatasetOverview,
   DatasetUpload
 } from '../components';
+import { isFeatureEnabled } from 'utils';
 
 const DatasetView = () => {
   const dispatch = useDispatch();
@@ -81,11 +82,13 @@ const DatasetView = () => {
         value: 'shares',
         icon: <ShareOutlined fontSize="small" />
       });
-      tabs.push({
-        label: 'Upload',
-        value: 'upload',
-        icon: <Upload fontSize="small" />
-      });
+      if (isFeatureEnabled('datasets', 'file_uploads')) {
+        tabs.push({
+          label: 'Upload',
+          value: 'upload',
+          icon: <Upload fontSize="small" />
+        });
+      }
       if (settings.isAdvancedMode) {
         tabs.push({
           label: 'Tags',
@@ -278,7 +281,9 @@ const DatasetView = () => {
                   >
                     Chat
                   </Button>
-                  <DatasetAWSActions dataset={dataset} isAdmin={isAdmin} />
+                  {isFeatureEnabled('datasets', 'aws_actions') && (
+                    <DatasetAWSActions dataset={dataset} isAdmin={isAdmin} />
+                  )}
                   <Button
                     color="primary"
                     component={RouterLink}

--- a/frontend/src/modules/Environments/components/EnvironmentFeatures.js
+++ b/frontend/src/modules/Environments/components/EnvironmentFeatures.js
@@ -41,46 +41,50 @@ export const EnvironmentFeatures = (props) => {
   // Filter the features based on the 'active' attribute
   const activeFeatures = features.filter((feature) => feature.active);
 
-  return (
-    <Card {...other}>
-      <CardHeader title="Features" />
-      <Divider />
-      <CardContent sx={{ pt: 0 }}>
-        <List>
-          {activeFeatures.map((feature) => (
-            <ListItem
-              key={feature.title}
-              disableGutters
-              divider
-              sx={{
-                justifyContent: 'space-between',
-                padding: 2
-              }}
-            >
-              <Typography color="textSecondary" variant="subtitle2">
-                {feature.title}
-              </Typography>
-              <Typography color="textPrimary" variant="body2">
-                <Label
-                  color={
-                    environment.parameters[feature.enabledEnvVariableName] ===
+  if (activeFeatures.length === 0) {
+    return <></>;
+  } else {
+    return (
+      <Card {...other}>
+        <CardHeader title="Features" />
+        <Divider />
+        <CardContent sx={{ pt: 0 }}>
+          <List>
+            {activeFeatures.map((feature) => (
+              <ListItem
+                key={feature.title}
+                disableGutters
+                divider
+                sx={{
+                  justifyContent: 'space-between',
+                  padding: 2
+                }}
+              >
+                <Typography color="textSecondary" variant="subtitle2">
+                  {feature.title}
+                </Typography>
+                <Typography color="textPrimary" variant="body2">
+                  <Label
+                    color={
+                      environment.parameters[feature.enabledEnvVariableName] ===
+                      'true'
+                        ? 'success'
+                        : 'error'
+                    }
+                  >
+                    {environment.parameters[feature.enabledEnvVariableName] ===
                     'true'
-                      ? 'success'
-                      : 'error'
-                  }
-                >
-                  {environment.parameters[feature.enabledEnvVariableName] ===
-                  'true'
-                    ? 'Enabled'
-                    : 'Disabled'}
-                </Label>
-              </Typography>
-            </ListItem>
-          ))}
-        </List>
-      </CardContent>
-    </Card>
-  );
+                      ? 'Enabled'
+                      : 'Disabled'}
+                  </Label>
+                </Typography>
+              </ListItem>
+            ))}
+          </List>
+        </CardContent>
+      </Card>
+    );
+  }
 };
 
 EnvironmentFeatures.propTypes = {

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -51,6 +51,7 @@ import {
 import { EnvironmentRoleAddForm } from './EnvironmentRoleAddForm';
 import { EnvironmentTeamInviteEditForm } from './EnvironmentTeamInviteEditForm';
 import { EnvironmentTeamInviteForm } from './EnvironmentTeamInviteForm';
+import { isFeatureEnabled } from '../../../utils';
 
 function TeamRow({ team, environment, fetchItems }) {
   const client = useClient();
@@ -176,37 +177,14 @@ function TeamRow({ team, environment, fetchItems }) {
           />
         )}
       </TableCell>
-      <TableCell>
-        <Box>
-          <LoadingButton
-            loading={accessingConsole}
-            onClick={() => getConsoleLink(team.groupUri)}
-          >
-            <FaIcons.FaAws
-              size={25}
-              color={
-                theme.palette.mode === 'dark'
-                  ? theme.palette.primary.contrastText
-                  : theme.palette.primary.main
-              }
-            />
-          </LoadingButton>
-          <LoadingButton
-            loading={loadingCreds}
-            onClick={() => generateCredentials(team.groupUri)}
-          >
-            <CopyAllOutlined
-              sx={{
-                color:
-                  theme.palette.mode === 'dark'
-                    ? theme.palette.primary.contrastText
-                    : theme.palette.primary.main
-              }}
-            />
-          </LoadingButton>
-          {team.groupUri !== environment.SamlGroupName && (
-            <LoadingButton onClick={() => removeGroup(team.groupUri)}>
-              <HiUserRemove
+      {isFeatureEnabled('core', 'env_aws_actions') && (
+        <TableCell>
+          <Box>
+            <LoadingButton
+              loading={accessingConsole}
+              onClick={() => getConsoleLink(team.groupUri)}
+            >
+              <FaIcons.FaAws
                 size={25}
                 color={
                   theme.palette.mode === 'dark'
@@ -215,9 +193,34 @@ function TeamRow({ team, environment, fetchItems }) {
                 }
               />
             </LoadingButton>
-          )}
-        </Box>
-      </TableCell>
+            <LoadingButton
+              loading={loadingCreds}
+              onClick={() => generateCredentials(team.groupUri)}
+            >
+              <CopyAllOutlined
+                sx={{
+                  color:
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.primary.contrastText
+                      : theme.palette.primary.main
+                }}
+              />
+            </LoadingButton>
+            {team.groupUri !== environment.SamlGroupName && (
+              <LoadingButton onClick={() => removeGroup(team.groupUri)}>
+                <HiUserRemove
+                  size={25}
+                  color={
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.primary.contrastText
+                      : theme.palette.primary.main
+                  }
+                />
+              </LoadingButton>
+            )}
+          </Box>
+        </TableCell>
+      )}
     </TableRow>
   );
 }
@@ -445,7 +448,9 @@ export const EnvironmentTeams = ({ environment }) => {
                     <TableCell>IAM Role</TableCell>
                     <TableCell>Athena WorkGroup</TableCell>
                     <TableCell>Permissions</TableCell>
-                    <TableCell>Actions</TableCell>
+                    {isFeatureEnabled('core', 'env_aws_actions') && (
+                      <TableCell>Actions</TableCell>
+                    )}
                   </TableRow>
                 </TableHead>
                 {loading ? (

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -177,38 +177,16 @@ function TeamRow({ team, environment, fetchItems }) {
           />
         )}
       </TableCell>
-      {isFeatureEnabled('core', 'env_aws_actions') && (
-        <TableCell>
-          <Box>
-            <LoadingButton
-              loading={accessingConsole}
-              onClick={() => getConsoleLink(team.groupUri)}
-            >
-              <FaIcons.FaAws
-                size={25}
-                color={
-                  theme.palette.mode === 'dark'
-                    ? theme.palette.primary.contrastText
-                    : theme.palette.primary.main
-                }
-              />
-            </LoadingButton>
-            <LoadingButton
-              loading={loadingCreds}
-              onClick={() => generateCredentials(team.groupUri)}
-            >
-              <CopyAllOutlined
-                sx={{
-                  color:
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.primary.contrastText
-                      : theme.palette.primary.main
-                }}
-              />
-            </LoadingButton>
-            {team.groupUri !== environment.SamlGroupName && (
-              <LoadingButton onClick={() => removeGroup(team.groupUri)}>
-                <HiUserRemove
+
+      <TableCell>
+        <Box>
+          {isFeatureEnabled('core', 'env_aws_actions') && (
+            <>
+              <LoadingButton
+                loading={accessingConsole}
+                onClick={() => getConsoleLink(team.groupUri)}
+              >
+                <FaIcons.FaAws
                   size={25}
                   color={
                     theme.palette.mode === 'dark'
@@ -217,10 +195,35 @@ function TeamRow({ team, environment, fetchItems }) {
                   }
                 />
               </LoadingButton>
-            )}
-          </Box>
-        </TableCell>
-      )}
+              <LoadingButton
+                loading={loadingCreds}
+                onClick={() => generateCredentials(team.groupUri)}
+              >
+                <CopyAllOutlined
+                  sx={{
+                    color:
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.primary.contrastText
+                        : theme.palette.primary.main
+                  }}
+                />
+              </LoadingButton>
+            </>
+          )}
+          {team.groupUri !== environment.SamlGroupName && (
+            <LoadingButton onClick={() => removeGroup(team.groupUri)}>
+              <HiUserRemove
+                size={25}
+                color={
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.primary.contrastText
+                    : theme.palette.primary.main
+                }
+              />
+            </LoadingButton>
+          )}
+        </Box>
+      </TableCell>
     </TableRow>
   );
 }
@@ -448,9 +451,7 @@ export const EnvironmentTeams = ({ environment }) => {
                     <TableCell>IAM Role</TableCell>
                     <TableCell>Athena WorkGroup</TableCell>
                     <TableCell>Permissions</TableCell>
-                    {isFeatureEnabled('core', 'env_aws_actions') && (
-                      <TableCell>Actions</TableCell>
-                    )}
+                    <TableCell>Actions</TableCell>
                   </TableRow>
                 </TableHead>
                 {loading ? (

--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -51,7 +51,12 @@ import {
   getPivotRolePresignedUrl,
   getCDKExecPolicyPresignedUrl
 } from '../services';
-import { AwsRegions, isFeatureEnabled } from 'utils';
+import {
+  AwsRegions,
+  isAnyFeatureModuleEnabled,
+  isModuleEnabled,
+  ModuleNames
+} from 'utils';
 
 const EnvironmentCreateForm = (props) => {
   const dispatch = useDispatch();
@@ -599,135 +604,143 @@ const EnvironmentCreateForm = (props) => {
                         </CardContent>
                       </Card>
                       <Box sx={{ mt: 3 }}>
-                        {isFeatureEnabled('core', 'env_feature_management') && (
+                        {isAnyFeatureModuleEnabled() && (
                           <Card>
                             <CardHeader title="Features management" />
                             <CardContent>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="dashboardsEnabled"
-                                        value={values.dashboardsEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        Dashboards{' '}
-                                        <small>
-                                          (Requires Amazon QuickSight Enterprise
-                                          Subscription)
-                                        </small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.dashboardsEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="notebooksEnabled"
-                                        value={values.notebooksEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Box>
+                              {isModuleEnabled(ModuleNames.DASHBOARDS) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="dashboardsEnabled"
+                                          value={values.dashboardsEnabled}
+                                        />
+                                      }
+                                      label={
                                         <Typography
                                           color="textSecondary"
                                           gutterBottom
                                           variant="subtitle2"
                                         >
-                                          Notebooks{' '}
+                                          Dashboards{' '}
                                           <small>
-                                            (Requires Amazon Sagemaker notebook
-                                            instances)
+                                            (Requires Amazon QuickSight
+                                            Enterprise Subscription)
                                           </small>
                                         </Typography>
-                                      </Box>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.notebooksEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="mlStudiosEnabled"
-                                        value={values.mlStudiosEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        ML Studio{' '}
-                                        <small>
-                                          (Requires Amazon Sagemaker Studio)
-                                        </small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="pipelinesEnabled"
-                                        value={values.pipelinesEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        Pipelines{' '}
-                                        <small>(Requires AWS DevTools)</small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.pipelinesEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.dashboardsEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.NOTEBOOKS) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="notebooksEnabled"
+                                          value={values.notebooksEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Box>
+                                          <Typography
+                                            color="textSecondary"
+                                            gutterBottom
+                                            variant="subtitle2"
+                                          >
+                                            Notebooks{' '}
+                                            <small>
+                                              (Requires Amazon Sagemaker
+                                              notebook instances)
+                                            </small>
+                                          </Typography>
+                                        </Box>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.notebooksEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.MLSTUDIO) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="mlStudiosEnabled"
+                                          value={values.mlStudiosEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          ML Studio{' '}
+                                          <small>
+                                            (Requires Amazon Sagemaker Studio)
+                                          </small>
+                                        </Typography>
+                                      }
+                                      labelPlacement="end"
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.PIPELINES) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="pipelinesEnabled"
+                                          value={values.pipelinesEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          Pipelines{' '}
+                                          <small>(Requires AWS DevTools)</small>
+                                        </Typography>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.pipelinesEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
                             </CardContent>
                           </Card>
                         )}

--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -51,7 +51,7 @@ import {
   getPivotRolePresignedUrl,
   getCDKExecPolicyPresignedUrl
 } from '../services';
-import { AwsRegions } from 'utils';
+import { AwsRegions, isFeatureEnabled } from 'utils';
 
 const EnvironmentCreateForm = (props) => {
   const dispatch = useDispatch();
@@ -599,136 +599,138 @@ const EnvironmentCreateForm = (props) => {
                         </CardContent>
                       </Card>
                       <Box sx={{ mt: 3 }}>
-                        <Card>
-                          <CardHeader title="Features management" />
-                          <CardContent>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="dashboardsEnabled"
-                                      value={values.dashboardsEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      Dashboards{' '}
-                                      <small>
-                                        (Requires Amazon QuickSight Enterprise
-                                        Subscription)
-                                      </small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.dashboardsEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="notebooksEnabled"
-                                      value={values.notebooksEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Box>
+                        {isFeatureEnabled('core', 'env_feature_management') && (
+                          <Card>
+                            <CardHeader title="Features management" />
+                            <CardContent>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="dashboardsEnabled"
+                                        value={values.dashboardsEnabled}
+                                      />
+                                    }
+                                    label={
                                       <Typography
                                         color="textSecondary"
                                         gutterBottom
                                         variant="subtitle2"
                                       >
-                                        Notebooks{' '}
+                                        Dashboards{' '}
                                         <small>
-                                          (Requires Amazon Sagemaker notebook
-                                          instances)
+                                          (Requires Amazon QuickSight Enterprise
+                                          Subscription)
                                         </small>
                                       </Typography>
-                                    </Box>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.notebooksEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="mlStudiosEnabled"
-                                      value={values.mlStudiosEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      ML Studio{' '}
-                                      <small>
-                                        (Requires Amazon Sagemaker Studio)
-                                      </small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="pipelinesEnabled"
-                                      value={values.pipelinesEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      Pipelines{' '}
-                                      <small>(Requires AWS DevTools)</small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.pipelinesEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                          </CardContent>
-                        </Card>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.dashboardsEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="notebooksEnabled"
+                                        value={values.notebooksEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Box>
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          Notebooks{' '}
+                                          <small>
+                                            (Requires Amazon Sagemaker notebook
+                                            instances)
+                                          </small>
+                                        </Typography>
+                                      </Box>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.notebooksEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="mlStudiosEnabled"
+                                        value={values.mlStudiosEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Typography
+                                        color="textSecondary"
+                                        gutterBottom
+                                        variant="subtitle2"
+                                      >
+                                        ML Studio{' '}
+                                        <small>
+                                          (Requires Amazon Sagemaker Studio)
+                                        </small>
+                                      </Typography>
+                                    }
+                                    labelPlacement="end"
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="pipelinesEnabled"
+                                        value={values.pipelinesEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Typography
+                                        color="textSecondary"
+                                        gutterBottom
+                                        variant="subtitle2"
+                                      >
+                                        Pipelines{' '}
+                                        <small>(Requires AWS DevTools)</small>
+                                      </Typography>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.pipelinesEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                            </CardContent>
+                          </Card>
+                        )}
                       </Box>
                     </Grid>
                     <Grid item lg={7} md={6} xs={12}>

--- a/frontend/src/modules/Environments/views/EnvironmentEditForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentEditForm.js
@@ -32,6 +32,7 @@ import {
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { useClient } from 'services';
 import { getEnvironment, updateEnvironment } from '../services';
+import { isFeatureEnabled } from 'utils';
 
 const EnvironmentEditForm = (props) => {
   const dispatch = useDispatch();
@@ -378,139 +379,143 @@ const EnvironmentEditForm = (props) => {
                           </CardContent>
                         </Card>
                       </Box>
-                      <Box sx={{ mt: 3 }}>
-                        <Card>
-                          <CardHeader title="Features management" />
-                          <CardContent>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked={values.dashboardsEnabled}
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="dashboardsEnabled"
-                                      value={values.dashboardsEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      Dashboards{' '}
-                                      <small>
-                                        (Requires Amazon QuickSight Enterprise
-                                        Subscription)
-                                      </small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.dashboardsEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked={values.notebooksEnabled}
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="notebooksEnabled"
-                                      value={values.notebooksEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Box>
+                      {isFeatureEnabled('core', 'env_feature_management') && (
+                        <Box sx={{ mt: 3 }}>
+                          <Card>
+                            <CardHeader title="Features management" />
+                            <CardContent>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked={
+                                          values.dashboardsEnabled
+                                        }
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="dashboardsEnabled"
+                                        value={values.dashboardsEnabled}
+                                      />
+                                    }
+                                    label={
                                       <Typography
                                         color="textSecondary"
                                         gutterBottom
                                         variant="subtitle2"
                                       >
-                                        Notebooks{' '}
+                                        Dashboards{' '}
                                         <small>
-                                          (Requires Amazon Sagemaker notebook
-                                          instances)
+                                          (Requires Amazon QuickSight Enterprise
+                                          Subscription)
                                         </small>
                                       </Typography>
-                                    </Box>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.notebooksEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked={values.mlStudiosEnabled}
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="mlStudiosEnabled"
-                                      value={values.mlStudiosEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      ML Studio{' '}
-                                      <small>
-                                        (Requires Amazon Sagemaker Studio)
-                                      </small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.mlStudiosEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                            <Box sx={{ ml: 2 }}>
-                              <FormGroup>
-                                <FormControlLabel
-                                  color="primary"
-                                  control={
-                                    <Switch
-                                      defaultChecked={values.pipelinesEnabled}
-                                      color="primary"
-                                      onChange={handleChange}
-                                      edge="start"
-                                      name="pipelinesEnabled"
-                                      value={values.pipelinesEnabled}
-                                    />
-                                  }
-                                  label={
-                                    <Typography
-                                      color="textSecondary"
-                                      gutterBottom
-                                      variant="subtitle2"
-                                    >
-                                      Pipelines{' '}
-                                      <small>(Requires AWS DevTools)</small>
-                                    </Typography>
-                                  }
-                                  labelPlacement="end"
-                                  value={values.pipelinesEnabled}
-                                />
-                              </FormGroup>
-                            </Box>
-                          </CardContent>
-                        </Card>
-                      </Box>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.dashboardsEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked={values.notebooksEnabled}
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="notebooksEnabled"
+                                        value={values.notebooksEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Box>
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          Notebooks{' '}
+                                          <small>
+                                            (Requires Amazon Sagemaker notebook
+                                            instances)
+                                          </small>
+                                        </Typography>
+                                      </Box>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.notebooksEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked={values.mlStudiosEnabled}
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="mlStudiosEnabled"
+                                        value={values.mlStudiosEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Typography
+                                        color="textSecondary"
+                                        gutterBottom
+                                        variant="subtitle2"
+                                      >
+                                        ML Studio{' '}
+                                        <small>
+                                          (Requires Amazon Sagemaker Studio)
+                                        </small>
+                                      </Typography>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.mlStudiosEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                              <Box sx={{ ml: 2 }}>
+                                <FormGroup>
+                                  <FormControlLabel
+                                    color="primary"
+                                    control={
+                                      <Switch
+                                        defaultChecked={values.pipelinesEnabled}
+                                        color="primary"
+                                        onChange={handleChange}
+                                        edge="start"
+                                        name="pipelinesEnabled"
+                                        value={values.pipelinesEnabled}
+                                      />
+                                    }
+                                    label={
+                                      <Typography
+                                        color="textSecondary"
+                                        gutterBottom
+                                        variant="subtitle2"
+                                      >
+                                        Pipelines{' '}
+                                        <small>(Requires AWS DevTools)</small>
+                                      </Typography>
+                                    }
+                                    labelPlacement="end"
+                                    value={values.pipelinesEnabled}
+                                  />
+                                </FormGroup>
+                              </Box>
+                            </CardContent>
+                          </Card>
+                        </Box>
+                      )}
 
                       {errors.submit && (
                         <Box sx={{ mt: 3 }}>

--- a/frontend/src/modules/Environments/views/EnvironmentEditForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentEditForm.js
@@ -32,7 +32,7 @@ import {
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { useClient } from 'services';
 import { getEnvironment, updateEnvironment } from '../services';
-import { isFeatureEnabled } from 'utils';
+import { isAnyFeatureModuleEnabled, isModuleEnabled, ModuleNames } from 'utils';
 
 const EnvironmentEditForm = (props) => {
   const dispatch = useDispatch();
@@ -379,144 +379,158 @@ const EnvironmentEditForm = (props) => {
                           </CardContent>
                         </Card>
                       </Box>
-                      {isFeatureEnabled('core', 'env_feature_management') && (
+                      {isAnyFeatureModuleEnabled() && (
                         <Box sx={{ mt: 3 }}>
                           <Card>
                             <CardHeader title="Features management" />
+
                             <CardContent>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked={
-                                          values.dashboardsEnabled
-                                        }
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="dashboardsEnabled"
-                                        value={values.dashboardsEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        Dashboards{' '}
-                                        <small>
-                                          (Requires Amazon QuickSight Enterprise
-                                          Subscription)
-                                        </small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.dashboardsEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked={values.notebooksEnabled}
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="notebooksEnabled"
-                                        value={values.notebooksEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Box>
+                              {isModuleEnabled(ModuleNames.DASHBOARDS) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked={
+                                            values.dashboardsEnabled
+                                          }
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="dashboardsEnabled"
+                                          value={values.dashboardsEnabled}
+                                        />
+                                      }
+                                      label={
                                         <Typography
                                           color="textSecondary"
                                           gutterBottom
                                           variant="subtitle2"
                                         >
-                                          Notebooks{' '}
+                                          Dashboards{' '}
                                           <small>
-                                            (Requires Amazon Sagemaker notebook
-                                            instances)
+                                            (Requires Amazon QuickSight
+                                            Enterprise Subscription)
                                           </small>
                                         </Typography>
-                                      </Box>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.notebooksEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked={values.mlStudiosEnabled}
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="mlStudiosEnabled"
-                                        value={values.mlStudiosEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        ML Studio{' '}
-                                        <small>
-                                          (Requires Amazon Sagemaker Studio)
-                                        </small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.mlStudiosEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
-                              <Box sx={{ ml: 2 }}>
-                                <FormGroup>
-                                  <FormControlLabel
-                                    color="primary"
-                                    control={
-                                      <Switch
-                                        defaultChecked={values.pipelinesEnabled}
-                                        color="primary"
-                                        onChange={handleChange}
-                                        edge="start"
-                                        name="pipelinesEnabled"
-                                        value={values.pipelinesEnabled}
-                                      />
-                                    }
-                                    label={
-                                      <Typography
-                                        color="textSecondary"
-                                        gutterBottom
-                                        variant="subtitle2"
-                                      >
-                                        Pipelines{' '}
-                                        <small>(Requires AWS DevTools)</small>
-                                      </Typography>
-                                    }
-                                    labelPlacement="end"
-                                    value={values.pipelinesEnabled}
-                                  />
-                                </FormGroup>
-                              </Box>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.dashboardsEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.NOTEBOOKS) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked={
+                                            values.notebooksEnabled
+                                          }
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="notebooksEnabled"
+                                          value={values.notebooksEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Box>
+                                          <Typography
+                                            color="textSecondary"
+                                            gutterBottom
+                                            variant="subtitle2"
+                                          >
+                                            Notebooks{' '}
+                                            <small>
+                                              (Requires Amazon Sagemaker
+                                              notebook instances)
+                                            </small>
+                                          </Typography>
+                                        </Box>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.notebooksEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.MLSTUDIO) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked={
+                                            values.mlStudiosEnabled
+                                          }
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="mlStudiosEnabled"
+                                          value={values.mlStudiosEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          ML Studio{' '}
+                                          <small>
+                                            (Requires Amazon Sagemaker Studio)
+                                          </small>
+                                        </Typography>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.mlStudiosEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
+                              {isModuleEnabled(ModuleNames.PIPELINES) && (
+                                <Box sx={{ ml: 2 }}>
+                                  <FormGroup>
+                                    <FormControlLabel
+                                      color="primary"
+                                      control={
+                                        <Switch
+                                          defaultChecked={
+                                            values.pipelinesEnabled
+                                          }
+                                          color="primary"
+                                          onChange={handleChange}
+                                          edge="start"
+                                          name="pipelinesEnabled"
+                                          value={values.pipelinesEnabled}
+                                        />
+                                      }
+                                      label={
+                                        <Typography
+                                          color="textSecondary"
+                                          gutterBottom
+                                          variant="subtitle2"
+                                        >
+                                          Pipelines{' '}
+                                          <small>(Requires AWS DevTools)</small>
+                                        </Typography>
+                                      }
+                                      labelPlacement="end"
+                                      value={values.pipelinesEnabled}
+                                    />
+                                  </FormGroup>
+                                </Box>
+                              )}
                             </CardContent>
                           </Card>
                         </Box>
                       )}
-
                       {errors.submit && (
                         <Box sx={{ mt: 3 }}>
                           <FormHelperText error>{errors.submit}</FormHelperText>

--- a/frontend/src/modules/Folders/views/FolderView.js
+++ b/frontend/src/modules/Folders/views/FolderView.js
@@ -38,6 +38,7 @@ import { getDatasetStorageLocation } from '../services';
 
 import { FeedComments } from 'modules/Shared';
 import { FolderOverview } from '../components';
+import { isFeatureEnabled } from 'utils';
 
 const tabs = [{ label: 'Overview', value: 'overview' }];
 
@@ -123,16 +124,18 @@ function FolderPageHeader(props) {
               Chat
             </Button>
           )}
-          <LoadingButton
-            loading={isLoadingUI}
-            startIcon={<FaExternalLinkAlt size={15} />}
-            variant="outlined"
-            color="primary"
-            sx={{ m: 1 }}
-            onClick={goToS3Console}
-          >
-            S3 Bucket
-          </LoadingButton>
+          {isFeatureEnabled('datasets', 'aws_actions') && (
+            <LoadingButton
+              loading={isLoadingUI}
+              startIcon={<FaExternalLinkAlt size={15} />}
+              variant="outlined"
+              color="primary"
+              sx={{ m: 1 }}
+              onClick={goToS3Console}
+            >
+              S3 Bucket
+            </LoadingButton>
+          )}
           {isAdmin && (
             <Button
               color="primary"

--- a/frontend/src/modules/Tables/views/TableView.js
+++ b/frontend/src/modules/Tables/views/TableView.js
@@ -36,13 +36,19 @@ import {
   TableOverview,
   TablePreview
 } from '../components';
+import { isFeatureEnabled } from 'utils';
+
+const previewDataEnabled = isFeatureEnabled('datasets', 'preview_data');
 
 const tabs = [
-  { label: 'Preview', value: 'preview' },
   { label: 'Overview', value: 'overview' },
   { label: 'Columns', value: 'columns' },
   { label: 'Metrics', value: 'metrics' }
 ];
+
+if (previewDataEnabled) {
+  tabs.unshift({ label: 'Preview', value: 'preview' });
+}
 
 function TablePageHeader(props) {
   const { table, handleDeleteObjectModalOpen, isAdmin } = props;
@@ -256,7 +262,9 @@ const TableView = () => {
           </Box>
           <Divider />
           <Box sx={{ mt: 3 }}>
-            {currentTab === 'preview' && <TablePreview table={table} />}
+            {previewDataEnabled && currentTab === 'preview' && (
+              <TablePreview table={table} />
+            )}
             {currentTab === 'overview' && (
               <TableOverview table={table} isAdmin={isAdmin} />
             )}

--- a/frontend/src/modules/Tables/views/TableView.js
+++ b/frontend/src/modules/Tables/views/TableView.js
@@ -163,7 +163,7 @@ const TableView = () => {
   const client = useClient();
   const navigate = useNavigate();
   const [table, setTable] = useState({});
-  const [currentTab, setCurrentTab] = useState('preview');
+  const [currentTab, setCurrentTab] = useState(tabs[0].value);
   const [loading, setLoading] = useState(true);
   const [isDeleteObjectModalOpen, setIsDeleteObjectModalOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);

--- a/frontend/src/utils/helpers/moduleUtils.js
+++ b/frontend/src/utils/helpers/moduleUtils.js
@@ -44,4 +44,21 @@ function getModuleActiveStatus(moduleKey) {
   return false;
 }
 
-export { ModuleNames, isModuleEnabled };
+function isFeatureEnabled(moduleKey, featureKey) {
+  if (
+    moduleKey === 'core' &&
+    config.core.features !== undefined &&
+    config.core.features[featureKey] !== undefined
+  ) {
+    return config.core.features[featureKey];
+  } else if (
+    getModuleActiveStatus(moduleKey) &&
+    config.modules[moduleKey]['features'] !== undefined &&
+    config.modules[moduleKey]['features'][featureKey] !== undefined
+  ) {
+    return config.modules[moduleKey]['features'][featureKey];
+  }
+  return false;
+}
+
+export { ModuleNames, isModuleEnabled, isFeatureEnabled };

--- a/frontend/src/utils/helpers/moduleUtils.js
+++ b/frontend/src/utils/helpers/moduleUtils.js
@@ -33,16 +33,13 @@ function isModuleEnabled(module) {
   return getModuleActiveStatus(module);
 }
 
-function isAnyFeatureModuleEnabled(modules) {
-  if (
+function isAnyFeatureModuleEnabled() {
+  return !!(
     isModuleEnabled(ModuleNames.PIPELINES) ||
     isModuleEnabled(ModuleNames.DASHBOARDS) ||
     isModuleEnabled(ModuleNames.MLSTUDIO) ||
     isModuleEnabled(ModuleNames.NOTEBOOKS)
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 function getModuleActiveStatus(moduleKey) {

--- a/frontend/src/utils/helpers/moduleUtils.js
+++ b/frontend/src/utils/helpers/moduleUtils.js
@@ -33,6 +33,18 @@ function isModuleEnabled(module) {
   return getModuleActiveStatus(module);
 }
 
+function isAnyFeatureModuleEnabled(modules) {
+  if (
+    isModuleEnabled(ModuleNames.PIPELINES) ||
+    isModuleEnabled(ModuleNames.DASHBOARDS) ||
+    isModuleEnabled(ModuleNames.MLSTUDIO) ||
+    isModuleEnabled(ModuleNames.NOTEBOOKS)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function getModuleActiveStatus(moduleKey) {
   if (
     config.modules &&
@@ -61,4 +73,9 @@ function isFeatureEnabled(moduleKey, featureKey) {
   return false;
 }
 
-export { ModuleNames, isModuleEnabled, isFeatureEnabled };
+export {
+  ModuleNames,
+  isModuleEnabled,
+  isAnyFeatureModuleEnabled,
+  isFeatureEnabled
+};

--- a/tests/modules/datasets/test_dataset.py
+++ b/tests/modules/datasets/test_dataset.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dataall.base.config import config
 from dataall.core.environment.db.environment_models import Environment
 from dataall.core.organizations.db.organization_models import Organization
 from dataall.modules.datasets_base.db.dataset_repositories import DatasetRepository
@@ -152,7 +153,7 @@ def test_update_dataset(dataset1, client, group, group2, module_mocker):
     assert response.data.updateDataset.stewards == dataset1.SamlAdminGroupName
     assert response.data.updateDataset.confidentiality == 'Official'
 
-
+@pytest.mark.skipif(not config.get_property("modules.datasets.features.glue_crawler"), reason="Feature Disabled by Config")
 def test_start_crawler(org_fixture, env_fixture, dataset1, client, group, module_mocker):
     module_mocker.patch(
         'dataall.modules.datasets.services.dataset_service.DatasetCrawler', MagicMock()


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Adding frontend support for all feature flags defined in config.json with a new util method isFeatureEnabled
- Adding a new flag **preview_data** in the datasets module to control whether previewing data is allowed
- Adding a new flag **glue_crawler** in the datasets module to control whether running glue crawler is allowed
- Updating environment features to be hidden or visible based on whether the module is active. Adding a new util isAnyFeatureModuleEnabled to check whether to render the entire feature box.

### Relates
N/A

### Security
Not relevant

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
