### PR TITLE
Create frontend config role regardless of custom auth or not in backend

### DIFF
--- a/deploy/stacks/albfront_stack.py
+++ b/deploy/stacks/albfront_stack.py
@@ -28,7 +28,6 @@ class AlbFrontStack(Stack):
         image_tag=None,
         custom_domain=None,
         ip_ranges=None,
-        tooling_account_id=None,
         custom_auth=None,
         **kwargs,
     ):
@@ -36,28 +35,6 @@ class AlbFrontStack(Stack):
 
         if self.node.try_get_context('image_tag'):
             image_tag = self.node.try_get_context('image_tag')
-
-        cross_account_front_end_deployment_role = iam.Role(
-            self,
-            f'{resource_prefix}-{envname}-front_end_deployment_role',
-            role_name=f'{resource_prefix}-{envname}-front_end_deployment_role',
-            assumed_by=iam.AccountPrincipal(tooling_account_id),
-        )
-
-        cross_account_front_end_deployment_role.add_to_policy(
-            iam.PolicyStatement(
-                actions=[
-                    'ssm:GetParameterHistory',
-                    'ssm:GetParameters',
-                    'ssm:GetParameter',
-                    'ssm:GetParametersByPath'
-                ],
-                resources=[
-                    f'arn:aws:ssm:*:{self.account}:parameter/*{resource_prefix}*',
-                    f'arn:aws:ssm:*:{self.account}:parameter/*dataall*'
-                ],
-            ),
-        )
 
         frontend_image_tag = f'frontend-{image_tag}'
         userguide_image_tag = f'userguide-{image_tag}'

--- a/deploy/stacks/albfront_stage.py
+++ b/deploy/stacks/albfront_stage.py
@@ -16,7 +16,6 @@ class AlbFrontStage(Stage):
         image_tag=None,
         custom_domain=None,
         ip_ranges=None,
-        tooling_account_id=None,
         custom_auth=None,
         **kwargs,
     ):
@@ -31,7 +30,6 @@ class AlbFrontStage(Stage):
             image_tag=image_tag,
             custom_domain=custom_domain,
             ip_ranges=ip_ranges,
-            tooling_account_id=tooling_account_id,
             custom_auth=custom_auth
         )
 

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -127,7 +127,27 @@ class BackendStack(Stack):
                 cognito_user_session_timeout_inmins=cognito_user_session_timeout_inmins,
                 **kwargs,
             )
-
+        else:
+            cross_account_frontend_config_role = iam.Role(
+                self,
+                f'{resource_prefix}-{envname}-frontend-config-role',
+                role_name=f'{resource_prefix}-{envname}-frontend-config-role',
+                assumed_by=iam.AccountPrincipal(tooling_account_id),
+            )
+            cross_account_frontend_config_role.add_to_policy(
+                iam.PolicyStatement(
+                    actions=[
+                        'ssm:GetParameterHistory',
+                        'ssm:GetParameters',
+                        'ssm:GetParameter',
+                        'ssm:GetParametersByPath'
+                    ],
+                    resources=[
+                        f'arn:aws:ssm:*:{self.account}:parameter/*{resource_prefix}*',
+                        f'arn:aws:ssm:*:{self.account}:parameter/*dataall*'
+                    ],
+                ),
+            )
 
         sqs_stack = SqsStack(
             self,

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -158,13 +158,13 @@ class IdpStack(pyNestedClass):
             string_value=self.region,
         )
 
-        cross_account_cognito_config_role = iam.Role(
+        cross_account_frontend_config_role = iam.Role(
             self,
-            f'{resource_prefix}-{envname}-cognito-config-role',
-            role_name=f'{resource_prefix}-{envname}-cognito-config-role',
+            f'{resource_prefix}-{envname}-frontend-config-role',
+            role_name=f'{resource_prefix}-{envname}-frontend-config-role',
             assumed_by=iam.AccountPrincipal(tooling_account_id),
         )
-        cross_account_cognito_config_role.add_to_policy(
+        cross_account_frontend_config_role.add_to_policy(
             iam.PolicyStatement(
                 actions=[
                     'cognito-idp:AddCustomAttributes',
@@ -202,7 +202,7 @@ class IdpStack(pyNestedClass):
             self,
             'CognitoConfigRoleName',
             parameter_name=f'/dataall/{envname}/cognito/crossAccountRole',
-            string_value=cross_account_cognito_config_role.role_name,
+            string_value=cross_account_frontend_config_role.role_name,
         )
 
         if internet_facing:

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -892,7 +892,7 @@ class PipelineStack(Stack):
                 f'export enable_cw_canaries={target_env.get("enable_cw_canaries", False)}',
                 'mkdir ~/.aws/ && touch ~/.aws/config',
                 'echo "[profile buildprofile]" > ~/.aws/config',
-                f'echo "role_arn = arn:aws:iam::{target_env["account"]}:role/{self.resource_prefix}-{target_env["envname"]}-cognito-config-role" >> ~/.aws/config',
+                f'echo "role_arn = arn:aws:iam::{target_env["account"]}:role/{self.resource_prefix}-{target_env["envname"]}-frontend-config-role" >> ~/.aws/config',
                 'echo "credential_source = EcsContainer" >> ~/.aws/config',
                 'aws sts get-caller-identity --profile buildprofile',
                 'export AWS_PROFILE=buildprofile',
@@ -919,7 +919,6 @@ class PipelineStack(Stack):
                 custom_domain=target_env['custom_domain'],
                 ip_ranges=target_env.get('ip_ranges'),
                 resource_prefix=self.resource_prefix,
-                tooling_account_id=self.account,
                 custom_auth=target_env.get('custom_auth', None)
             ),
             pre=[
@@ -956,7 +955,7 @@ class PipelineStack(Stack):
                         f'export custom_auth_claims_mapping_user_id={str(target_env.get("custom_auth", {}).get("claims_mapping", {}).get("user_id", "None"))}',
                         'mkdir ~/.aws/ && touch ~/.aws/config',
                         'echo "[profile buildprofile]" > ~/.aws/config',
-                        f'echo "role_arn = arn:aws:iam::{target_env["account"]}:role/{self.resource_prefix}-{target_env["envname"]}-front_end_deployment_role" >> ~/.aws/config',
+                        f'echo "role_arn = arn:aws:iam::{target_env["account"]}:role/{self.resource_prefix}-{target_env["envname"]}-frontend-config-role" >> ~/.aws/config',
                         'echo "credential_source = EcsContainer" >> ~/.aws/config',
                         'aws sts get-caller-identity --profile buildprofile',
                         'export AWS_PROFILE=buildprofile',


### PR DESCRIPTION
…nd stack

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Config Role used to read SSM parameters in deployment account assumed by tooling account needs to be created in the BackendStack so it can be used in the pre CodeBuild commands of the ALBFront Stack
- Applies for VPC Facing Deployments

### Relates
- https://github.com/awslabs/aws-dataall/pull/897

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
