### PR TITLE
Use op.execute to alter column type in migration script

### DIFF
--- a/backend/migrations/versions/4f3c1d84a628_modify_notifications_column_types.py
+++ b/backend/migrations/versions/4f3c1d84a628_modify_notifications_column_types.py
@@ -5,6 +5,8 @@ Revises: 917b923f74bd
 Create Date: 2023-10-20 15:04:15.061516
 
 """
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -21,12 +23,8 @@ def upgrade():
     Define column "type" as: type = Column(String, nullable=True)
     Rename column " " to " " both of type String
     """
-    op.alter_column(
-        'notification',
-        'type',
-        existing_type=sa.String(),
-        nullable=True
-    )
+    envname = os.getenv('envname', 'local')
+    op.execute(f'ALTER TABLE {envname}.notification ALTER COLUMN "type" TYPE VARCHAR(100);')
     op.alter_column(
         'notification',
         'username',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In theory op.alter_table can modify column data types. But in our validation testing alembic runs into issues when those data types are more complex, like the user-define data type that we are trying to modify in the latest migration script. 
The migration seems to succeed but the data type does not change from the Enum type. The problem is that if in the future customers introduce new notification types they will receive failures when writing data to RDS.

After digging a bit, I found that other projects have faced similar issues and the way to work around it is to directly use SQL statements to modify the data type.

The migration script has been tested in AWS. I set a limit of 100 characters which is more than the double of the longest notification type at the moment.

### Relates
V2.1 release

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
