### PR TITLE
Add QS Validation on Submit Share

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -7,6 +7,7 @@ from dataall.core.permissions.db.resource_policy_repositories import ResourcePol
 from dataall.core.permissions.permission_checker import has_resource_permission
 from dataall.core.tasks.db.task_models import Task
 from dataall.base.db import utils
+from dataall.base.aws.quicksight import QuicksightClient
 from dataall.base.db.exceptions import UnauthorizedOperation
 from dataall.modules.dataset_sharing.db.enums import ShareObjectActions, ShareableType, ShareItemStatus, \
     ShareObjectStatus, PrincipalType
@@ -178,6 +179,13 @@ class ShareObjectService:
                     action='Submit Share Object',
                     message='The request is empty of pending items. Add items to share request.',
                 )
+
+            env = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
+            dashboard_enabled = EnvironmentService.get_boolean_env_param(session, env, "dashboardsEnabled")
+            if dashboard_enabled:
+                share_table_items = ShareObjectRepository.find_all_share_items(session, uri, ShareableType.Table.value)
+                if share_table_items:
+                    QuicksightClient.check_quicksight_enterprise_subscription(AwsAccountId=env.AwsAccountId)
 
             cls._run_transitions(session, share, states, ShareObjectActions.Submit)
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Add QS Validation on the requestor's environment in a share and ensure Quicksight account is set up if tables are being shared before submitting a new share request

### Relates
- [Issue #801](https://github.com/awslabs/aws-dataall/issues/801)


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
