### PR TITLE
feat: support for custom env linking text with sanitization

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "dayjs": "^1.11.0",
+        "dompurify": "^3.0.6",
         "formik": "^2.2.9",
         "graphql-tag": "^2.12.6",
         "json5": "^2.2.2",
@@ -16235,6 +16236,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -42416,6 +42422,11 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "react-router": "6.0.0",
     "react-router-dom": "6.0.0",
     "react-scripts": "^5.0.1",
+    "dompurify": "^3.0.6",
     "simplebar": "^5.3.6",
     "simplebar-react": "^2.3.6",
     "web-vitals": "^2.1.4",

--- a/frontend/src/design/components/SanitizedHTML.js
+++ b/frontend/src/design/components/SanitizedHTML.js
@@ -1,0 +1,12 @@
+import DOMPurify from 'dompurify';
+
+export const SanitizedHTML = ({ dirtyHTML }) => {
+  const defaultOptions = {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'],
+    ALLOWED_ATTR: ['href']
+  };
+
+  const sanitizedHtml = DOMPurify.sanitize(dirtyHTML, defaultOptions);
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
+};

--- a/frontend/src/design/components/index.js
+++ b/frontend/src/design/components/index.js
@@ -28,3 +28,4 @@ export * from './UpVotesReadOnly';
 export * from './defaults';
 export * from './layout';
 export * from './popovers';
+export * from './SanitizedHTML';

--- a/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
+++ b/frontend/src/modules/Environments/views/EnvironmentCreateForm.js
@@ -39,6 +39,7 @@ import {
   getCDKExecPolicyPresignedUrl
 } from '../services';
 import {
+  SanitizedHTML,
   ArrowLeftIcon,
   ChevronRightIcon,
   ChipInput,
@@ -57,6 +58,7 @@ import {
   isModuleEnabled,
   ModuleNames
 } from 'utils';
+import config from '../../../generated/config.json';
 
 const EnvironmentCreateForm = (props) => {
   const dispatch = useDispatch();
@@ -305,171 +307,190 @@ const EnvironmentCreateForm = (props) => {
             <CardHeader title="Prerequisite Steps" />
             <Divider />
             <CardContent>
-              <Box>
-                <Typography color="textSecondary" variant="subtitle2">
-                  1. (OPTIONAL) As part of setting up your AWS Environment with
-                  CDK you need to specify a IAM Policy that gives permission for
-                  CDK to create AWS Resources via CloudFormation (i.e. CDK
-                  Execution Policy). You optionally can use the below
-                  CloudFormation template to create the custom IAM policy that
-                  is more restrictive than the default{' '}
-                  <b>AdministratorAccess</b> policy.
-                </Typography>
-                <Button
-                  color="primary"
-                  startIcon={<CloudDownloadOutlined fontSize="small" />}
-                  sx={{ mt: 1, mb: 2, ml: 2 }}
-                  variant="outlined"
-                  onClick={() => {
-                    getCDKExecPolicyUrl().catch((e) =>
-                      dispatch({ type: SET_ERROR, error: e.message })
-                    );
-                  }}
-                >
-                  CloudFormation stack for CDK custom execution policy
-                </Button>
-              </Box>
-              <Box>
-                <Typography color="textSecondary" variant="subtitle2">
-                  2. Bootstrap your AWS account with AWS CDK
-                </Typography>
-                <Grid
-                  container
-                  rowSpacing={1}
-                  columnSpacing={{ xs: 1, sm: 2, md: 3 }}
-                >
-                  <Grid item xs={6}>
-                    <Card>
-                      <CardContent>
-                        <Typography
-                          sx={{ fontSize: 14 }}
-                          color="text.secondary"
-                          gutterBottom
-                        >
-                          If Using Default CDK Execution Policy:
-                        </Typography>
-                        <Typography color="textPrimary" variant="subtitle2">
-                          <CopyToClipboard
-                            onCopy={() => copyNotification()}
-                            text={`cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://ACCOUNT_ID/REGION`}
-                          >
-                            <IconButton>
-                              <CopyAllOutlined
-                                sx={{
-                                  color:
-                                    theme.palette.mode === 'dark'
-                                      ? theme.palette.primary.contrastText
-                                      : theme.palette.primary.main
-                                }}
-                              />
-                            </IconButton>
-                          </CopyToClipboard>
-                          {`cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://ACCOUNT_ID/REGION`}
-                        </Typography>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                  <Grid item xs={6}>
-                    <Card>
-                      <CardContent>
-                        <Typography
-                          sx={{ fontSize: 14 }}
-                          color="text.secondary"
-                          gutterBottom
-                        >
-                          If Using Custom CDK Execution Policy (From Step 1):
-                        </Typography>
-                        <Typography color="textPrimary" variant="subtitle2">
-                          <CopyToClipboard
-                            onCopy={() => copyNotification()}
-                            text={`aws cloudformation --region REGION create-stack --stack-name DataAllCustomCDKExecPolicyStack --template-body file://cdkExecPolicy.yaml --parameters ParameterKey=EnvironmentResourcePrefix,ParameterValue=dataall --capabilities CAPABILITY_NAMED_IAM && aws cloudformation wait stack-create-complete --stack-name DataAllCustomCDKExecPolicyStack --region REGION && cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::ACCOUNT_ID:policy/DataAllCustomCDKPolicy aws://ACCOUNT_ID/REGION`}
-                          >
-                            <IconButton>
-                              <CopyAllOutlined
-                                sx={{
-                                  color:
-                                    theme.palette.mode === 'dark'
-                                      ? theme.palette.primary.contrastText
-                                      : theme.palette.primary.main
-                                }}
-                              />
-                            </IconButton>
-                          </CopyToClipboard>
-                          {`aws cloudformation --region REGION create-stack --stack-name DataAllCustomCDKExecPolicyStack --template-body file://cdkExecPolicy.yaml --parameters ParameterKey=EnvironmentResourcePrefix,ParameterValue=dataall --capabilities CAPABILITY_NAMED_IAM && aws cloudformation wait stack-create-complete --stack-name DataAllCustomCDKExecPolicyStack --region REGION && cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::ACCOUNT_ID:policy/DataAllCustomCDKPolicy aws://ACCOUNT_ID/REGION`}
-                        </Typography>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                </Grid>
-              </Box>
-              {process.env.REACT_APP_ENABLE_PIVOT_ROLE_AUTO_CREATE ===
-              'True' ? (
+              {config.core.custom_env_linking_text !== undefined ? (
                 <Box>
                   <Typography color="textSecondary" variant="subtitle2">
-                    3. As part of the environment CloudFormation stack data.all
-                    will create an IAM role (Pivot Role) to manage AWS
-                    operations in the environment AWS Account.
+                    <SanitizedHTML
+                      dirtyHTML={config.core.custom_env_linking_text}
+                    />
                   </Typography>
                 </Box>
               ) : (
-                <Box>
+                <>
                   <Box>
                     <Typography color="textSecondary" variant="subtitle2">
-                      3. Create an IAM role named <b>{pivotRoleName}</b> using
-                      the AWS CloudFormation stack below
+                      1. (OPTIONAL) As part of setting up your AWS Environment
+                      with CDK you need to specify a IAM Policy that gives
+                      permission for CDK to create AWS Resources via
+                      CloudFormation (i.e. CDK Execution Policy). You optionally
+                      can use the below CloudFormation template to create the
+                      custom IAM policy that is more restrictive than the
+                      default <b>AdministratorAccess</b> policy.
+                    </Typography>
+                    <Button
+                      color="primary"
+                      startIcon={<CloudDownloadOutlined fontSize="small" />}
+                      sx={{ mt: 1, mb: 2, ml: 2 }}
+                      variant="outlined"
+                      onClick={() => {
+                        getCDKExecPolicyUrl().catch((e) =>
+                          dispatch({ type: SET_ERROR, error: e.message })
+                        );
+                      }}
+                    >
+                      CloudFormation stack for CDK custom execution policy
+                    </Button>
+                  </Box>
+                  <Box>
+                    <Typography color="textSecondary" variant="subtitle2">
+                      2. Bootstrap your AWS account with AWS CDK
+                    </Typography>
+                    <Grid
+                      container
+                      rowSpacing={1}
+                      columnSpacing={{ xs: 1, sm: 2, md: 3 }}
+                    >
+                      <Grid item xs={6}>
+                        <Card>
+                          <CardContent>
+                            <Typography
+                              sx={{ fontSize: 14 }}
+                              color="text.secondary"
+                              gutterBottom
+                            >
+                              If Using Default CDK Execution Policy:
+                            </Typography>
+                            <Typography color="textPrimary" variant="subtitle2">
+                              <CopyToClipboard
+                                onCopy={() => copyNotification()}
+                                text={`cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://ACCOUNT_ID/REGION`}
+                              >
+                                <IconButton>
+                                  <CopyAllOutlined
+                                    sx={{
+                                      color:
+                                        theme.palette.mode === 'dark'
+                                          ? theme.palette.primary.contrastText
+                                          : theme.palette.primary.main
+                                    }}
+                                  />
+                                </IconButton>
+                              </CopyToClipboard>
+                              {`cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://ACCOUNT_ID/REGION`}
+                            </Typography>
+                          </CardContent>
+                        </Card>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Card>
+                          <CardContent>
+                            <Typography
+                              sx={{ fontSize: 14 }}
+                              color="text.secondary"
+                              gutterBottom
+                            >
+                              If Using Custom CDK Execution Policy (From Step
+                              1):
+                            </Typography>
+                            <Typography color="textPrimary" variant="subtitle2">
+                              <CopyToClipboard
+                                onCopy={() => copyNotification()}
+                                text={`aws cloudformation --region REGION create-stack --stack-name DataAllCustomCDKExecPolicyStack --template-body file://cdkExecPolicy.yaml --parameters ParameterKey=EnvironmentResourcePrefix,ParameterValue=dataall --capabilities CAPABILITY_NAMED_IAM && aws cloudformation wait stack-create-complete --stack-name DataAllCustomCDKExecPolicyStack --region REGION && cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::ACCOUNT_ID:policy/DataAllCustomCDKPolicy aws://ACCOUNT_ID/REGION`}
+                              >
+                                <IconButton>
+                                  <CopyAllOutlined
+                                    sx={{
+                                      color:
+                                        theme.palette.mode === 'dark'
+                                          ? theme.palette.primary.contrastText
+                                          : theme.palette.primary.main
+                                    }}
+                                  />
+                                </IconButton>
+                              </CopyToClipboard>
+                              {`aws cloudformation --region REGION create-stack --stack-name DataAllCustomCDKExecPolicyStack --template-body file://cdkExecPolicy.yaml --parameters ParameterKey=EnvironmentResourcePrefix,ParameterValue=dataall --capabilities CAPABILITY_NAMED_IAM && aws cloudformation wait stack-create-complete --stack-name DataAllCustomCDKExecPolicyStack --region REGION && cdk bootstrap --trust ${trustedAccount} -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::ACCOUNT_ID:policy/DataAllCustomCDKPolicy aws://ACCOUNT_ID/REGION`}
+                            </Typography>
+                          </CardContent>
+                        </Card>
+                      </Grid>
+                    </Grid>
+                  </Box>
+                  {process.env.REACT_APP_ENABLE_PIVOT_ROLE_AUTO_CREATE ===
+                  'True' ? (
+                    <Box>
+                      <Typography color="textSecondary" variant="subtitle2">
+                        3. As part of the environment CloudFormation stack
+                        data.all will create an IAM role (Pivot Role) to manage
+                        AWS operations in the environment AWS Account.
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <Box>
+                      <Box>
+                        <Typography color="textSecondary" variant="subtitle2">
+                          3. Create an IAM role named <b>{pivotRoleName}</b>{' '}
+                          using the AWS CloudFormation stack below
+                        </Typography>
+                      </Box>
+                      <Grid
+                        container
+                        justifyContent="space-between"
+                        spacing={3}
+                      >
+                        <Grid item lg={6} xl={6} xs={6}>
+                          <Button
+                            color="primary"
+                            startIcon={
+                              <CloudDownloadOutlined fontSize="small" />
+                            }
+                            sx={{ mt: 1, mb: 2, ml: 2 }}
+                            variant="outlined"
+                            onClick={() => {
+                              getPivotRoleUrl().catch((e) =>
+                                dispatch({ type: SET_ERROR, error: e.message })
+                              );
+                            }}
+                          >
+                            CloudFormation stack
+                          </Button>
+                          <Button
+                            color="primary"
+                            startIcon={<CopyAllOutlined fontSize="small" />}
+                            sx={{ mt: 1, mb: 2, ml: 2 }}
+                            variant="outlined"
+                            onClick={() => {
+                              copyPivotRoleName().catch((e) =>
+                                dispatch({ type: SET_ERROR, error: e.message })
+                              );
+                            }}
+                          >
+                            Pivot role name
+                          </Button>
+                          <Button
+                            color="primary"
+                            startIcon={<CopyAllOutlined fontSize="small" />}
+                            sx={{ mt: 1, mb: 2, ml: 2 }}
+                            variant="outlined"
+                            onClick={() => {
+                              getExternalId().catch((e) =>
+                                dispatch({ type: SET_ERROR, error: e.message })
+                              );
+                            }}
+                          >
+                            External Id
+                          </Button>
+                        </Grid>
+                      </Grid>
+                    </Box>
+                  )}
+                  <Box>
+                    <Typography color="textSecondary" variant="subtitle2">
+                      Make sure that the services needed for the selected
+                      environment features are available in your AWS Account.
                     </Typography>
                   </Box>
-                  <Grid container justifyContent="space-between" spacing={3}>
-                    <Grid item lg={6} xl={6} xs={6}>
-                      <Button
-                        color="primary"
-                        startIcon={<CloudDownloadOutlined fontSize="small" />}
-                        sx={{ mt: 1, mb: 2, ml: 2 }}
-                        variant="outlined"
-                        onClick={() => {
-                          getPivotRoleUrl().catch((e) =>
-                            dispatch({ type: SET_ERROR, error: e.message })
-                          );
-                        }}
-                      >
-                        CloudFormation stack
-                      </Button>
-                      <Button
-                        color="primary"
-                        startIcon={<CopyAllOutlined fontSize="small" />}
-                        sx={{ mt: 1, mb: 2, ml: 2 }}
-                        variant="outlined"
-                        onClick={() => {
-                          copyPivotRoleName().catch((e) =>
-                            dispatch({ type: SET_ERROR, error: e.message })
-                          );
-                        }}
-                      >
-                        Pivot role name
-                      </Button>
-                      <Button
-                        color="primary"
-                        startIcon={<CopyAllOutlined fontSize="small" />}
-                        sx={{ mt: 1, mb: 2, ml: 2 }}
-                        variant="outlined"
-                        onClick={() => {
-                          getExternalId().catch((e) =>
-                            dispatch({ type: SET_ERROR, error: e.message })
-                          );
-                        }}
-                      >
-                        External Id
-                      </Button>
-                    </Grid>
-                  </Grid>
-                </Box>
+                </>
               )}
-              <Box>
-                <Typography color="textSecondary" variant="subtitle2">
-                  Make sure that the services needed for the selected
-                  environment features are available in your AWS Account.
-                </Typography>
-              </Box>
             </CardContent>
           </Card>
           <Box sx={{ mt: 3 }}>


### PR DESCRIPTION
**Feature or Bugfix**
- Feature

**Detail**

Adding a way to override env linking prerequisites for those that do not want to use manual steps and have other ways to achieve the same thing.

**Security**
The only security concern is that there's an html value coming out of config.json which gets set as innerHTML. I don't think this would be an issue unless someone would find a way to override the config. value as an attack.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.