### PR TITLE
Add GenerateEmbedUrlForRegisteredUser for QS Reader sessions

### DIFF
--- a/backend/dataall/modules/dashboards/cdk/pivot_role_dashboards_policy.py
+++ b/backend/dataall/modules/dashboards/cdk/pivot_role_dashboards_policy.py
@@ -23,6 +23,7 @@ class DashboardsPivotRole(PivotRoleStatementSet):
                     'quicksight:SearchDashboards',
                     'quicksight:GetDashboardEmbedUrl',
                     'quicksight:GenerateEmbedUrlForAnonymousUser',
+                    'quicksight:GenerateEmbedUrlForRegisteredUser',
                     'quicksight:UpdateUser',
                     'quicksight:ListUserGroups',
                     'quicksight:RegisterUser',


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Missing QS Permission for QS Dashboard Reader Sessions in data.all
  - Exists in PivotRole.yaml but not for auto-created cdk pivotRole (pivotRole-cdk)


### Security
N/A

Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
