### PR TITLE
Fix: ssm prefix custom cdk policy

### DIFF
--- a/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
@@ -88,14 +88,14 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             setup,
             'LakeformationDefaultSettingsCustomeResourceFunctionArn',
             string_value=lf_default_settings_custom_resource.function_arn,
-            parameter_name=f'/dataall/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/arn',
+            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/arn',
         )
 
         ssm.StringParameter(
             setup,
             'LakeformationDefaultSettingsCustomeResourceFunctionName',
             string_value=lf_default_settings_custom_resource.function_name,
-            parameter_name=f'/dataall/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/name',
+            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/name',
         )
         # Glue database custom resource
         # This Lambda is triggered with the creation of each dataset, it is not executed when the environment is created
@@ -142,21 +142,21 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             setup,
             'GlueLFCustomResourceFunctionArn',
             string_value=gluedb_lf_custom_resource.function_arn,
-            parameter_name=f'/dataall/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/arn',
+            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/arn',
         )
 
         ssm.StringParameter(
             setup,
             'GlueLFCustomResourceFunctionName',
             string_value=gluedb_lf_custom_resource.function_name,
-            parameter_name=f'/dataall/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/name',
+            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/name',
         )
 
         ssm.StringParameter(
             setup,
             'GlueLFCustomResourceProviderServiceToken',
             string_value=glue_db_provider.service_token,
-            parameter_name=f'/dataall/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
+            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
         )
 
     @staticmethod

--- a/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_custom_resources_extension.py
@@ -24,9 +24,10 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
 
     @staticmethod
     def extent(setup: EnvironmentSetup):
+        _environment = setup.environment()
         kms_key = DatasetCustomResourcesExtension.set_cr_kms_key(
             setup=setup,
-            environment=setup.environment(),
+            environment=_environment,
             group_roles=setup.group_roles,
             default_role=setup.default_role
         )
@@ -40,13 +41,13 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
 
         lakeformation_cr_dlq = DatasetCustomResourcesExtension.set_dlq(
             setup=setup,
-            queue_name=f'{setup.environment().resourcePrefix}-lfcr-{setup.environment().environmentUri}',
+            queue_name=f'{_environment.resourcePrefix}-lfcr-{_environment.environmentUri}',
             kms_key=kms_key
         )
         lf_default_settings_custom_resource = _lambda.Function(
             setup,
             'LakeformationDefaultSettingsHandler',
-            function_name=f'{setup.environment().resourcePrefix}-lf-settings-handler-{setup.environment().environmentUri}',
+            function_name=f'{_environment.resourcePrefix}-lf-settings-handler-{_environment.environmentUri}',
             role=setup.pivot_role,
             handler='index.on_event',
             code=_lambda.Code.from_asset(entry_point),
@@ -54,11 +55,11 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             description='This Lambda function is a cloudformation custom resource provider for Lakeformation default settings',
             timeout=Duration.seconds(5 * 60),
             environment={
-                'envname': setup.environment().name,
+                'envname': _environment.name,
                 'LOG_LEVEL': 'DEBUG',
-                'AWS_ACCOUNT': setup.environment().AwsAccountId,
-                'DEFAULT_ENV_ROLE_ARN': setup.environment().EnvironmentDefaultIAMRoleArn,
-                'DEFAULT_CDK_ROLE_ARN': setup.environment().CDKRoleArn,
+                'AWS_ACCOUNT': _environment.AwsAccountId,
+                'DEFAULT_ENV_ROLE_ARN': _environment.EnvironmentDefaultIAMRoleArn,
+                'DEFAULT_CDK_ROLE_ARN': _environment.CDKRoleArn,
             },
             dead_letter_queue_enabled=True,
             dead_letter_queue=lakeformation_cr_dlq,
@@ -67,18 +68,18 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
         )
         LakeformationDefaultSettingsProvider = cr.Provider(
             setup,
-            f'{setup.environment().resourcePrefix}LakeformationDefaultSettingsProvider',
+            f'{_environment.resourcePrefix}LakeformationDefaultSettingsProvider',
             on_event_handler=lf_default_settings_custom_resource,
         )
 
         default_lf_settings = CustomResource(
             setup,
-            f'{setup.environment().resourcePrefix}DefaultLakeFormationSettings',
+            f'{_environment.resourcePrefix}DefaultLakeFormationSettings',
             service_token=LakeformationDefaultSettingsProvider.service_token,
             resource_type='Custom::LakeformationDefaultSettings',
             properties={
                 'DataLakeAdmins': [
-                    f'arn:aws:iam::{setup.environment().AwsAccountId}:role/{setup.pivot_role_name}',
+                    f'arn:aws:iam::{_environment.AwsAccountId}:role/{setup.pivot_role_name}',
                 ],
                 'Version': "data.all V2"
             },
@@ -88,14 +89,14 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             setup,
             'LakeformationDefaultSettingsCustomeResourceFunctionArn',
             string_value=lf_default_settings_custom_resource.function_arn,
-            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/arn',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/cfn/lf/defaultsettings/lambda/arn',
         )
 
         ssm.StringParameter(
             setup,
             'LakeformationDefaultSettingsCustomeResourceFunctionName',
             string_value=lf_default_settings_custom_resource.function_name,
-            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/lf/defaultsettings/lambda/name',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/cfn/lf/defaultsettings/lambda/name',
         )
         # Glue database custom resource
         # This Lambda is triggered with the creation of each dataset, it is not executed when the environment is created
@@ -105,13 +106,13 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
 
         gluedb_lf_cr_dlq = DatasetCustomResourcesExtension.set_dlq(
             setup=setup,
-            queue_name=f'{setup.environment().resourcePrefix}-gluedb-lf-cr-{setup.environment().environmentUri}',
+            queue_name=f'{_environment.resourcePrefix}-gluedb-lf-cr-{_environment.environmentUri}',
             kms_key=kms_key
         )
         gluedb_lf_custom_resource = _lambda.Function(
             setup,
             'GlueDatabaseLFCustomResourceHandler',
-            function_name=f'{setup.environment().resourcePrefix}-gluedb-lf-handler-{setup.environment().environmentUri}',
+            function_name=f'{_environment.resourcePrefix}-gluedb-lf-handler-{_environment.environmentUri}',
             role=setup.pivot_role,
             handler='index.on_event',
             code=_lambda.Code.from_asset(entry_point),
@@ -120,11 +121,11 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
             'as Cfn currently does not support the CreateTableDefaultPermissions parameter',
             timeout=Duration.seconds(5 * 60),
             environment={
-                'envname': setup.environment().name,
+                'envname': _environment.name,
                 'LOG_LEVEL': 'DEBUG',
-                'AWS_ACCOUNT': setup.environment().AwsAccountId,
-                'DEFAULT_ENV_ROLE_ARN': setup.environment().EnvironmentDefaultIAMRoleArn,
-                'DEFAULT_CDK_ROLE_ARN': setup.environment().CDKRoleArn,
+                'AWS_ACCOUNT': _environment.AwsAccountId,
+                'DEFAULT_ENV_ROLE_ARN': _environment.EnvironmentDefaultIAMRoleArn,
+                'DEFAULT_CDK_ROLE_ARN': _environment.CDKRoleArn,
             },
             dead_letter_queue_enabled=True,
             dead_letter_queue=gluedb_lf_cr_dlq,
@@ -135,28 +136,28 @@ class DatasetCustomResourcesExtension(EnvironmentStackExtension):
 
         glue_db_provider = cr.Provider(
             setup,
-            f'{setup.environment().resourcePrefix}GlueDbCustomResourceProvider',
+            f'{_environment.resourcePrefix}GlueDbCustomResourceProvider',
             on_event_handler=gluedb_lf_custom_resource
         )
         ssm.StringParameter(
             setup,
             'GlueLFCustomResourceFunctionArn',
             string_value=gluedb_lf_custom_resource.function_arn,
-            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/arn',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/cfn/custom-resources/gluehandler/lambda/arn',
         )
 
         ssm.StringParameter(
             setup,
             'GlueLFCustomResourceFunctionName',
             string_value=gluedb_lf_custom_resource.function_name,
-            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/lambda/name',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/cfn/custom-resources/gluehandler/lambda/name',
         )
 
         ssm.StringParameter(
             setup,
             'GlueLFCustomResourceProviderServiceToken',
             string_value=glue_db_provider.service_token,
-            parameter_name=f'/{setup.environment().resourcePrefix}/{setup.environment().environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
         )
 
     @staticmethod

--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -432,7 +432,7 @@ class DatasetStack(Stack):
         glue_db_provider_service_token = ssm.StringParameter.from_string_parameter_name(
             self,
             'GlueDatabaseProviderServiceToken',
-            string_parameter_name=f'/dataall/{dataset.environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
+            string_parameter_name=f'/{env.resourcePrefix}/{dataset.environmentUri}/cfn/custom-resources/gluehandler/provider/servicetoken',
         )
 
         glue_db = CustomResource(

--- a/backend/dataall/modules/mlstudio/cdk/mlstudio_extension.py
+++ b/backend/dataall/modules/mlstudio/cdk/mlstudio_extension.py
@@ -196,7 +196,7 @@ class SageMakerDomainExtension(EnvironmentStackExtension):
             setup,
             'SagemakerStudioDomainId',
             string_value=sagemaker_domain.attr_domain_id,
-            parameter_name=f'/dataall/{_environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
+            parameter_name=f'/{_environment.resourcePrefix}/{_environment.environmentUri}/sagemaker/sagemakerstudio/domain_id',
         )
         return sagemaker_domain
 
@@ -210,7 +210,7 @@ class SageMakerDomainExtension(EnvironmentStackExtension):
             )
             dataall_created_domain = ParameterStoreManager.client(
                 AwsAccountId=environment.AwsAccountId, region=environment.region, role=cdk_look_up_role_arn
-            ).get_parameter(Name=f'/dataall/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id')
+            ).get_parameter(Name=f'/{environment.resourcePrefix}/{environment.environmentUri}/sagemaker/sagemakerstudio/domain_id')
             return False
         except ClientError as e:
             logger.info(f'check sagemaker studio domain created outside of data.all. Parameter data.all not found: {e}')

--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -176,6 +176,7 @@ Resources:
               - 'ssm:DeleteParameter'
             Resource:
               - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentResourcePrefix}*'
+              - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/dataall*'
               - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk*'
               - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-bootstrap/*'
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
As part of the environment stack we deploy some SSM parameters prefixed with `dataall` prefix in all cases. The custom DataallCustomCDKPolicy provided to use in the `cdk bootstrap` command restricts SSM permissions to resource-prefixed parameters. As a result, when using an environment with a resource prefix different from the default `dataall` the stack fails to create and to delete because it cannot create or delete those SSM parameters.

- The first commit adds the generic `dataall` SSM permisssions to the custom policy. It open the permissions slightly
- The second and third commits rename the SSM parameters to use the resource prefix

Each commit would solve the issue on its own, so we don't really need both. However, there are arguments to keep both. Having generic permissions to dataall-SSM parameters is restrictive and might be useful for other cases when the toolkit is used. It is good to keep all created resources prefixed with the same prefix, so that users can easily track which resources belong to a data.all environment.

The only issue is that for number 2, we need users to update the environment stacks before creating more datasets (add in release notes)

### Relates
- v2.1 release

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
