### PR TITLE
Isssue 849 - Add the cloudformation:ContinueUpdateRollback permission to the pivotRole, for administration of linked environment accounts.

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_core_policies/cloudformation.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_core_policies/cloudformation.py
@@ -17,7 +17,8 @@ class CloudformationPivotRole(PivotRoleStatementSet):
                     "cloudformation:DeleteStack",
                     "cloudformation:DescribeStacks",
                     "cloudformation:DescribeStackEvents",
-                    "cloudformation:DescribeStackResources"
+                    "cloudformation:DescribeStackResources",
+                    "cloudformation:ContinueUpdateRollback"
                 ],
                 resources=[
                     f'arn:aws:cloudformation:*:{self.account}:stack/{self.env_resource_prefix}*/*',

--- a/deploy/pivot_role/pivotRole.yaml
+++ b/deploy/pivot_role/pivotRole.yaml
@@ -320,6 +320,7 @@ Resources:
               - 'cloudformation:DescribeStackResources'
               - 'cloudformation:DescribeStackEvents'
               - 'cloudformation:DeleteStack'
+              - 'cloudformation:ContinueUpdateRollback'
             Resource:
               - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/${EnvironmentResourcePrefix}*/*'
               - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/CDKToolkit/*'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Adds the cloudformation:ContinueUpdateRollback permission to the pivotRole.  This makes it possible for an admin of the central infra account, who assumes the pivotRole of a linked environment, to help get a user's environment out of a bad state where an Update Rollback might have failed.  An administrator can iterate through all linked environments and trigger the Continue Update Rollback if many environment accounts have somehow gotten into the Update Rollback Failed state.

### Relates
https://github.com/awslabs/aws-dataall/issues/849

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?  No
  - Is the input sanitized?  N/A
  - What precautions are you taking before deserializing the data you consume?  N/A
  - Is injection prevented by parametrizing queries?  N/A
  - Have you ensured no `eval` or similar functions are used?  N/A
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?  N/A
  - Are you logging failed auth attempts?  N/A
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations?  N/A
  - Are the used keys controlled by the customer? Where are they stored?  N/A
- Are you introducing any new policies/roles/users?  The PR adds the cloudformation:ContinueUpdateRollback permission to the pivotRole.
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
