### PR TITLE
Added KMS encryption for Aurora DB secrets

### DIFF
--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -65,7 +65,7 @@ class AuroraServerlessStack(pyNestedClass):
         )
         
         db_credentials = rds.DatabaseSecret(
-            self, f'{resource_prefix}-{envname}-aurora-db', username='dtaadmin', encryptionKey=key
+            self, f'{resource_prefix}-{envname}-aurora-db', username='dtaadmin', encryption_key=key
         )
 
         database = rds.ServerlessCluster(

--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -30,9 +30,7 @@ class AuroraServerlessStack(pyNestedClass):
         super().__init__(scope, id, **kwargs)
 
         # if exclude_characters property is set make sure that the pwd regex in DbConfig is changed accordingly
-        db_credentials = rds.DatabaseSecret(
-            self, f'{resource_prefix}-{envname}-aurora-db', username='dtaadmin'
-        )
+
 
         db_subnet_group = rds.SubnetGroup(
             self,
@@ -64,6 +62,10 @@ class AuroraServerlessStack(pyNestedClass):
             else RemovalPolicy.RETAIN,
             alias=f'{resource_prefix}-{envname}-aurora',
             enable_key_rotation=True,
+        )
+        
+        db_credentials = rds.DatabaseSecret(
+            self, f'{resource_prefix}-{envname}-aurora-db', username='dtaadmin', encryptionKey=key
         )
 
         database = rds.ServerlessCluster(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Added KMS key for encrypting Aurora DB secrets

### Relates
https://github.com/awslabs/aws-dataall/issues/880

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? No
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used?N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts?N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
