### PR TITLE
Fix SES Stack Permissions and Email Sender Id

### DIFF
--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -141,7 +141,7 @@ class BackendStack(Stack):
             self, 'ECRREPO', repository_arn=ecr_repository
         )
         if None not in [custom_domain, ses_stack]:
-            email_sender = custom_domain.get('email_notification_sender_email_id', None) if custom_domain.get('email_notification_sender_email_id', None) != None else f'noreply@{custom_domain.get("hosted_zone_name")}'
+            email_sender = custom_domain.get('email_notification_sender_email_id', "noreply") + "@" + custom_domain.get("hosted_zone_name")
         else:
             email_sender = 'none'
 

--- a/deploy/stacks/ses_stack.py
+++ b/deploy/stacks/ses_stack.py
@@ -22,13 +22,32 @@ class SesStack(pyNestedClass):
             **kwargs,
     ):
         super().__init__(scope, id,  **kwargs)
-
+        configuration_set_name = f"{resource_prefix}-{envname}-ses-configuration-set"
         self.KMS_SNS = kms.Key(
             self,
             f'{resource_prefix}-{envname}-SNS-key',
             removal_policy=RemovalPolicy.DESTROY,
             alias=f'{resource_prefix}-{envname}-SNS-key',
-            enable_key_rotation=True
+            enable_key_rotation=True,
+        )
+
+        self.KMS_SNS.add_to_resource_policy(
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "kms:Decrypt",
+                    "kms:GenerateDataKey*"
+                ],
+                principals=[
+                    iam.ServicePrincipal('ses.amazonaws.com')
+                ],
+                resources=['*'],
+                conditions={
+                    "StringLike": {
+                        "aws:SourceArn": f"arn:aws:ses:{self.region}:{self.account}:configuration-set/{configuration_set_name}"
+                    }
+                }
+            )
         )
 
         self.sns = sns.Topic(
@@ -44,6 +63,7 @@ class SesStack(pyNestedClass):
         self.configuration_set = ses.ConfigurationSet(
             self,
             f'{resource_prefix}-{envname}-SES-Configuration-Set',
+            configuration_set_name=configuration_set_name,
             tls_policy=ses.ConfigurationSetTlsPolicy.REQUIRE
         )
 
@@ -54,25 +74,6 @@ class SesStack(pyNestedClass):
         )
 
         self.configuration_set.apply_removal_policy(RemovalPolicy.DESTROY)
-
-        self.KMS_SNS.add_to_resource_policy(
-            iam.PolicyStatement(
-                effect=iam.Effect.ALLOW,
-                actions=[
-                    "kms:Decrypt",
-                    "kms:GenerateDataKey*"
-                ],
-                principals=[
-                    iam.AccountPrincipal(self.account)
-                ],
-                resources=['*'],
-                conditions={
-                    "StringLike": {
-                        "aws:SourceArn": f"arn:aws:ses:{self.region}:{self.account}:configuration-set/{self.configuration_set.configuration_set_name}"
-                    }
-                }
-            )
-        )
 
         hosted_zone = route53.HostedZone.from_hosted_zone_attributes(
             self,

--- a/template_cdk.json
+++ b/template_cdk.json
@@ -27,7 +27,7 @@
           "hosted_zone_name": "string_ROUTE_53_EXISTING_DOMAIN_NAME|DEFAULT=None, REQUIRED if internet_facing=false",
           "hosted_zone_id": "string_ROUTE_53_EXISTING_HOSTED_ZONE_ID|DEFAULT=None, REQUIRED if internet_facing=false",
           "certificate_arn": "string_AWS_CERTIFICATE_MANAGER_ARN|DEFAULT=None, REQUIRED if internet_facing=false",
-          "email_notification_sender_email_id": "string_EMAIL_NOTIFICATION_SENDER_EMAIL_ID|DEFAULT=None"
+          "email_notification_sender_email_id": "string_EMAIL_NOTIFICATION_SENDER_EMAIL_ID|DEFAULT=noreply"
         },
         "ip_ranges": "list_of_strings_IP_RANGES_TO_ALLOW_IF_NOT_INTERNET_FACING|DEFAULT=None",
         "apig_vpce": "string_USE_AN_EXISTING_VPCE_FOR_APIG_IF_NOT_INTERNET_FACING|DEFAULT=None",


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Add Service Principal for `ses.amazonaws.com` for SNS Topic to handle bounced emails
- Make `email_sender` defined as `email_notification_sender_id` + `custom_domain.hosted_zone` to avoid unverified email identity errors


### Security

Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
