### PR TITLE
Add Athena:UpdateWorkGroup permissions to CDK Exec Policy

### DIFF
--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -24,6 +24,7 @@ Resources:
               - 'athena:*Tag*'
               - 'athena:GetWorkGroup'
               - 'athena:DeleteWorkGroup'
+              - 'athena:UpdateWorkGroup'
             Resource:
               - !Sub 'arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${EnvironmentResourcePrefix}*'
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- When trying to update an Environment to use the latest Athena Version (from this [previous PR](https://github.com/awslabs/aws-dataall/pull/886)) and having CDK use the data.all provided CDK Execution Policy ran into an `Update_Failed` error on the Environment CloudFormation Stack due to missing permissions for `athena:UpdateWorkGroup`
  - Added `athena:UpdateWorkGroup` to the CDK Exec Policy YAML file

### Relates
- N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
