### PR TITLE
Update CodeBuild images to Linux2 standard5.0

### DIFF
--- a/deploy/stacks/dbmigration.py
+++ b/deploy/stacks/dbmigration.py
@@ -141,7 +141,7 @@ class DBMigrationStack(pyNestedClass):
             id=f'DBMigrationCBProject{envname}',
             project_name=f'{resource_prefix}-{envname}-dbmigration',
             environment=codebuild.BuildEnvironment(
-                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_3,
+                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
             ),
             role=self.build_project_role,
             build_spec=codebuild.BuildSpec.from_object(

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -137,7 +137,7 @@ class PipelineStack(Stack):
                 'Synth',
                 input=source,
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                 ),
                 commands=[
                     f'aws codeartifact login --tool npm --repository {self.codeartifact.codeartifact_npm_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',
@@ -430,7 +430,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='ValidateDBMigrations',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     commands=[
                         f'aws codeartifact login --tool pip --repository {self.codeartifact.codeartifact_pip_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',
@@ -447,7 +447,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='SecurityChecks',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     commands=[
                         f'aws codeartifact login --tool pip --repository {self.codeartifact.codeartifact_pip_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',
@@ -462,7 +462,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='Lint',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     commands=[
                         f'aws codeartifact login --tool pip --repository {self.codeartifact.codeartifact_pip_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',
@@ -484,7 +484,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='IntegrationTests',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     partial_build_spec=codebuild.BuildSpec.from_object(
                         dict(
@@ -518,7 +518,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='UploadCodeToS3',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     commands=[
                         'mkdir -p source_build',
@@ -538,7 +538,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='UploadCodeToS3',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     ),
                     commands=[
                         'mkdir -p source_build',
@@ -576,7 +576,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='LambdaImage',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     privileged=True,
                     environment_variables={
                         'REPOSITORY_URI': codebuild.BuildEnvironmentVariable(
@@ -594,7 +594,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='ECSImage',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     privileged=True,
                     environment_variables={
                         'REPOSITORY_URI': codebuild.BuildEnvironmentVariable(
@@ -660,7 +660,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='MigrateDB',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                 ),
                 commands=[
                     'mkdir ~/.aws/ && touch ~/.aws/config',
@@ -690,7 +690,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='StacksUpdater',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                 ),
                 commands=[
                     'mkdir ~/.aws/ && touch ~/.aws/config',
@@ -730,7 +730,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='DeployFrontEnd',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                     compute_type=codebuild.ComputeType.LARGE,
                 ),
                 commands=[
@@ -781,7 +781,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='UpdateDocumentation',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                 ),
                 commands=[
                     f'aws codeartifact login --tool pip --repository {self.codeartifact.codeartifact_pip_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',
@@ -806,7 +806,7 @@ class PipelineStack(Stack):
         return pipelines.CodeBuildStep(
             id='ConfigureRUM',
             build_environment=codebuild.BuildEnvironment(
-                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
             ),
             commands=[
                 f'export envname={target_env["envname"]}',
@@ -832,7 +832,7 @@ class PipelineStack(Stack):
         return pipelines.CodeBuildStep(
             id='ConfigureCognito',
             build_environment=codebuild.BuildEnvironment(
-                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
             ),
             commands=[
                 f'export envname={target_env["envname"]}',
@@ -875,7 +875,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='FrontendImage',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                         compute_type=codebuild.ComputeType.LARGE,
                         privileged=True,
                         environment_variables={
@@ -915,7 +915,7 @@ class PipelineStack(Stack):
                 pipelines.CodeBuildStep(
                     id='UserGuideImage',
                     build_environment=codebuild.BuildEnvironment(
-                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                        build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                         compute_type=codebuild.ComputeType.LARGE,
                         privileged=True,
                         environment_variables={
@@ -961,7 +961,7 @@ class PipelineStack(Stack):
             pipelines.CodeBuildStep(
                 id='GitRelease',
                 build_environment=codebuild.BuildEnvironment(
-                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+                    build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
                 ),
                 partial_build_spec=codebuild.BuildSpec.from_object(
                     dict(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
[Amazon Linux 2 x86_64 standard:4.0 use node16 ](https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html)which is already deprecated. In this PR we update the CodeBuild images to use Amazon Linux 2 x86_64 standard:5.0 instead

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). N/A

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
