### PR TITLE
Upgrade Athena engine version to v3

### DIFF
--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -495,7 +495,7 @@ class EnvironmentSetup(Stack):
                 requester_pays_enabled=False,
                 publish_cloud_watch_metrics_enabled=False,
                 engine_version=aws_athena.CfnWorkGroup.EngineVersionProperty(
-                    selected_engine_version='Athena engine version 2',
+                    selected_engine_version='Athena engine version 3',
                 ),
             ),
         )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
It is not a bug yet but Athena has already included he following warning at workgroup creation `Athena engine version 2 will be deprecated in the near future. You can view this information in your AWS Personal Health Dashboard. Workgroups not upgraded by the deprecation date will be upgraded to version 3 automatically.` 

To avoid future failures, we are updating the engine version selected for the creation to new workgroups in data.all to version 3.

Here is the [documentation](https://docs.aws.amazon.com/athena/latest/ug/engine-versions-reference-0003.html) of version 3 which include the breaking changes from v2. Engine version 3 was released on October 13, 2022 and as it can be verified in the Athena [release notes](https://docs.aws.amazon.com/athena/latest/ug/release-notes.html), it has been constantly improved during this year, surpassing in features athena v2.


### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). `N/A`

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
