### PR TITLE
Add Pagination to Return Full List Cognito Groups

### DIFF
--- a/backend/dataall/base/aws/cognito.py
+++ b/backend/dataall/base/aws/cognito.py
@@ -50,8 +50,7 @@ class Cognito(IdentityProvider):
             paginator = cognito.get_paginator('list_groups')
             pages = paginator.paginate(UserPoolId=user_pool_id)
             for page in pages:
-                group_names = [gr['GroupName'] for gr in page['Groups']]
-                groups += group_names
+                groups += [gr['GroupName'] for gr in page['Groups']]
         except Exception as e:
             log.error(
                 f'Failed to list groups of user pool {user_pool_id} due to {e}'

--- a/backend/dataall/base/aws/cognito.py
+++ b/backend/dataall/base/aws/cognito.py
@@ -18,7 +18,14 @@ class Cognito(IdentityProvider):
             parameter_path = f'/dataall/{envname}/cognito/userpool'
             ssm = boto3.client('ssm', region_name=os.getenv('AWS_REGION', 'eu-west-1'))
             user_pool_id = ssm.get_parameter(Name=parameter_path)['Parameter']['Value']
-            cognito_user_list = self.client.list_users_in_group(UserPoolId=user_pool_id, GroupName=groupName)["Users"]
+            paginator = self.client.get_paginator('list_users_in_group')
+            pages = paginator.paginate(
+                UserPoolId=user_pool_id,
+                GroupName=groupName
+            )
+            cognito_user_list = []
+            for page in pages:
+                cognito_user_list += page['Users']
             group_email_ids = []
             attributes = []
             # Make a flat list

--- a/backend/dataall/core/cognito_groups/api/resolvers.py
+++ b/backend/dataall/core/cognito_groups/api/resolvers.py
@@ -68,6 +68,6 @@ def list_cognito_groups(context, source, filter: dict = None):
     invited_group_uris = [item.groupUri for item in invited_groups]
     res = []
     for group in groups:
-        if group['GroupName'] not in invited_group_uris:
-            res.append({"groupName": group['GroupName']})
+        if group not in invited_group_uris:
+            res.append({"groupName": group})
     return res

--- a/tests/core/cognito_groups/test_group.py
+++ b/tests/core/cognito_groups/test_group.py
@@ -3,7 +3,7 @@
 def test_list_cognito_groups_env(client, env_fixture, group, module_mocker):
     module_mocker.patch(
         'dataall.base.aws.cognito.Cognito.list_cognito_groups',
-        return_value=[{"GroupName": 'cognitos'}, {"GroupName": 'testadmins'}],
+        return_value=['cognitos', 'testadmins'],
     )
     response = client.query(
         """


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- When inviting a new team to an Organization or Environment we call the API `listCognitoGroups` which calls boto3's `list_groups()` on the Cognito User Pool in the backend
- By default - if the the Cognito User Pool has over 25 Groups in it, the `list_groups()` will only return the first 25 in the response as a default limit
  - This PR adds a paginator to `list_groups()` to that backend API returns the full list of groups in the Cognito User Pool that can be invited to the Organization or Environment in the data.all UI


### Relates
- N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
