### PR TITLE
Remove unnecessary MANAGE_ORGANIZATIONS check

### DIFF
--- a/backend/dataall/core/organizations/api/queries.py
+++ b/backend/dataall/core/organizations/api/queries.py
@@ -23,15 +23,6 @@ listOrganizations = gql.QueryField(
     test_scope='Organization',
 )
 
-listOrganizationInvitedGroups = gql.QueryField(
-    name='listOrganizationInvitedGroups',
-    type=gql.Ref('GroupSearchResult'),
-    args=[
-        gql.Argument(name='organizationUri', type=gql.NonNullableType(gql.String)),
-        gql.Argument(name='filter', type=gql.Ref('GroupFilter')),
-    ],
-    resolver=list_organization_invited_groups,
-)
 
 listOrganizationGroups = gql.QueryField(
     name='listOrganizationGroups',

--- a/backend/dataall/core/organizations/api/resolvers.py
+++ b/backend/dataall/core/organizations/api/resolvers.py
@@ -107,19 +107,6 @@ def remove_group(context: Context, source, organizationUri=None, groupUri=None):
         return organization
 
 
-def list_organization_invited_groups(
-    context: Context, source, organizationUri=None, filter=None
-):
-    if filter is None:
-        filter = {}
-    with context.engine.scoped_session() as session:
-        return Organization.paginated_organization_invited_groups(
-            session=session,
-            uri=organizationUri,
-            data=filter,
-        )
-
-
 def list_organization_groups(
     context: Context, source, organizationUri=None, filter=None
 ):

--- a/backend/dataall/core/organizations/db/organization_repositories.py
+++ b/backend/dataall/core/organizations/db/organization_repositories.py
@@ -287,45 +287,10 @@ class Organization:
         return query
 
     @staticmethod
-    @has_tenant_permission(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_permission(permissions.GET_ORGANIZATION)
     def paginated_organization_groups(session, uri, data=None) -> dict:
         return paginate(
             query=Organization.query_organization_groups(session, uri, data),
-            page=data.get('page', 1),
-            page_size=data.get('pageSize', 10),
-        ).to_dict()
-
-    @staticmethod
-    def query_organization_invited_groups(session, organization, filter) -> Query:
-        query = (
-            session.query(models.OrganizationGroup)
-            .join(
-                models.Organization,
-                models.OrganizationGroup.organizationUri == models.Organization.organizationUri,
-            )
-            .filter(
-                and_(
-                    models.Organization.organizationUri == organization.organizationUri,
-                    models.OrganizationGroup.groupUri != models.Organization.SamlGroupName,
-                )
-            )
-        )
-        if filter and filter.get('term'):
-            query = query.filter(
-                or_(
-                    models.OrganizationGroup.groupUri.ilike('%' + filter.get('term') + '%'),
-                )
-            )
-        return query
-
-    @staticmethod
-    @has_tenant_permission(permissions.MANAGE_ORGANIZATIONS)
-    @has_resource_permission(permissions.GET_ORGANIZATION)
-    def paginated_organization_invited_groups(session, uri, data=None) -> dict:
-        organization = Organization.get_organization_by_uri(session, uri)
-        return paginate(
-            query=Organization.query_organization_invited_groups(session, organization, data),
             page=data.get('page', 1),
             page_size=data.get('pageSize', 10),
         ).to_dict()

--- a/backend/dataall/core/organizations/db/organization_repositories.py
+++ b/backend/dataall/core/organizations/db/organization_repositories.py
@@ -151,7 +151,6 @@ class Organization:
         return query
 
     @staticmethod
-    @has_tenant_permission(permissions.MANAGE_ORGANIZATIONS)
     @has_resource_permission(permissions.GET_ORGANIZATION)
     def paginated_organization_environments(session, uri, data=None) -> dict:
         return paginate(

--- a/tests/core/organizations/test_organization.py
+++ b/tests/core/organizations/test_organization.py
@@ -222,25 +222,6 @@ def test_group_invitation(db, client, org1, group2, user, group3, group, env):
     assert response.data.getOrganization.userRoleInOrganization == 'Invited'
     assert response.data.getOrganization.stats.groups == 1
 
-    response = client.query(
-        """
-        query listOrganizationInvitedGroups($organizationUri: String!, $filter:GroupFilter){
-            listOrganizationInvitedGroups(organizationUri:$organizationUri, filter:$filter){
-                count
-                nodes{
-                    groupUri
-                    name
-                }
-            }
-        }
-        """,
-        username=user.username,
-        groups=[group.name, group2.name],
-        organizationUri=org1.organizationUri,
-        filter={},
-    )
-
-    assert response.data.listOrganizationInvitedGroups.count == 1
 
     response = client.query(
         """
@@ -302,26 +283,6 @@ def test_group_invitation(db, client, org1, group2, user, group3, group, env):
     )
     print(response)
     assert response.data.removeGroupFromOrganization
-
-    response = client.query(
-        """
-        query listOrganizationInvitedGroups($organizationUri: String!, $filter:GroupFilter){
-            listOrganizationInvitedGroups(organizationUri:$organizationUri, filter:$filter){
-                count
-                nodes{
-                    groupUri
-                    name
-                }
-            }
-        }
-        """,
-        username=user.username,
-        groups=[group.name, group2.name],
-        organizationUri=org1.organizationUri,
-        filter={},
-    )
-
-    assert response.data.listOrganizationInvitedGroups.count == 0
 
     response = client.query(
         """


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Remove unnecessary permission check in list environments in the organization

### Relates
- #842 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
