### PR TITLE
Fix permissions on share workflows

### DIFF
--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -858,11 +858,11 @@ class ShareObjectRepository:
                         ShareObjectItem.itemType == share_type
                     )
                 )
-            ).all()
+            )
         )
-        if status:
+        if status :
             query = query.filter(ShareObjectItem.status.in_(status))
-        return query
+        return query.all()
 
     @staticmethod
     def other_approved_share_item_table_exists(session, environment_uri, item_uri, share_item_uri):

--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -849,8 +849,8 @@ class ShareObjectRepository:
         )
 
     @staticmethod
-    def find_all_share_items(session, share_uri, share_type):
-        return (
+    def find_all_share_items(session, share_uri, share_type, status=None):
+        query = (
             session.query(ShareObjectItem).filter(
                 (
                     and_(
@@ -860,6 +860,9 @@ class ShareObjectRepository:
                 )
             ).all()
         )
+        if status:
+            query = query.filter(ShareObjectItem.status.in_(status))
+        return query
 
     @staticmethod
     def other_approved_share_item_table_exists(session, environment_uri, item_uri, share_item_uri):

--- a/backend/dataall/modules/dataset_sharing/services/share_item_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_item_service.py
@@ -61,11 +61,11 @@ class ShareItemService:
                 revoke_table_items = ShareObjectRepository.find_all_share_items(
                     session, uri, ShareableType.Table.value, [ShareItemStatus.Revoke_Approved.value]
                 )
-                for table in revoke_table_items:
+                for item in revoke_table_items:
                     ResourcePolicy.delete_resource_policy(
                         session=session,
                         group=share.groupUri,
-                        resource_uri=table.tableUri,
+                        resource_uri=item.itemUri,
                     )
 
             ShareNotificationService(

--- a/backend/dataall/modules/dataset_sharing/services/share_item_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_item_service.py
@@ -57,11 +57,12 @@ class ShareItemService:
 
             share_sm.update_state(session, share, new_share_state)
 
-            ResourcePolicy.delete_resource_policy(
-                session=session,
-                group=share.groupUri,
-                resource_uri=dataset.datasetUri,
-            )
+            if share.groupUri != dataset.SamlAdminGroupName:
+                ResourcePolicy.delete_resource_policy(
+                    session=session,
+                    group=share.groupUri,
+                    resource_uri=dataset.datasetUri,
+                )
 
             ShareNotificationService(
                 session=session,

--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -302,13 +302,13 @@ class ShareObjectService:
                 )
 
                 # Deleting APPROVER permissions
-                ResourcePolicy.attach_resource_policy(
+                ResourcePolicy.delete_resource_policy(
                     session=session,
                     group=dataset.SamlAdminGroupName,
                     resource_uri=share.shareUri,
                 )
                 if dataset.stewards != dataset.SamlAdminGroupName:
-                    ResourcePolicy.attach_resource_policy(
+                    ResourcePolicy.delete_resource_policy(
                         session=session,
                         group=dataset.stewards,
                         resource_uri=share.shareUri,

--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -261,11 +261,12 @@ class ShareObjectService:
         with context.db_engine.scoped_session() as session:
             share, dataset, states = cls._get_share_data(session, uri)
             cls._run_transitions(session, share, states, ShareObjectActions.Reject)
-            ResourcePolicy.delete_resource_policy(
-                session=session,
-                group=share.groupUri,
-                resource_uri=dataset.datasetUri,
-            )
+            if share.groupUri != dataset.SamlAdminGroupName:
+                ResourcePolicy.delete_resource_policy(
+                    session=session,
+                    group=share.groupUri,
+                    resource_uri=dataset.datasetUri,
+                )
 
             # Update Reject Purpose
             share.rejectPurpose = reject_purpose


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
There has been a mismatch on the permissions-granting in the shares. There are 2 types of permissions: on the share_object and preview permissions for requesters in the shared_tabled

In this PR:
- delete share object permissions from RDS when the share object is deleted
- attach table permissions to requesters for approved tables in `approve_share_object`
- delete table permissions to requesters for revoked tables in `revoke_items_share_object`
- delete table permissions to requesters for revoked tables in `remove_shared_item` if the removed item is a table and was in Share_Failed
- remove the deletion of permissions on the dataset level (which should not have been there in the first place)

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
