### PR TITLE
changed name button + title to be consistent in ui

### DIFF
--- a/frontend/src/modules/MLStudio/views/MLStudioView.js
+++ b/frontend/src/modules/MLStudio/views/MLStudioView.js
@@ -149,7 +149,7 @@ const MLStudioView = () => {
           <Grid container justifyContent="space-between" spacing={3}>
             <Grid item>
               <Typography color="textPrimary" variant="h5">
-                MLStudio User {mlstudio.label}
+                ML Studio User {mlstudio.label}
               </Typography>
               <Breadcrumbs
                 aria-label="breadcrumb"
@@ -190,7 +190,7 @@ const MLStudioView = () => {
                   type="button"
                   variant="outlined"
                 >
-                  Open JupyterLab
+                  Open ML Studio
                 </LoadingButton>
                 <Button
                   color="primary"


### PR DESCRIPTION
### Feature or Bugfix
- Feature/ UI Improvement


### Detail
- UI improvements for ML Studio. In title MLStudio was used instead of ML Studio (with a whitespace inbetween, which is used in all other places in UI)
- Button name was changed to ML Studio instead of JupyterLab. This makes sense because from a data.all user's perspective they don't know what JupyterLab is, for them this functionality is called ML Studio. 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? No
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
