### PR TITLE
fix: adding missing pivot role permission to get key policy

### DIFF
--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -87,6 +87,7 @@ Resources:
               - 'kms:Decrypt'
               - 'kms:Encrypt'
               - 'kms:GenerateDataKey*'
+              - 'kms:GetKeyPolicy'
               - 'kms:PutKeyPolicy'
               - 'kms:ReEncrypt*'
               - 'kms:TagResource'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- getKeyPolicy permission is required by share manager. I'm not sure if it is required in 2.0 but it is definitely required for S3 bucket policy sharing. Though I suspect it should be needed for OS version to as for access points to work pivotRole needs to update KMS key policy right? Without this permission sharing manager fails to get the policy and fails. The only workaround is if you manually add the pivotRole to the KMS key policy.

### Relates
N/A

### Security
This change expands the pivot role with a new permission to get key policy. This is still following least permission principle.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
