### PR TITLE
Add SCP error handling in Quicksight identity region checks

### DIFF
--- a/backend/dataall/base/aws/quicksight.py
+++ b/backend/dataall/base/aws/quicksight.py
@@ -10,6 +10,23 @@ logger.setLevel(logging.DEBUG)
 class QuicksightClient:
 
     DEFAULT_GROUP_NAME = 'dataall'
+    QUICKSIGHT_IDENTITY_REGIONS = [
+        {"name": 'US East (N. Virginia)', "code": 'us-east-1'},
+        {"name": 'US East (Ohio)', "code": 'us-east-2'},
+        {"name": 'US West (Oregon)', "code": 'us-west-2'},
+        {"name": 'Europe (Frankfurt)', "code": 'eu-central-1'},
+        {"name": 'Europe (Stockholm)', "code": 'eu-north-1'},
+        {"name": 'Europe (Ireland)', "code": 'eu-west-1'},
+        {"name": 'Europe (London)', "code": 'eu-west-2'},
+        {"name": 'Europe (Paris)', "code": 'eu-west-3'},
+        {"name": 'Asia Pacific (Singapore)', "code": 'ap-southeast-1'},
+        {"name": 'Asia Pacific (Sydney)', "code": 'ap-southeast-2'},
+        {"name": 'Asia Pacific (Tokyo)', "code": 'ap-northeast-1'},
+        {"name": 'Asia Pacific (Seoul)', "code": 'ap-northeast-2'},
+        {"name": 'South America (São Paulo)', "code": 'sa-east-1'},
+        {"name": 'Canada (Central)', "code": 'ca-central-1'},
+        {"name": 'Asia Pacific (Mumbai)', "code": 'ap-south-1'},
+    ]
 
     def __init__(self):
         pass
@@ -37,20 +54,31 @@ class QuicksightClient:
             the region quicksight uses as identity region
         """
         identity_region_rex = re.compile('Please use the (?P<region>.*) endpoint.')
-        identity_region = 'us-east-1'
-        client = QuicksightClient.get_quicksight_client(AwsAccountId=AwsAccountId, region=identity_region)
-        try:
-            response = client.describe_group(
-                AwsAccountId=AwsAccountId, GroupName=QuicksightClient.DEFAULT_GROUP_NAME, Namespace='default'
-            )
-        except client.exceptions.AccessDeniedException as e:
-            match = identity_region_rex.findall(str(e))
-            if match:
-                identity_region = match[0]
-            else:
-                raise e
-        except client.exceptions.ResourceNotFoundException:
-            pass
+        scp = 'with an explicit deny in a service control policy'
+        index = 0
+        while index < len(QuicksightClient.QUICKSIGHT_IDENTITY_REGIONS):
+            try:
+                identity_region = QuicksightClient.QUICKSIGHT_IDENTITY_REGIONS[index].get("code")
+                index += 1
+                client = QuicksightClient.get_quicksight_client(AwsAccountId=AwsAccountId, region=identity_region)
+                response = client.describe_group(
+                    AwsAccountId=AwsAccountId, GroupName=QuicksightClient.DEFAULT_GROUP_NAME, Namespace='default'
+                )
+                break
+            except client.exceptions.AccessDeniedException as e:
+                if scp in str(e):
+                    logger.info(f'Quicksight SCP found in {identity_region} for account {AwsAccountId}. Trying next region...')
+                else:
+                    logger.info(f'Quicksight identity region is not {identity_region}, selecting correct region endpoint...')
+                    match = identity_region_rex.findall(str(e))
+                    if match:
+                        identity_region = match[0]
+                        break
+                    else:
+                        raise e
+            except client.exceptions.ResourceNotFoundException:
+                pass
+        logger.info(f'Returning identity region = {identity_region} for account {AwsAccountId}')
         return identity_region
 
     @staticmethod

--- a/backend/dataall/modules/dashboards/aws/dashboard_quicksight_client.py
+++ b/backend/dataall/modules/dashboards/aws/dashboard_quicksight_client.py
@@ -17,18 +17,18 @@ class DashboardQuicksightClient:
     _DEFAULT_GROUP_NAME = QuicksightClient.DEFAULT_GROUP_NAME
 
     def __init__(self, username, aws_account_id, region='eu-west-1'):
-        session = SessionHelper.remote_session(accountid=aws_account_id)
-        self._client = session.client('quicksight', region_name=region)
         self._account_id = aws_account_id
         self._region = region
         self._username = username
+        self._client = QuicksightClient.get_quicksight_client(aws_account_id, region)
 
     def register_user_in_group(self, group_name, user_role='READER'):
+        identity_region_client = QuicksightClient.get_quicksight_client_in_identity_region(self._account_id)
         QuicksightClient.create_quicksight_group(self._account_id, group_name)
         user = self._describe_user()
 
         if user is not None:
-            self._client.update_user(
+            identity_region_client.update_user(
                 UserName=self._username,
                 AwsAccountId=self._account_id,
                 Namespace='default',
@@ -36,7 +36,7 @@ class DashboardQuicksightClient:
                 Role=user_role,
             )
         else:
-            self._client.register_user(
+            identity_region_client.register_user(
                 UserName=self._username,
                 Email=self._username,
                 AwsAccountId=self._account_id,
@@ -45,13 +45,13 @@ class DashboardQuicksightClient:
                 UserRole=user_role,
             )
 
-        response = self._client.list_user_groups(
+        response = identity_region_client.list_user_groups(
             UserName=self._username, AwsAccountId=self._account_id, Namespace='default'
         )
         log.info(f'list_user_groups for {self._username}: {response})')
         if group_name not in [g['GroupName'] for g in response['GroupList']]:
             log.warning(f'Adding {self._username} to Quicksight group {group_name} on {self._account_id}')
-            self._client.create_group_membership(
+            identity_region_client.create_group_membership(
                 MemberName=self._username,
                 GroupName=group_name,
                 AwsAccountId=self._account_id,


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
There is no API to obtain the Quicksight identity region used for an account, we obtain it form the error logs of the response of describe_groups. However, it does not take into account AccessDenied errors based on SCPs. 
A more detailed description of the issue can be found in #851 
 
This PR:
- handles AccessDenied errors based on SCPs and retries other Quicksight identity regions
- fixes some methods for registering users that should be using the Quicksight client in the identity region.

### Relates
- #851 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). --> `N/A`

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
