### PR TITLE
Env features dynamic enable

### DIFF
--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -479,10 +479,10 @@ const EnvironmentCreateForm = (props) => {
                 AwsAccountId: '',
                 region: '',
                 tags: [],
-                dashboardsEnabled: true,
-                notebooksEnabled: true,
-                mlStudiosEnabled: true,
-                pipelinesEnabled: true,
+                dashboardsEnabled: isModuleEnabled(ModuleNames.DASHBOARDS),
+                notebooksEnabled: isModuleEnabled(ModuleNames.NOTEBOOKS),
+                mlStudiosEnabled: isModuleEnabled(ModuleNames.MLSTUDIO),
+                pipelinesEnabled: isModuleEnabled(ModuleNames.PIPELINES),
                 EnvironmentDefaultIAMRoleArn: '',
                 resourcePrefix: 'dataall'
               }}


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- If I disable a module (i.e. dashboards), the `modulesEnabled` environment parameter will still be set to `true` because the default value is `true`

- This PR sets the default value of the environment feature to be the true/false value of `isModuleEnabled()` so 
  - If a module is disabled the initial value is `false` and will not be editable on the frontend EnvironmentCreateForm
  - If a module is enabled the initial value is `true` and is editable on the frontend EnvironmentCreateForm


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
